### PR TITLE
Add per-project Docker network isolation

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/elliottregan/cspace/internal/compose"
+	"github.com/elliottregan/cspace/internal/docker"
 	"github.com/elliottregan/cspace/internal/instance"
 	"github.com/spf13/cobra"
 )
@@ -70,6 +71,10 @@ func runDownAll() error {
 			fmt.Fprintf(os.Stderr, "  warning: %v\n", err)
 		}
 	}
+
+	// Remove the project network now that all instances are gone.
+	docker.NetworkRemove(cfg.ProjectNetwork())
+
 	return nil
 }
 

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -54,6 +54,7 @@ func ComposeEnv(name string, cfg *config.Config) []string {
 		"CSPACE_MEMORY_VOLUME=" + cfg.MemoryVolume(),
 		"CSPACE_LOGS_VOLUME=" + cfg.LogsVolume(),
 		"CSPACE_LABEL=" + cfg.InstanceLabel(),
+		"CSPACE_PROJECT_NETWORK=" + cfg.ProjectNetwork(),
 		"CSPACE_HOME=" + cspaceHome,
 		"HOST_PORT_DEV=" + strconv.Itoa(pm.Dev),
 		"HOST_PORT_PREVIEW=" + strconv.Itoa(pm.Preview),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -249,6 +249,14 @@ func (c *Config) ComposeName(instance string) string {
 	return c.Project.Prefix + "-" + instance
 }
 
+// ProjectNetwork returns the name of the shared Docker bridge network
+// for this project. All devcontainer instances of the same project join
+// this network, enabling inter-instance communication while keeping
+// different projects fully isolated from each other.
+func (c *Config) ProjectNetwork() string {
+	return appPrefix + "-" + c.Project.Name
+}
+
 // ImageName returns the Docker image name for this project.
 func (c *Config) ImageName() string {
 	return appPrefix + "-" + c.Project.Name

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -28,6 +28,32 @@ func VolumeRemove(name string) error {
 	return nil
 }
 
+// NetworkCreate creates a named Docker bridge network labelled for this
+// project. Idempotent — if the network already exists, returns nil.
+func NetworkCreate(name, instanceLabel string) error {
+	out, err := exec.Command(
+		"docker", "network", "inspect", name, "--format", "{{.Name}}",
+	).Output()
+	if err == nil && strings.TrimSpace(string(out)) == name {
+		return nil
+	}
+	cmd := exec.Command("docker", "network", "create",
+		"--label", instanceLabel,
+		"--label", "cspace.network=project",
+		name,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("creating network %s: %s: %w", name, out, err)
+	}
+	return nil
+}
+
+// NetworkRemove removes a named Docker network, ignoring errors.
+// Used during teardown when no instances remain on the network.
+func NetworkRemove(name string) {
+	exec.Command("docker", "network", "rm", name).Run() //nolint:errcheck
+}
+
 // IsContainerRunning checks whether a container with the given name exists
 // and is in a running state.
 func IsContainerRunning(name string) bool {

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -99,7 +99,14 @@ func Run(p Params) (Result, error) {
 			return Result{}, fmt.Errorf("creating volumes: %w", err)
 		}
 
-		// 6. Start container
+		// 6. Ensure the shared project network exists before starting the
+		// Compose stack. The devcontainer service declares this as an external
+		// network in docker-compose.core.yml, so it must exist before compose up.
+		if err := docker.NetworkCreate(cfg.ProjectNetwork(), cfg.InstanceLabel()); err != nil {
+			return Result{}, fmt.Errorf("creating project network: %w", err)
+		}
+
+		// 7. Start container
 		if err := compose.Run(name, cfg, "up", "-d"); err != nil {
 			return Result{}, fmt.Errorf("starting container: %w", err)
 		}

--- a/lib/templates/docker-compose.core.yml
+++ b/lib/templates/docker-compose.core.yml
@@ -51,6 +51,10 @@ services:
       - TERM_PROGRAM=${TERM_PROGRAM:-}
       - COLORTERM=${COLORTERM:-}
 
+    networks:
+      - default   # instance-scoped Compose network (playwright, chromium-cdp, project services)
+      - project   # project-scoped network (shared across all instances of this project)
+
     depends_on:
       - playwright
       - chromium-cdp
@@ -106,3 +110,9 @@ volumes:
   cspace-logs:
     name: ${CSPACE_LOGS_VOLUME:-cspace-logs}
     external: true
+
+networks:
+  default: {}
+  project:
+    external: true
+    name: ${CSPACE_PROJECT_NETWORK}


### PR DESCRIPTION
## Summary

- Creates a named Docker bridge network per project (`cspace-{project.name}`) so instances within the same project can communicate while different projects are fully isolated at the network layer
- Devcontainers join both the instance-local Compose network (for sidecars) and the project-scoped network (for inter-instance traffic)
- Project network is cleaned up on `cspace down --all`

## Changes

- `internal/config/config.go` — `ProjectNetwork()` helper
- `internal/docker/docker.go` — `NetworkCreate()` / `NetworkRemove()` functions
- `internal/compose/compose.go` — export `CSPACE_PROJECT_NETWORK` env var
- `internal/provision/provision.go` — create project network before `compose up`
- `lib/templates/docker-compose.core.yml` — devcontainer joins `default` + `project` networks
- `internal/cli/down.go` — remove project network on `down --all`

## Test plan

- [ ] `cspace rebuild` after merging (compose template is embedded)
- [ ] Two instances in same project can reach each other (`cspace ssh mercury`, then `curl http://venus:5173`)
- [ ] Instance in a different project cannot reach the first project's instances
- [ ] `cspace down --all` removes the project network
- [ ] `cspace down <name>` leaves the project network intact for other instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)