### PR TITLE
Planet focus-pull overlay during provisioning

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,6 @@
+{
+  "enabledMcpjsonServers": [
+    "cspace-context"
+  ],
+  "enableAllProjectMcpServers": true
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,0 @@
-{
-  "enabledMcpjsonServers": [
-    "cspace-context"
-  ],
-  "enableAllProjectMcpServers": true
-}

--- a/.cspace/memory/MEMORY.md
+++ b/.cspace/memory/MEMORY.md
@@ -1,0 +1,12 @@
+<!--
+This directory holds project-shared Claude Code memory.
+
+It is bind-mounted into every cspace container at:
+  /home/dev/.claude/projects/-workspace/memory
+
+Agents read and write here via the built-in memory system (four types:
+user, feedback, project, reference). Committed to git so learnings
+survive volume wipes and propagate to fresh clones.
+
+See CLAUDE.md for the full convention.
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist/
 # `make sync-embedded` has ever run.
 internal/assets/embedded/*
 !internal/assets/embedded/.gitkeep
+.claude/settings.local.json

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,12 @@
+# Shellcheck suppressions for existing project scripts.
+#
+# SC2059: variable in printf format string. Our statusline uses color
+# escape vars in format strings intentionally, which is safe because
+# the contents are hard-coded terminal escapes.
+# SC1083: literal `{` — flags braces in format strings that are meant
+# as output characters, not shell syntax.
+# SC2034: variable appears unused — exported style vars that are read
+# externally or left for future use.
+# SC1003: escape a single quote — alternate quoting that shellcheck
+# flags but is intentional in several places.
+disable=SC2059,SC1083,SC2034,SC1003

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LDFLAGS         := -ldflags "-X github.com/elliottregan/cspace/internal/cli.Vers
 LDFLAGS_RELEASE := -ldflags "-s -w -X github.com/elliottregan/cspace/internal/cli.Version=$(VERSION)"
 GOBIN           := ./bin/cspace-go
 
-.PHONY: build build-linux clean test test-node vet sync-embedded fmt fmt-check lint check install-tools setup-hooks
+.PHONY: build build-linux clean test test-node vet sync-embedded overlay-demo fmt fmt-check lint check install-tools setup-hooks
 
 # Sync lib/ contents into internal/assets/embedded/ for go:embed
 sync-embedded:
@@ -23,6 +23,12 @@ sync-embedded:
 
 build: sync-embedded
 	go build $(LDFLAGS) -o $(GOBIN) ./cmd/cspace
+
+# Run the provisioning overlay against synthesized phase events. Useful for
+# iterating on the UI without spinning up a real container. Forwards any
+# extra args through ARGS, e.g. `make overlay-demo ARGS="--planet=jupiter"`.
+overlay-demo: sync-embedded
+	@go run ./cmd/overlay-demo/ $(ARGS)
 
 build-linux: sync-embedded
 	@mkdir -p dist

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ sync-embedded:
 	@cp -r lib/skills internal/assets/embedded/
 	@cp -r lib/commands internal/assets/embedded/
 	@cp lib/defaults.json internal/assets/embedded/
+	@cp lib/planets.json internal/assets/embedded/
 
 build: sync-embedded
 	go build $(LDFLAGS) -o $(GOBIN) ./cmd/cspace

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LDFLAGS         := -ldflags "-X github.com/elliottregan/cspace/internal/cli.Vers
 LDFLAGS_RELEASE := -ldflags "-s -w -X github.com/elliottregan/cspace/internal/cli.Version=$(VERSION)"
 GOBIN           := ./bin/cspace-go
 
-.PHONY: build build-linux clean test test-node vet sync-embedded overlay-demo fmt fmt-check lint check install-tools setup-hooks
+.PHONY: build build-linux clean test test-node vet sync-embedded overlay-demo overlay-web fmt fmt-check lint check install-tools setup-hooks
 
 # Sync lib/ contents into internal/assets/embedded/ for go:embed
 sync-embedded:
@@ -29,6 +29,12 @@ build: sync-embedded
 # extra args through ARGS, e.g. `make overlay-demo ARGS="--planet=jupiter"`.
 overlay-demo: sync-embedded
 	@go run ./cmd/overlay-demo/ $(ARGS)
+
+# Serve a browser preview of the overlay at http://localhost:8080/ with
+# sliders for the main image parameters. Faster visual iteration than
+# the TUI demo. Override the port with ARGS="-addr :9000".
+overlay-web: sync-embedded
+	@go run ./cmd/overlay-web/ $(ARGS)
 
 build-linux: sync-embedded
 	@mkdir -p dist

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build: sync-embedded
 overlay-demo: sync-embedded
 	@go run ./cmd/overlay-demo/ $(ARGS)
 
-# Serve a browser preview of the overlay at http://localhost:8080/ with
+# Serve a browser preview of the overlay at http://localhost:3000/ with
 # sliders for the main image parameters. Faster visual iteration than
 # the TUI demo. Override the port with ARGS="-addr :9000".
 overlay-web: sync-embedded

--- a/cmd/overlay-demo/main.go
+++ b/cmd/overlay-demo/main.go
@@ -1,0 +1,66 @@
+// Command overlay-demo renders the cspace provisioning overlay with
+// synthesized phase events so developers can iterate on the UI without
+// spinning up a real container. Requires a TTY.
+//
+// Examples:
+//
+//	go run ./cmd/overlay-demo/
+//	go run ./cmd/overlay-demo/ --planet=jupiter --per-phase=400ms
+//	go run ./cmd/overlay-demo/ --fail-at=8
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/elliottregan/cspace/internal/overlay"
+	"github.com/elliottregan/cspace/internal/planets"
+	"github.com/elliottregan/cspace/internal/provision"
+)
+
+func main() {
+	planet := flag.String("planet", "mercury",
+		"planet name: mercury, venus, earth, mars, jupiter, saturn, uranus, neptune")
+	perPhase := flag.Duration("per-phase", 900*time.Millisecond,
+		"simulated delay between phase transitions")
+	failAt := flag.Int("fail-at", 0,
+		"simulate a failure at phase N (1..14); 0 means finish successfully")
+	flag.Parse()
+
+	if _, ok := planets.Get(*planet); !ok {
+		fmt.Fprintf(os.Stderr, "unknown planet %q; use one of mercury/venus/earth/mars/jupiter/saturn/uranus/neptune\n", *planet)
+		os.Exit(2)
+	}
+
+	events := make(chan overlay.ProvisionEvent, 16)
+	reporter := overlay.NewChannelReporter(events)
+
+	go func() {
+		for i, label := range provision.Phases {
+			num := i + 1
+			reporter.Phase(label, num, len(provision.Phases))
+			time.Sleep(*perPhase)
+			if *failAt == num {
+				reporter.Error(label, errors.New("simulated provisioning failure"))
+				close(events)
+				return
+			}
+		}
+		reporter.Done()
+		close(events)
+	}()
+
+	cfg := overlay.ModelConfig{
+		Name:   *planet,
+		Planet: planets.MustGet(*planet),
+		Total:  len(provision.Phases),
+		Events: events,
+	}
+	if err := overlay.Run(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "overlay error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/overlay-demo/main.go
+++ b/cmd/overlay-demo/main.go
@@ -2,11 +2,15 @@
 // synthesized phase events so developers can iterate on the UI without
 // spinning up a real container. Requires a TTY.
 //
-// Examples:
+// Run via the Makefile so embedded assets are synced first:
 //
-//	go run ./cmd/overlay-demo/
-//	go run ./cmd/overlay-demo/ --planet=jupiter --per-phase=400ms
-//	go run ./cmd/overlay-demo/ --fail-at=8
+//	make overlay-demo
+//	make overlay-demo ARGS="--planet=jupiter --per-phase=400ms"
+//	make overlay-demo ARGS="--fail-at=8"
+//
+// Or manually after `make sync-embedded`:
+//
+//	go run ./cmd/overlay-demo/ --planet=saturn
 package main
 
 import (

--- a/cmd/overlay-web/main.go
+++ b/cmd/overlay-web/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/elliottregan/cspace/internal/provision"
 )
 
-var addr = flag.String("addr", ":8080", "listen address")
+var addr = flag.String("addr", ":3000", "listen address")
 
 var planetNames = []string{
 	"mercury", "venus", "earth", "mars",

--- a/cmd/overlay-web/main.go
+++ b/cmd/overlay-web/main.go
@@ -89,6 +89,7 @@ func handleIndex(w http.ResponseWriter, r *http.Request) {
 
 	p := planets.MustGet(planet)
 	shape := planets.GetShape(planet)
+	opts.Overlays = planets.GetOverlays(planet)
 	total := len(provision.Phases)
 
 	frames := make([]frameData, 0, total)

--- a/cmd/overlay-web/main.go
+++ b/cmd/overlay-web/main.go
@@ -1,0 +1,369 @@
+// Command overlay-web serves a browser preview of the provisioning
+// overlay so image parameters can be iterated on without running the
+// TUI. Renders all 14 phases side-by-side as HTML with inline CSS
+// converted from the overlay's truecolor ANSI output. Sliders in the
+// header let you tweak the main image knobs; reload after changing
+// Go code.
+//
+//	make overlay-web       # starts http://localhost:8080/
+package main
+
+import (
+	"flag"
+	"fmt"
+	"html"
+	"html/template"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/elliottregan/cspace/internal/overlay"
+	"github.com/elliottregan/cspace/internal/planets"
+	"github.com/elliottregan/cspace/internal/provision"
+)
+
+var addr = flag.String("addr", ":8080", "listen address")
+
+var planetNames = []string{
+	"mercury", "venus", "earth", "mars",
+	"jupiter", "saturn", "uranus", "neptune",
+}
+
+func main() {
+	flag.Parse()
+	http.HandleFunc("/", handleIndex)
+	log.Printf("overlay preview at http://localhost%s/", *addr)
+	log.Fatal(http.ListenAndServe(*addr, nil))
+}
+
+type frameData struct {
+	Phase int
+	Label string
+	State string
+	HTML  template.HTML
+}
+
+type indexData struct {
+	Planets []string
+	Planet  string
+	Total   int
+	Frames  []frameData
+	Opts    overlay.RenderOptions
+}
+
+func handleIndex(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	planet := q.Get("planet")
+	if planet == "" {
+		planet = "mercury"
+	}
+
+	opts := overlay.DefaultRenderOptions()
+	if v := q.Get("blockSize"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			opts.MaxBlockSize = n
+		}
+	}
+	if v := q.Get("halo"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			opts.HaloThreshold = f
+		}
+	}
+	if v := q.Get("texStart"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			opts.TextureStart = f
+		}
+	}
+	if v := q.Get("texDensity"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			opts.TextureDensity = f
+		}
+	}
+	if v := q.Get("texContrast"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			opts.TextureContrast = f
+		}
+	}
+
+	p := planets.MustGet(planet)
+	shape := planets.GetShape(planet)
+	total := len(provision.Phases)
+
+	frames := make([]frameData, 0, total)
+	for phase := 1; phase <= total; phase++ {
+		art := overlay.RenderPlanetWith(shape, p, phase, total, opts)
+		label := provision.Phases[phase-1]
+		frames = append(frames, frameData{
+			Phase: phase,
+			Label: label,
+			State: overlay.SciFiLabelFor(label),
+			HTML:  template.HTML(ansiToHTML(art)),
+		})
+	}
+
+	data := indexData{
+		Planets: planetNames,
+		Planet:  planet,
+		Total:   total,
+		Frames:  frames,
+		Opts:    opts,
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tpl.Execute(w, data); err != nil {
+		log.Printf("template execute: %v", err)
+	}
+}
+
+var ansiRegex = regexp.MustCompile(`\x1b\[([0-9;]*)m`)
+
+// ansiToHTML converts the overlay's truecolor ANSI output to an HTML
+// fragment of <span style="color:#..; background:#..">…</span> runs.
+// Only handles SGR reset (0) and truecolor (38;2;R;G;B / 48;2;R;G;B),
+// which is all the overlay emits.
+func ansiToHTML(s string) string {
+	var out strings.Builder
+	fg, bg := "", ""
+	spanOpen := false
+
+	openSpan := func() {
+		if spanOpen {
+			return
+		}
+		style := ""
+		if fg != "" {
+			style += "color:" + fg + ";"
+		}
+		if bg != "" {
+			style += "background:" + bg + ";"
+		}
+		if style == "" {
+			return
+		}
+		out.WriteString(`<span style="`)
+		out.WriteString(style)
+		out.WriteString(`">`)
+		spanOpen = true
+	}
+	closeSpan := func() {
+		if spanOpen {
+			out.WriteString(`</span>`)
+			spanOpen = false
+		}
+	}
+	writeText := func(t string) {
+		if t == "" {
+			return
+		}
+		openSpan()
+		out.WriteString(html.EscapeString(t))
+	}
+
+	parseSGR := func(codes string) {
+		if codes == "" || codes == "0" {
+			fg, bg = "", ""
+			return
+		}
+		parts := strings.Split(codes, ";")
+		for i := 0; i < len(parts); i++ {
+			switch parts[i] {
+			case "0":
+				fg, bg = "", ""
+			case "38":
+				if i+4 < len(parts) && parts[i+1] == "2" {
+					r, _ := strconv.Atoi(parts[i+2])
+					g, _ := strconv.Atoi(parts[i+3])
+					b, _ := strconv.Atoi(parts[i+4])
+					fg = fmt.Sprintf("#%02x%02x%02x", r, g, b)
+					i += 4
+				}
+			case "48":
+				if i+4 < len(parts) && parts[i+1] == "2" {
+					r, _ := strconv.Atoi(parts[i+2])
+					g, _ := strconv.Atoi(parts[i+3])
+					b, _ := strconv.Atoi(parts[i+4])
+					bg = fmt.Sprintf("#%02x%02x%02x", r, g, b)
+					i += 4
+				}
+			}
+		}
+	}
+
+	i := 0
+	for i < len(s) {
+		loc := ansiRegex.FindStringIndex(s[i:])
+		if loc == nil {
+			writeText(s[i:])
+			break
+		}
+		writeText(s[i : i+loc[0]])
+		closeSpan()
+		codes := s[i+loc[0]+2 : i+loc[1]-1]
+		parseSGR(codes)
+		i += loc[1]
+	}
+	closeSpan()
+	return out.String()
+}
+
+var tpl = template.Must(template.New("index").Parse(pageTemplate))
+
+const pageTemplate = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Overlay preview · {{.Planet}}</title>
+<style>
+  :root {
+    --bg: #101010;
+    --panel: #000;
+    --ink: #d4d4d4;
+    --dim: #888;
+    --border: #2a2a2a;
+    --accent: #4fc3f7;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 13px;
+  }
+  header.controls {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: #181818;
+    border-bottom: 1px solid var(--border);
+    padding: 12px 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 18px;
+    align-items: center;
+  }
+  header h1 {
+    margin: 0 12px 0 0;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    color: var(--ink);
+  }
+  header form { display: contents; }
+  header label {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    color: var(--dim);
+    font-size: 11px;
+    letter-spacing: 0.05em;
+  }
+  header label span.val {
+    color: var(--ink);
+    min-width: 36px;
+    text-align: right;
+  }
+  header select, header input[type=range] {
+    background: #111;
+    color: var(--ink);
+    border: 1px solid #333;
+    font: inherit;
+  }
+  header select { padding: 2px 6px; }
+  header input[type=range] { width: 110px; }
+  header button {
+    background: #111;
+    color: var(--ink);
+    border: 1px solid #333;
+    font: inherit;
+    padding: 3px 10px;
+    cursor: pointer;
+  }
+  header button:hover { border-color: var(--accent); }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+    padding: 20px;
+  }
+  @media (min-width: 1400px) { .grid { grid-template-columns: repeat(3, 1fr); } }
+  @media (min-width: 1900px) { .grid { grid-template-columns: repeat(4, 1fr); } }
+
+  .frame {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    padding: 14px 18px;
+  }
+  .frame .caption {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    color: var(--dim);
+    margin-bottom: 10px;
+    display: flex;
+    justify-content: space-between;
+  }
+  .frame .caption .state {
+    color: var(--ink);
+    font-weight: 600;
+  }
+  pre.art {
+    margin: 0;
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.0;
+    letter-spacing: 0;
+    white-space: pre;
+    color: #fff;
+  }
+</style>
+</head>
+<body>
+<header class="controls">
+  <h1>OVERLAY PREVIEW</h1>
+  <form action="/" method="get">
+    <label>PLANET
+      <select name="planet" onchange="this.form.submit()">
+        {{range .Planets}}<option value="{{.}}"{{if eq . $.Planet}} selected{{end}}>{{.}}</option>{{end}}
+      </select>
+    </label>
+    <label>BLOCK <span class="val" id="v-blockSize">{{.Opts.MaxBlockSize}}</span>
+      <input type="range" name="blockSize" min="1" max="16" step="1" value="{{.Opts.MaxBlockSize}}"
+        oninput="document.getElementById('v-blockSize').textContent=this.value" onchange="this.form.submit()">
+    </label>
+    <label>HALO <span class="val" id="v-halo">{{printf "%.2f" .Opts.HaloThreshold}}</span>
+      <input type="range" name="halo" min="0" max="0.5" step="0.01" value="{{printf "%.2f" .Opts.HaloThreshold}}"
+        oninput="document.getElementById('v-halo').textContent=this.value" onchange="this.form.submit()">
+    </label>
+    <label>TEX.START <span class="val" id="v-texStart">{{printf "%.2f" .Opts.TextureStart}}</span>
+      <input type="range" name="texStart" min="0" max="1" step="0.01" value="{{printf "%.2f" .Opts.TextureStart}}"
+        oninput="document.getElementById('v-texStart').textContent=this.value" onchange="this.form.submit()">
+    </label>
+    <label>TEX.DENS <span class="val" id="v-texDensity">{{printf "%.2f" .Opts.TextureDensity}}</span>
+      <input type="range" name="texDensity" min="0" max="1" step="0.01" value="{{printf "%.2f" .Opts.TextureDensity}}"
+        oninput="document.getElementById('v-texDensity').textContent=this.value" onchange="this.form.submit()">
+    </label>
+    <label>TEX.CON <span class="val" id="v-texContrast">{{printf "%.2f" .Opts.TextureContrast}}</span>
+      <input type="range" name="texContrast" min="0" max="0.5" step="0.01" value="{{printf "%.2f" .Opts.TextureContrast}}"
+        oninput="document.getElementById('v-texContrast').textContent=this.value" onchange="this.form.submit()">
+    </label>
+  </form>
+  <button onclick="location.reload()">RELOAD</button>
+</header>
+
+<div class="grid">
+  {{range .Frames}}
+  <div class="frame">
+    <div class="caption">
+      <span>PH {{printf "%02d" .Phase}} / {{$.Total}} &middot; {{.Label}}</span>
+      <span class="state">{{.State}}</span>
+    </div>
+    <pre class="art">{{.HTML}}</pre>
+  </div>
+  {{end}}
+</div>
+</body>
+</html>
+`

--- a/docs/superpowers/plans/2026-04-17-planet-focus-pull-overlay.md
+++ b/docs/superpowers/plans/2026-04-17-planet-focus-pull-overlay.md
@@ -1,0 +1,1846 @@
+# Planet Focus-Pull Overlay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the raw log stream during `cspace up` provisioning with a bubbletea alt-screen overlay showing the instance's planet "coming into focus" across 14 phases, with a clean handoff to Claude on success and a bordered error panel on failure.
+
+**Architecture:** `provision.Run` grows a `Reporter` interface and `Stdout`/`Stderr` writers in `Params`. `cspace up` creates a buffered event channel and a bubbletea `tea.Program` with `tea.WithAltScreen()`, then runs provisioning in a goroutine while the overlay consumes events. Six palette stages (block → half-block → braille) combined with a per-phase RGB lerp from grey to the planet's canonical color create the focus-pull effect. `--verbose`, non-TTY stdout, and terminals smaller than 40×30 bypass the overlay entirely.
+
+**Tech Stack:** Go 1.25 + `github.com/charmbracelet/bubbletea` v1.3.10, `github.com/charmbracelet/bubbles/spinner`, `github.com/charmbracelet/lipgloss` v1.1.0 (already direct dep), `golang.org/x/term` (terminal size). Bubbletea and bubbles are currently transitive via huh; we promote them to direct deps.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `lib/planets.json` | Create | Canonical planet config. Synced into `internal/assets/embedded/` by `make sync-embedded`, read by Go via `assets.EmbeddedFS`. Future: shell `statusline.sh` reads via `jq`. |
+| `Makefile` | Modify | Add `cp lib/planets.json internal/assets/embedded/` to `sync-embedded` target. |
+| `internal/planets/planets.go` | Create | `Planet` struct, `Get`, `MustGet`. Loads from `assets.EmbeddedFS`. |
+| `internal/planets/shapes.go` | Create | `Shape` type (`[6][12]float64`), `GetShape(name)` returning per-planet shade grid. |
+| `internal/planets/planets_test.go` | Create | Unit tests for Get, MustGet, GetShape. |
+| `internal/overlay/render.go` | Create | `LerpColor`, `ShadeToChar`, `RenderPlanet` — pure functions, easy to test. |
+| `internal/overlay/render_test.go` | Create | Unit tests for all render functions. |
+| `internal/overlay/overlay.go` | Create | Bubbletea model, `ProvisionEvent` types, `ChannelReporter`, `NewModel`, `Run`. |
+| `internal/overlay/overlay_test.go` | Create | `View()` output tests for loading/error states. |
+| `internal/provision/provision.go` | Modify | Add `Reporter` interface, `logReporter`, `Stdout`/`Stderr` fields on `Params`, phase callbacks at each boundary, tracked-phase error defer. |
+| `internal/cli/up.go` | Modify | Add `--verbose` flag, terminal size check, wire channel reporter + overlay goroutine for TTY path. |
+| `go.mod` / `go.sum` | Modify (via `go get`) | Promote `bubbletea` and `bubbles` to direct deps; add `golang.org/x/term`. |
+
+---
+
+## Conventions
+
+- After any change to `lib/` run `make sync-embedded` (build does this automatically).
+- After any Go change run `make vet && make test` before committing.
+- Keep commit messages short imperative ("Add planets package", "Wire overlay into cspace up").
+- All file paths in this plan are relative to `/workspace`.
+
+---
+
+## Task 1: Planets package + canonical JSON
+
+**Files:**
+- Create: `lib/planets.json`
+- Create: `internal/planets/planets.go`
+- Create: `internal/planets/planets_test.go`
+- Modify: `Makefile` (one line)
+- Modify: `go.mod` / `go.sum` (via `go get`)
+
+- [ ] **Step 1: Write `lib/planets.json`**
+
+```json
+{
+  "planets": {
+    "mercury": { "symbol": "☿", "color": [169, 169, 169], "accent": [120, 120, 120] },
+    "venus":   { "symbol": "♀", "color": [237, 214, 153], "accent": [200, 170, 110] },
+    "earth":   { "symbol": "♁", "color": [78, 159, 222],  "accent": [60, 130, 90]   },
+    "mars":    { "symbol": "♂", "color": [193, 68, 14],   "accent": [220, 180, 160] },
+    "jupiter": { "symbol": "♃", "color": [200, 133, 44],  "accent": [150, 90, 40]   },
+    "saturn":  { "symbol": "♄", "color": [212, 180, 131], "accent": [170, 140, 100] },
+    "uranus":  { "symbol": "♅", "color": [127, 223, 223], "accent": [90, 170, 170]  },
+    "neptune": { "symbol": "♆", "color": [63, 84, 186],   "accent": [40, 60, 140]   }
+  }
+}
+```
+
+- [ ] **Step 2: Extend the `sync-embedded` Makefile target**
+
+Add this line inside the `sync-embedded:` recipe in `Makefile`, immediately after the existing `@cp lib/defaults.json internal/assets/embedded/` line (around line 21):
+
+```makefile
+	@cp lib/planets.json internal/assets/embedded/
+```
+
+Then run:
+
+```bash
+make sync-embedded
+ls internal/assets/embedded/planets.json
+```
+
+Expected: file exists.
+
+- [ ] **Step 3: Write the failing test `internal/planets/planets_test.go`**
+
+```go
+package planets
+
+import "testing"
+
+func TestGetMercury(t *testing.T) {
+	p, ok := Get("mercury")
+	if !ok {
+		t.Fatal("expected mercury to be present")
+	}
+	if p.Symbol != "☿" {
+		t.Errorf("symbol: got %q, want ☿", p.Symbol)
+	}
+	if p.Color != [3]uint8{169, 169, 169} {
+		t.Errorf("color: got %v, want [169 169 169]", p.Color)
+	}
+}
+
+func TestGetUnknown(t *testing.T) {
+	if _, ok := Get("pluto"); ok {
+		t.Error("expected pluto to be absent")
+	}
+}
+
+func TestMustGetFallback(t *testing.T) {
+	p := MustGet("pluto")
+	if p.Symbol == "" {
+		t.Error("expected non-empty fallback symbol")
+	}
+}
+
+func TestAllPlanetsPresent(t *testing.T) {
+	want := []string{"mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"}
+	for _, name := range want {
+		if _, ok := Get(name); !ok {
+			t.Errorf("missing planet %q", name)
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run the test to see it fail**
+
+```bash
+go test ./internal/planets/...
+```
+
+Expected: FAIL with "package internal/planets: build failed" (no planets.go yet).
+
+- [ ] **Step 5: Implement `internal/planets/planets.go`**
+
+```go
+// Package planets loads the canonical planet visual config shared between
+// the provisioning overlay and the in-container statusline.
+package planets
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/elliottregan/cspace/internal/assets"
+)
+
+// Planet describes how a single planet renders: unicode symbol, canonical
+// 24-bit color, and a complementary accent color for band/detail shading.
+type Planet struct {
+	Symbol string   `json:"symbol"`
+	Color  [3]uint8 `json:"color"`
+	Accent [3]uint8 `json:"accent"`
+}
+
+type planetsFile struct {
+	Planets map[string]Planet `json:"planets"`
+}
+
+var all map[string]Planet
+
+func init() {
+	data, err := assets.EmbeddedFS.ReadFile("embedded/planets.json")
+	if err != nil {
+		panic(fmt.Sprintf("planets: reading embedded planets.json: %v", err))
+	}
+	var f planetsFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		panic(fmt.Sprintf("planets: unmarshal planets.json: %v", err))
+	}
+	all = f.Planets
+}
+
+// Get returns the Planet config for name. The second return value is false
+// when the name is not a known planet.
+func Get(name string) (Planet, bool) {
+	p, ok := all[name]
+	return p, ok
+}
+
+// MustGet returns Get(name) on hit, or a neutral grey fallback otherwise.
+// Callers use this when the instance name was user-provided and may not
+// correspond to a known planet (e.g. a custom instance name like "ci-bot").
+func MustGet(name string) Planet {
+	if p, ok := all[name]; ok {
+		return p
+	}
+	return Planet{
+		Symbol: "●",
+		Color:  [3]uint8{128, 128, 128},
+		Accent: [3]uint8{90, 90, 90},
+	}
+}
+```
+
+- [ ] **Step 6: Run the test to see it pass**
+
+```bash
+make sync-embedded
+go test ./internal/planets/...
+```
+
+Expected: PASS on all four tests.
+
+- [ ] **Step 7: Promote bubbletea, bubbles, and x/term to direct deps**
+
+```bash
+cd /workspace
+go get github.com/charmbracelet/bubbletea@v1.3.10
+go get github.com/charmbracelet/bubbles/spinner
+go get golang.org/x/term
+go mod tidy
+```
+
+Then verify:
+
+```bash
+grep -E "bubbletea|bubbles|golang.org/x/term" go.mod
+```
+
+Expected: all three appear outside `// indirect` blocks.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/planets.json internal/planets/ Makefile go.mod go.sum internal/assets/embedded/planets.json
+git commit -m "Add planets package with canonical visual config"
+```
+
+Note: `internal/assets/embedded/planets.json` is a build product but is committed because `.gitkeep` lives alongside it and sync-embedded writes into the tree. If your repo .gitignores that path, drop it from the `git add`.
+
+---
+
+## Task 2: Shape maps (all 8 planets)
+
+**Files:**
+- Create: `internal/planets/shapes.go`
+- Modify: `internal/planets/planets_test.go` (add shape tests)
+
+- [ ] **Step 1: Add failing test for `GetShape`**
+
+Append to `internal/planets/planets_test.go`:
+
+```go
+func TestGetShapeDimensions(t *testing.T) {
+	names := []string{"mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"}
+	for _, name := range names {
+		s := GetShape(name)
+		if len(s) != 6 {
+			t.Errorf("%s: got %d rows, want 6", name, len(s))
+		}
+		for r, row := range s {
+			if len(row) != 12 {
+				t.Errorf("%s row %d: got %d cols, want 12", name, r, len(row))
+			}
+		}
+	}
+}
+
+func TestGetShapeUnknown(t *testing.T) {
+	// Unknown names should fall back to the mercury shape so custom
+	// instance names still render something.
+	s := GetShape("ci-bot")
+	if len(s) != 6 {
+		t.Errorf("fallback shape: got %d rows, want 6", len(s))
+	}
+}
+
+func TestShapeValuesInRange(t *testing.T) {
+	s := GetShape("mercury")
+	for r, row := range s {
+		for c, v := range row {
+			if v < 0 || v > 1 {
+				t.Errorf("mercury[%d][%d] = %v, must be in [0,1]", r, c, v)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to see failure**
+
+```bash
+go test ./internal/planets/...
+```
+
+Expected: FAIL with "undefined: GetShape".
+
+- [ ] **Step 3: Implement `internal/planets/shapes.go`**
+
+Each shape is a 6-row × 12-col grid of shade values in [0.0, 1.0]. 0.0 = empty space, 1.0 = brightest center. Rows are terminal lines; cols are single terminal chars. Chars are roughly 2:1 height-to-width so a 12×6 grid renders as a roughly circular disk.
+
+```go
+package planets
+
+// Shape is a 6-row × 12-col grid of shade values in [0.0, 1.0] describing
+// how a planet renders. Each cell is one terminal character. 0.0 = empty,
+// 1.0 = maximum intensity.
+type Shape = [6][12]float64
+
+// mercurySimpleSphere — featureless silvery sphere, linear falloff.
+var mercurySimpleSphere = Shape{
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
+	{0.0, 0.3, 0.7, 0.9, 1.0, 1.0, 1.0, 0.9, 0.7, 0.5, 0.2, 0.0},
+	{0.0, 0.3, 0.7, 0.9, 1.0, 1.0, 1.0, 0.9, 0.7, 0.5, 0.2, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+}
+
+// venusUniformHaze — thick bright atmosphere, nearly uniform disk.
+var venusUniformHaze = Shape{
+	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.5, 0.8, 0.9, 0.9, 0.9, 0.9, 0.8, 0.5, 0.0, 0.0},
+	{0.0, 0.4, 0.8, 0.9, 0.9, 1.0, 1.0, 0.9, 0.9, 0.7, 0.3, 0.0},
+	{0.0, 0.4, 0.8, 0.9, 0.9, 1.0, 1.0, 0.9, 0.9, 0.7, 0.3, 0.0},
+	{0.0, 0.0, 0.5, 0.8, 0.9, 0.9, 0.9, 0.9, 0.8, 0.5, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+}
+
+// earthContinents — irregular shading suggests land/sea contrast.
+var earthContinents = Shape{
+	{0.0, 0.0, 0.0, 0.3, 0.6, 0.7, 0.7, 0.6, 0.3, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.5, 0.8, 0.7, 0.9, 0.9, 0.8, 0.6, 0.3, 0.0, 0.0},
+	{0.0, 0.3, 0.6, 0.7, 0.9, 1.0, 0.8, 0.9, 0.7, 0.4, 0.1, 0.0},
+	{0.0, 0.2, 0.7, 0.9, 0.8, 1.0, 1.0, 0.7, 0.8, 0.5, 0.2, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.9, 0.8, 0.9, 0.8, 0.6, 0.3, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+}
+
+// marsPolarCap — top row slightly brighter than bottom, hint of northern ice cap.
+var marsPolarCap = Shape{
+	{0.0, 0.0, 0.0, 0.3, 0.6, 0.8, 0.8, 0.6, 0.3, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
+	{0.0, 0.3, 0.6, 0.8, 0.9, 1.0, 1.0, 0.9, 0.7, 0.4, 0.1, 0.0},
+	{0.0, 0.2, 0.5, 0.8, 0.9, 1.0, 1.0, 0.9, 0.7, 0.4, 0.1, 0.0},
+	{0.0, 0.0, 0.3, 0.6, 0.7, 0.8, 0.8, 0.7, 0.5, 0.3, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.2, 0.4, 0.5, 0.5, 0.4, 0.2, 0.0, 0.0, 0.0},
+}
+
+// jupiterBands — alternating rows with different core intensity read as horizontal bands.
+var jupiterBands = Shape{
+	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+	{0.0, 0.2, 0.5, 0.8, 1.0, 1.0, 1.0, 0.9, 0.6, 0.2, 0.0, 0.0},
+	{0.0, 0.2, 0.6, 0.8, 0.9, 1.0, 1.0, 0.8, 0.7, 0.4, 0.1, 0.0},
+	{0.0, 0.1, 0.5, 0.8, 1.0, 1.0, 1.0, 0.9, 0.6, 0.3, 0.0, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+}
+
+// saturnRings — sphere in middle 4 rows, ring extends to cols 0-1 and 10-11 on the equator.
+var saturnRings = Shape{
+	{0.0, 0.0, 0.0, 0.0, 0.4, 0.6, 0.6, 0.4, 0.0, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.2, 0.6, 0.9, 1.0, 1.0, 0.9, 0.6, 0.2, 0.0, 0.0},
+	{0.3, 0.4, 0.5, 0.7, 0.9, 1.0, 1.0, 0.9, 0.7, 0.5, 0.4, 0.3},
+	{0.3, 0.4, 0.5, 0.7, 0.9, 1.0, 1.0, 0.9, 0.7, 0.5, 0.4, 0.3},
+	{0.0, 0.0, 0.2, 0.6, 0.9, 1.0, 1.0, 0.9, 0.6, 0.2, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.0, 0.4, 0.6, 0.6, 0.4, 0.0, 0.0, 0.0, 0.0},
+}
+
+// uranusSmallSphere — smaller, uniform disk (Uranus reads as a featureless blue-green ball).
+var uranusSmallSphere = Shape{
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.3, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.3, 0.0, 0.0},
+	{0.0, 0.2, 0.6, 0.8, 0.9, 1.0, 1.0, 0.9, 0.8, 0.6, 0.2, 0.0},
+	{0.0, 0.2, 0.6, 0.8, 0.9, 1.0, 1.0, 0.9, 0.8, 0.6, 0.2, 0.0},
+	{0.0, 0.0, 0.3, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.3, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+}
+
+// neptuneDenseCore — smaller, darker-edged disk with bright concentrated core.
+var neptuneDenseCore = Shape{
+	{0.0, 0.0, 0.0, 0.0, 0.3, 0.5, 0.5, 0.3, 0.0, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.2, 0.5, 0.7, 0.8, 0.8, 0.7, 0.5, 0.2, 0.0, 0.0},
+	{0.0, 0.1, 0.5, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.5, 0.1, 0.0},
+	{0.0, 0.1, 0.5, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.5, 0.1, 0.0},
+	{0.0, 0.0, 0.2, 0.5, 0.7, 0.8, 0.8, 0.7, 0.5, 0.2, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.0, 0.3, 0.5, 0.5, 0.3, 0.0, 0.0, 0.0, 0.0},
+}
+
+var shapes = map[string]Shape{
+	"mercury": mercurySimpleSphere,
+	"venus":   venusUniformHaze,
+	"earth":   earthContinents,
+	"mars":    marsPolarCap,
+	"jupiter": jupiterBands,
+	"saturn":  saturnRings,
+	"uranus":  uranusSmallSphere,
+	"neptune": neptuneDenseCore,
+}
+
+// GetShape returns the shade grid for the named planet. Unknown names fall
+// back to the mercury sphere so custom instance names still render.
+func GetShape(name string) Shape {
+	if s, ok := shapes[name]; ok {
+		return s
+	}
+	return mercurySimpleSphere
+}
+```
+
+- [ ] **Step 4: Run tests to see pass**
+
+```bash
+go test ./internal/planets/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/planets/shapes.go internal/planets/planets_test.go
+git commit -m "Add planet shape maps for focus-pull animation"
+```
+
+---
+
+## Task 3: Render primitives (LerpColor, ShadeToChar, RenderPlanet)
+
+**Files:**
+- Create: `internal/overlay/render.go`
+- Create: `internal/overlay/render_test.go`
+
+- [ ] **Step 1: Write failing tests `internal/overlay/render_test.go`**
+
+```go
+package overlay
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elliottregan/cspace/internal/planets"
+)
+
+func TestLerpColorEndpoints(t *testing.T) {
+	from := [3]uint8{0, 0, 0}
+	to := [3]uint8{100, 200, 50}
+
+	if got := LerpColor(from, to, 0); got != from {
+		t.Errorf("t=0: got %v, want %v", got, from)
+	}
+	if got := LerpColor(from, to, 1); got != to {
+		t.Errorf("t=1: got %v, want %v", got, to)
+	}
+	got := LerpColor(from, to, 0.5)
+	if got != [3]uint8{50, 100, 25} {
+		t.Errorf("t=0.5: got %v, want [50 100 25]", got)
+	}
+}
+
+func TestLerpColorReverseDirection(t *testing.T) {
+	// Lerping from a lighter to a darker channel must not underflow uint8.
+	from := [3]uint8{200, 200, 200}
+	to := [3]uint8{50, 50, 50}
+	got := LerpColor(from, to, 0.5)
+	if got[0] != 125 || got[1] != 125 || got[2] != 125 {
+		t.Errorf("got %v, want [125 125 125]", got)
+	}
+}
+
+func TestShadeToCharZero(t *testing.T) {
+	for phase := 1; phase <= 6; phase++ {
+		if got := ShadeToChar(0, phase); got != " " {
+			t.Errorf("phase %d shade 0: got %q, want \" \"", phase, got)
+		}
+	}
+}
+
+func TestShadeToCharNonZero(t *testing.T) {
+	for phase := 1; phase <= 6; phase++ {
+		if got := ShadeToChar(1.0, phase); got == " " {
+			t.Errorf("phase %d shade 1.0: got space, want non-space", phase)
+		}
+	}
+}
+
+func TestShadeToCharPhase1Binary(t *testing.T) {
+	// Phase 1 palette has only "█" for non-zero shade.
+	for _, v := range []float64{0.1, 0.5, 0.9, 1.0} {
+		if got := ShadeToChar(v, 1); got != "█" {
+			t.Errorf("phase 1 shade %.1f: got %q, want \"█\"", v, got)
+		}
+	}
+}
+
+func TestRenderPlanetDimensions(t *testing.T) {
+	p := planets.MustGet("mercury")
+	shape := planets.GetShape("mercury")
+	out := RenderPlanet(shape, p, 1, 14)
+	lines := strings.Split(out, "\n")
+	if len(lines) != 6 {
+		t.Errorf("got %d lines, want 6", len(lines))
+	}
+}
+
+func TestRenderPlanetChangesAcrossPhases(t *testing.T) {
+	p := planets.MustGet("mercury")
+	shape := planets.GetShape("mercury")
+	early := RenderPlanet(shape, p, 1, 14)
+	late := RenderPlanet(shape, p, 14, 14)
+	if early == late {
+		t.Error("expected render to differ between phase 1 and phase 14")
+	}
+}
+
+func TestRenderPlanetContainsAnsiColor(t *testing.T) {
+	p := planets.MustGet("mercury")
+	shape := planets.GetShape("mercury")
+	out := RenderPlanet(shape, p, 14, 14)
+	if !strings.Contains(out, "\x1b[38;2;") {
+		t.Error("expected truecolor ANSI escape in output")
+	}
+	if !strings.Contains(out, "\x1b[0m") {
+		t.Error("expected ANSI reset in output")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to see failure**
+
+```bash
+go test ./internal/overlay/...
+```
+
+Expected: FAIL with "undefined: LerpColor".
+
+- [ ] **Step 3: Implement `internal/overlay/render.go`**
+
+```go
+// Package overlay renders the bubbletea provisioning overlay — a planet
+// "coming into focus" through six palette stages while color lerps from
+// grey to the planet's canonical RGB.
+package overlay
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elliottregan/cspace/internal/planets"
+)
+
+// greyStart is the dim grey color the focus-pull begins with before
+// interpolating toward the planet's canonical color as phases advance.
+var greyStart = [3]uint8{85, 85, 85}
+
+// palettes[phase-1] is the lookup table used during phase N (1..6).
+// Index 0 is always the space rendered for shade 0; subsequent indices
+// map non-zero shade values (split evenly across [0,1]) to progressively
+// denser characters. See the issue for the "block → half-block → braille"
+// progression.
+var palettes = [6][]string{
+	{" ", "█"},
+	{" ", "▓", "█"},
+	{" ", "▒", "▓", "█"},
+	{" ", "░", "▒", "▓", "█"},
+	{" ", "░", "▒", "▓", "▌", "█"},
+	{" ", "⠂", "░", "▒", "▓", "▌", "█"},
+}
+
+// LerpColor linearly interpolates each channel of from→to by t∈[0,1].
+// Values outside [0,1] are clamped. Channel arithmetic uses float64 to
+// avoid uint8 underflow when a channel shrinks (e.g. 200 → 50).
+func LerpColor(from, to [3]uint8, t float64) [3]uint8 {
+	if t < 0 {
+		t = 0
+	}
+	if t > 1 {
+		t = 1
+	}
+	lerp := func(a, b uint8) uint8 {
+		v := float64(a) + t*(float64(b)-float64(a))
+		if v < 0 {
+			return 0
+		}
+		if v > 255 {
+			return 255
+		}
+		return uint8(v)
+	}
+	return [3]uint8{
+		lerp(from[0], to[0]),
+		lerp(from[1], to[1]),
+		lerp(from[2], to[2]),
+	}
+}
+
+// ShadeToChar maps a shade in [0,1] to a single character chosen from the
+// palette for the given phase (1..6). Phases outside the range are clamped.
+// Shade <= 0 always maps to " ".
+func ShadeToChar(shade float64, phase int) string {
+	if shade <= 0 {
+		return " "
+	}
+	if phase < 1 {
+		phase = 1
+	}
+	if phase > 6 {
+		phase = 6
+	}
+	pal := palettes[phase-1]
+	// Skip the leading " " for non-zero shades so a low but positive shade
+	// always renders a visible glyph.
+	nonBlank := pal[1:]
+	idx := int(shade * float64(len(nonBlank)))
+	if idx >= len(nonBlank) {
+		idx = len(nonBlank) - 1
+	}
+	return nonBlank[idx]
+}
+
+// ansiColor returns the 24-bit foreground SGR escape for rgb.
+func ansiColor(rgb [3]uint8) string {
+	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm", rgb[0], rgb[1], rgb[2])
+}
+
+// ansiReset restores default SGR.
+const ansiReset = "\x1b[0m"
+
+// RenderPlanet returns the colored ASCII art for one frame of the focus-pull
+// animation. Color lerps from grey to planet.Color by (phase/total) and the
+// palette densifies as phase grows. The return value is a 6-line string with
+// each non-empty cell wrapped in truecolor ANSI and a trailing reset.
+func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) string {
+	if total <= 0 {
+		total = 1
+	}
+	t := float64(phase) / float64(total)
+	rgb := LerpColor(greyStart, p.Color, t)
+	color := ansiColor(rgb)
+
+	var rows []string
+	for _, row := range shape {
+		var line strings.Builder
+		for _, shade := range row {
+			ch := ShadeToChar(shade, phaseStage(phase, total))
+			if ch == " " {
+				line.WriteByte(' ')
+				continue
+			}
+			line.WriteString(color)
+			line.WriteString(ch)
+			line.WriteString(ansiReset)
+		}
+		rows = append(rows, line.String())
+	}
+	return strings.Join(rows, "\n")
+}
+
+// phaseStage maps the provisioning phase index (1..total) to a 1..6 palette
+// stage. With 14 provisioning phases, each palette stage covers ~2.3 phases.
+// Phase 0 is treated as stage 1.
+func phaseStage(phase, total int) int {
+	if phase < 1 {
+		return 1
+	}
+	if total < 1 {
+		total = 1
+	}
+	stage := 1 + (phase-1)*6/total
+	if stage < 1 {
+		stage = 1
+	}
+	if stage > 6 {
+		stage = 6
+	}
+	return stage
+}
+```
+
+- [ ] **Step 4: Run tests to see pass**
+
+```bash
+go test ./internal/overlay/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/overlay/render.go internal/overlay/render_test.go
+git commit -m "Add planet render primitives for focus-pull overlay"
+```
+
+---
+
+## Task 4: Bubbletea overlay model (skeleton — loading + error states)
+
+**Files:**
+- Create: `internal/overlay/overlay.go`
+- Create: `internal/overlay/overlay_test.go`
+
+- [ ] **Step 1: Write failing tests `internal/overlay/overlay_test.go`**
+
+```go
+package overlay
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elliottregan/cspace/internal/planets"
+)
+
+func newTestModel() Model {
+	return NewModel(ModelConfig{
+		Name:   "mercury",
+		Planet: planets.MustGet("mercury"),
+		Total:  14,
+		Events: make(chan ProvisionEvent, 4),
+		Now:    func() time.Time { return time.Unix(0, 0) },
+	})
+}
+
+func TestViewShowsInstanceName(t *testing.T) {
+	m := newTestModel()
+	m.phase = "Validating"
+	m.phaseNum = 1
+	out := m.View()
+	if !strings.Contains(out, "mercury") {
+		t.Error("expected instance name in view")
+	}
+}
+
+func TestViewShowsPhaseName(t *testing.T) {
+	m := newTestModel()
+	m.phase = "Installing plugins"
+	m.phaseNum = 14
+	out := m.View()
+	if !strings.Contains(out, "Installing plugins") {
+		t.Error("expected phase name in view")
+	}
+}
+
+func TestViewShowsElapsed(t *testing.T) {
+	now := time.Unix(0, 0)
+	m := NewModel(ModelConfig{
+		Name:   "mercury",
+		Planet: planets.MustGet("mercury"),
+		Total:  14,
+		Events: make(chan ProvisionEvent, 4),
+		Now:    func() time.Time { return now.Add(107 * time.Second) },
+	})
+	m.phase = "Validating"
+	m.phaseNum = 1
+	out := m.View()
+	if !strings.Contains(out, "01:47") {
+		t.Errorf("expected elapsed 01:47 in view, got:\n%s", out)
+	}
+}
+
+func TestViewErrorPanel(t *testing.T) {
+	m := newTestModel()
+	m.err = errors.New("compose up failed: exit 1")
+	m.errPhase = "Starting containers"
+	out := m.View()
+	for _, want := range []string{
+		"Provisioning failed",
+		"Starting containers",
+		"--verbose",
+		"Press any key",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("error panel missing %q\nfull view:\n%s", want, out)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to see failure**
+
+```bash
+go test ./internal/overlay/...
+```
+
+Expected: FAIL with "undefined: NewModel".
+
+- [ ] **Step 3: Implement `internal/overlay/overlay.go`**
+
+```go
+package overlay
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/elliottregan/cspace/internal/planets"
+)
+
+// EventKind distinguishes provisioning events received by the overlay.
+type EventKind int
+
+const (
+	// PhaseEvent announces that provisioning has entered a new phase.
+	PhaseEvent EventKind = iota
+	// WarnEvent carries a provisioning warning (non-fatal).
+	WarnEvent
+	// DoneEvent signals successful completion.
+	DoneEvent
+	// ErrorEvent signals a fatal provisioning failure.
+	ErrorEvent
+)
+
+// ProvisionEvent is the message sent from provision.Run to the overlay over
+// a buffered channel. One goroutine writes; bubbletea reads.
+type ProvisionEvent struct {
+	Kind    EventKind
+	Phase   string
+	Num     int
+	Total   int
+	Message string
+	Err     error
+}
+
+// ChannelReporter implements provision.Reporter by pushing events into a
+// buffered channel. It tracks the most-recent phase name so Error() can
+// report which phase failed.
+type ChannelReporter struct {
+	events     chan<- ProvisionEvent
+	lastPhase  string
+	totalHint  int
+}
+
+// NewChannelReporter builds a reporter that writes into events. The total
+// hint is the total number of expected phases; callers pass 14 today.
+func NewChannelReporter(events chan<- ProvisionEvent, total int) *ChannelReporter {
+	return &ChannelReporter{events: events, totalHint: total}
+}
+
+// Phase records the current phase name and dispatches a PhaseEvent.
+func (r *ChannelReporter) Phase(name string, num, total int) {
+	r.lastPhase = name
+	r.events <- ProvisionEvent{
+		Kind:  PhaseEvent,
+		Phase: name,
+		Num:   num,
+		Total: total,
+	}
+}
+
+// Warn dispatches a WarnEvent. The overlay currently ignores warnings, but
+// they're captured so a future version could render a warning stack.
+func (r *ChannelReporter) Warn(msg string) {
+	r.events <- ProvisionEvent{Kind: WarnEvent, Message: msg}
+}
+
+// Done dispatches a DoneEvent. Caller should not send further events.
+func (r *ChannelReporter) Done() {
+	r.events <- ProvisionEvent{Kind: DoneEvent}
+}
+
+// Error dispatches an ErrorEvent using the most recently reported phase
+// when phase is empty (e.g. when called from a deferred error handler).
+func (r *ChannelReporter) Error(phase string, err error) {
+	if phase == "" {
+		phase = r.lastPhase
+	}
+	r.events <- ProvisionEvent{Kind: ErrorEvent, Phase: phase, Err: err}
+}
+
+// ModelConfig bundles the constructor arguments for NewModel so callers
+// (and tests) do not need to remember field order.
+type ModelConfig struct {
+	Name   string
+	Planet planets.Planet
+	Total  int
+	Events <-chan ProvisionEvent
+	Now    func() time.Time // injectable for tests
+}
+
+// Model is the bubbletea model driving the provisioning overlay.
+type Model struct {
+	cfg      ModelConfig
+	phase    string
+	phaseNum int
+	start    time.Time
+	err      error
+	errPhase string
+	done     bool
+	spinner  spinner.Model
+	width    int
+	height   int
+}
+
+// NewModel constructs a Model with sensible defaults. Events must be a
+// channel the caller feeds from provision.Run goroutines.
+func NewModel(cfg ModelConfig) Model {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Total <= 0 {
+		cfg.Total = 14
+	}
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	return Model{
+		cfg:     cfg,
+		start:   cfg.Now(),
+		spinner: sp,
+	}
+}
+
+// tickMsg fires once per second to keep the elapsed timer fresh.
+type tickMsg time.Time
+
+func tickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+// waitForEvent returns a command that blocks on the events channel and
+// converts the next event into a tea.Msg so bubbletea can dispatch it.
+func waitForEvent(events <-chan ProvisionEvent) tea.Cmd {
+	return func() tea.Msg {
+		ev, ok := <-events
+		if !ok {
+			// Channel closed without a Done event — treat as done.
+			return ProvisionEvent{Kind: DoneEvent}
+		}
+		return ev
+	}
+}
+
+// Init is part of the tea.Model interface.
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(
+		m.spinner.Tick,
+		tickCmd(),
+		waitForEvent(m.cfg.Events),
+	)
+}
+
+// Update is part of the tea.Model interface.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.err != nil {
+			// Any key dismisses the error panel.
+			m.done = true
+			return m, tea.Quit
+		}
+		if msg.Type == tea.KeyCtrlC {
+			m.done = true
+			return m, tea.Quit
+		}
+		return m, nil
+
+	case tickMsg:
+		if m.done {
+			return m, nil
+		}
+		return m, tickCmd()
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case ProvisionEvent:
+		switch msg.Kind {
+		case PhaseEvent:
+			m.phase = msg.Phase
+			m.phaseNum = msg.Num
+			if msg.Total > 0 {
+				m.cfg.Total = msg.Total
+			}
+			return m, waitForEvent(m.cfg.Events)
+		case WarnEvent:
+			// Drop silently for now.
+			return m, waitForEvent(m.cfg.Events)
+		case DoneEvent:
+			m.done = true
+			return m, tea.Quit
+		case ErrorEvent:
+			m.err = msg.Err
+			m.errPhase = msg.Phase
+			// Stay on screen until keypress.
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+// View is part of the tea.Model interface.
+func (m Model) View() string {
+	if m.done && m.err == nil {
+		return ""
+	}
+	if m.err != nil {
+		return m.errorView()
+	}
+	return m.loadingView()
+}
+
+var nameStyle = lipgloss.NewStyle().Bold(true)
+
+func (m Model) loadingView() string {
+	shape := planets.GetShape(m.cfg.Name)
+	art := RenderPlanet(shape, m.cfg.Planet, m.phaseNum, m.cfg.Total)
+
+	elapsed := m.cfg.Now().Sub(m.start)
+	mm := int(elapsed.Minutes())
+	ss := int(elapsed.Seconds()) % 60
+	timer := fmt.Sprintf("%02d:%02d", mm, ss)
+
+	planetColor := lipgloss.Color(fmt.Sprintf("#%02x%02x%02x",
+		m.cfg.Planet.Color[0], m.cfg.Planet.Color[1], m.cfg.Planet.Color[2]))
+	nameLine := nameStyle.Foreground(planetColor).Render(m.cfg.Name)
+
+	phaseLine := fmt.Sprintf("%s  %s", m.spinner.View(), m.phase)
+
+	content := strings.Join([]string{
+		art,
+		"",
+		nameLine,
+		"",
+		phaseLine,
+		"",
+		timer,
+	}, "\n")
+
+	if m.width == 0 || m.height == 0 {
+		// No WindowSizeMsg yet; return un-centered.
+		return content
+	}
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+}
+
+var errorPanelStyle = lipgloss.NewStyle().
+	Border(lipgloss.RoundedBorder()).
+	BorderForeground(lipgloss.Color("9")).
+	Padding(1, 2)
+
+func (m Model) errorView() string {
+	lines := []string{
+		"✗  Provisioning failed",
+		"",
+		fmt.Sprintf("Phase: %s", m.errPhase),
+		"",
+		"For the full log, run:",
+		fmt.Sprintf("  cspace up %s --verbose", m.cfg.Name),
+		"",
+		"Press any key to exit",
+	}
+	panel := errorPanelStyle.Render(strings.Join(lines, "\n"))
+	if m.width == 0 || m.height == 0 {
+		return panel
+	}
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, panel)
+}
+
+// Run starts the bubbletea program in alt-screen mode and returns when the
+// user dismisses the error panel or the provisioning completes. The ctx is
+// currently advisory — bubbletea exits on its own signals — but is reserved
+// for future graceful-cancel support.
+func Run(ctx context.Context, cfg ModelConfig) error {
+	p := tea.NewProgram(NewModel(cfg), tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}
+```
+
+- [ ] **Step 4: Run tests to see pass**
+
+```bash
+go test ./internal/overlay/...
+```
+
+Expected: PASS on all four overlay tests plus earlier render tests.
+
+- [ ] **Step 5: `go vet` the new package**
+
+```bash
+make vet
+```
+
+Expected: no output (clean).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/overlay/overlay.go internal/overlay/overlay_test.go
+git commit -m "Add bubbletea overlay model for provisioning focus-pull"
+```
+
+---
+
+## Task 5: Reporter interface in provision
+
+**Files:**
+- Modify: `internal/provision/provision.go`
+- Create: `internal/provision/reporter.go`
+- Create: `internal/provision/reporter_test.go`
+
+The 14 phases we report, in order (new-instance path) plus idempotent tail. Total = 14.
+
+| # | Label | Source |
+|---|---|---|
+| 1 | Validating name | `validateName` |
+| 2 | Removing orphans | orphan loop |
+| 3 | Bundling repo | `gitBundleCreate` |
+| 4 | Creating volumes | `ensureVolumes` |
+| 5 | Creating network | `NetworkCreate` |
+| 6 | Starting reverse proxy | `EnsureProxy` + `NetworkConnect` |
+| 7 | Setting up directories | teleport/memory/sessions/context dirs |
+| 8 | Starting containers | `compose.Run up -d` |
+| 9 | Waiting for container | `WaitForReady` |
+| 10 | Configuring hosts | `InjectHosts` |
+| 11 | Setting permissions | `chown` |
+| 12 | Initializing workspace | `initWorkspace` |
+| 13 | Configuring git & env | `configureGit` + env + GH |
+| 14 | Installing plugins | marketplace + plugins + post-setup |
+
+When the container is already running we jump straight to phase 14 (the idempotent tail).
+
+- [ ] **Step 1: Write failing test `internal/provision/reporter_test.go`**
+
+```go
+package provision
+
+import "testing"
+
+type captured struct {
+	kind  string // "phase", "warn", "done", "error"
+	name  string
+	num   int
+	total int
+	err   error
+}
+
+type recordingReporter struct{ events []captured }
+
+func (r *recordingReporter) Phase(name string, num, total int) {
+	r.events = append(r.events, captured{kind: "phase", name: name, num: num, total: total})
+}
+func (r *recordingReporter) Warn(msg string) {
+	r.events = append(r.events, captured{kind: "warn", name: msg})
+}
+func (r *recordingReporter) Done() {
+	r.events = append(r.events, captured{kind: "done"})
+}
+func (r *recordingReporter) Error(phase string, err error) {
+	r.events = append(r.events, captured{kind: "error", name: phase, err: err})
+}
+
+func TestReporterInterfaceImplementations(t *testing.T) {
+	// Compile-time assertion: both reporter types implement Reporter.
+	var _ Reporter = (*recordingReporter)(nil)
+	var _ Reporter = logReporter{}
+}
+
+func TestPhasesReference(t *testing.T) {
+	// Sanity check: the Phases slice exposes 14 labeled steps.
+	if len(Phases) != 14 {
+		t.Errorf("Phases: got %d entries, want 14", len(Phases))
+	}
+	if Phases[0] != "Validating name" {
+		t.Errorf("Phases[0]: got %q", Phases[0])
+	}
+	if Phases[13] != "Installing plugins" {
+		t.Errorf("Phases[13]: got %q", Phases[13])
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to see it fail**
+
+```bash
+go test ./internal/provision/... -run "TestReporterInterfaceImplementations|TestPhasesReference"
+```
+
+Expected: FAIL with "undefined: Reporter" or "undefined: Phases".
+
+- [ ] **Step 3: Create `internal/provision/reporter.go`**
+
+```go
+package provision
+
+import (
+	"fmt"
+	"os"
+)
+
+// Reporter receives provisioning progress notifications. Implementations
+// choose how to surface them — fmt.Printf (logReporter) or a bubbletea
+// channel (overlay.ChannelReporter).
+//
+// All methods are called from provision.Run's own goroutine; implementations
+// that forward to channels should use buffered channels so they never block
+// provisioning.
+type Reporter interface {
+	// Phase announces entry into a named phase (1-indexed).
+	Phase(name string, num, total int)
+	// Warn surfaces a non-fatal issue.
+	Warn(msg string)
+	// Done is called once, on successful completion.
+	Done()
+	// Error is called once, on fatal failure. phase is the last phase
+	// that started before the failure ("" = unknown).
+	Error(phase string, err error)
+}
+
+// Phases lists the human-readable label for each of the 14 provisioning
+// phases, in order. Exposed so callers (e.g. the overlay) can show the
+// total count ahead of provisioning starting.
+var Phases = []string{
+	"Validating name",
+	"Removing orphans",
+	"Bundling repo",
+	"Creating volumes",
+	"Creating network",
+	"Starting reverse proxy",
+	"Setting up directories",
+	"Starting containers",
+	"Waiting for container",
+	"Configuring hosts",
+	"Setting permissions",
+	"Initializing workspace",
+	"Configuring git & env",
+	"Installing plugins",
+}
+
+// logReporter is the default reporter used when Params.Reporter is nil.
+// It mimics pre-overlay behavior: plain fmt.Printf lines on stdout,
+// warnings on stderr.
+type logReporter struct{}
+
+func (logReporter) Phase(name string, num, total int) {
+	fmt.Printf("[%d/%d] %s...\n", num, total, name)
+}
+
+func (logReporter) Warn(msg string) {
+	fmt.Fprintf(os.Stderr, "warning: %s\n", msg)
+}
+
+func (logReporter) Done() {
+	fmt.Println("Setup complete.")
+}
+
+func (logReporter) Error(phase string, err error) {
+	if phase != "" {
+		fmt.Fprintf(os.Stderr, "error in phase %q: %v\n", phase, err)
+	}
+}
+```
+
+- [ ] **Step 4: Modify `internal/provision/provision.go` — wire reporter through Run**
+
+Add an `io` import and new fields to `Params`:
+
+```go
+import (
+	// ...existing imports...
+	"io"
+)
+
+type Params struct {
+	Name     string
+	Branch   string
+	Cfg      *config.Config
+	Reporter Reporter  // nil → logReporter{}
+	Stdout   io.Writer // subprocess stdout; nil → os.Stdout
+	Stderr   io.Writer // subprocess stderr; nil → os.Stderr
+}
+
+func (p Params) reporter() Reporter {
+	if p.Reporter != nil {
+		return p.Reporter
+	}
+	return logReporter{}
+}
+
+func (p Params) stdout() io.Writer {
+	if p.Stdout != nil {
+		return p.Stdout
+	}
+	return os.Stdout
+}
+
+func (p Params) stderr() io.Writer {
+	if p.Stderr != nil {
+		return p.Stderr
+	}
+	return os.Stderr
+}
+```
+
+Change the `Run` signature to named returns so a deferred reporter finalizer can see both:
+
+```go
+func Run(p Params) (result Result, err error) {
+	reporter := p.reporter()
+	currentPhase := ""
+	reportPhase := func(num int, label string) {
+		currentPhase = label
+		reporter.Phase(label, num, len(Phases))
+	}
+	reportWarn := func(msg string) { reporter.Warn(msg) }
+
+	defer func() {
+		if err != nil {
+			reporter.Error(currentPhase, err)
+			return
+		}
+		reporter.Done()
+	}()
+
+	name := p.Name
+	cfg := p.Cfg
+
+	// Phase 1
+	reportPhase(1, Phases[0])
+	if err = validateName(name); err != nil {
+		return Result{}, err
+	}
+	// ...rest of the function (see Step 5)
+}
+```
+
+Then replace each `fmt.Printf("Creating new instance...")` style progress statement with the corresponding `reportPhase(N, Phases[N-1])` call, and each `fmt.Fprintf(os.Stderr, "warning: ...")` with `reportWarn(...)`.
+
+- [ ] **Step 5: Concrete edits to `Run`**
+
+Replace the existing `Run` body with the fully-reported version below. (Diff listed inline; use Edit for each hunk.)
+
+At line ~67 (just after `composeName := cfg.ComposeName(name)`):
+
+```go
+	// 2. Check if already running
+	if instance.IsRunning(composeName) {
+		// Already-running path skips phases 2-13; jump to 14.
+		reportPhase(1, "Reusing running container")
+	} else {
+		created = true
+		reportPhase(1, Phases[0]) // redundant with the Phase 1 call above — delete that earlier call
+```
+
+Since Phase 1 was already reported before this block, replace the above with: delete the `reportPhase(1, Phases[0])` we added at function top and move it here so the "already running" branch can report a distinct phase-1 label.
+
+Final structure:
+
+```go
+func Run(p Params) (result Result, err error) {
+	reporter := p.reporter()
+	currentPhase := ""
+	reportPhase := func(num int, label string) {
+		currentPhase = label
+		reporter.Phase(label, num, len(Phases))
+	}
+	reportWarn := func(msg string) { reporter.Warn(msg) }
+	defer func() {
+		if err != nil {
+			reporter.Error(currentPhase, err)
+			return
+		}
+		reporter.Done()
+	}()
+
+	name := p.Name
+	cfg := p.Cfg
+
+	// Phase 1: validate (runs for both new and reused containers)
+	reportPhase(1, Phases[0])
+	if err = validateName(name); err != nil {
+		return Result{}, err
+	}
+
+	composeName := cfg.ComposeName(name)
+	created := false
+
+	if !instance.IsRunning(composeName) {
+		created = true
+
+		// Phase 2: remove orphans
+		reportPhase(2, Phases[1])
+		for _, suffix := range []string{"", ".browser"} {
+			if err = docker.RemoveOrphanContainer(composeName + suffix); err != nil {
+				return Result{}, fmt.Errorf("refusing to provision '%s': %w", name, err)
+			}
+		}
+
+		// Phase 3: bundle repo
+		branch := p.Branch
+		if branch == "" {
+			branch = gitCurrentBranch(cfg.ProjectRoot)
+		}
+		remoteURL := gitRemoteURL(cfg.ProjectRoot)
+		bundlePath := filepath.Join(os.TempDir(), fmt.Sprintf("cspace-%s.bundle", name))
+		reportPhase(3, Phases[2])
+		if err = gitBundleCreate(cfg.ProjectRoot, bundlePath, p.stdout(), p.stderr()); err != nil {
+			return Result{}, fmt.Errorf("creating git bundle: %w", err)
+		}
+		defer func() { _ = os.Remove(bundlePath) }()
+
+		// Phase 4: volumes
+		reportPhase(4, Phases[3])
+		if err = ensureVolumesReported(cfg, reportWarn); err != nil {
+			return Result{}, fmt.Errorf("creating volumes: %w", err)
+		}
+
+		// Phase 5: network
+		reportPhase(5, Phases[4])
+		if err = docker.NetworkCreate(cfg.ProjectNetwork(), cfg.InstanceLabel()); err != nil {
+			return Result{}, fmt.Errorf("creating project network: %w", err)
+		}
+
+		// Phase 6: reverse proxy
+		reportPhase(6, Phases[5])
+		if perr := docker.EnsureProxy(cfg.AssetsDir); perr != nil {
+			reportWarn(fmt.Sprintf("proxy: %v", perr))
+		}
+		if perr := docker.NetworkConnect(cfg.ProjectNetwork(), docker.ProxyContainerName); perr != nil {
+			reportWarn(fmt.Sprintf("connecting proxy to project network: %v", perr))
+		}
+
+		// Phase 7: directories
+		reportPhase(7, Phases[6])
+		tpDir := teleportHostDir()
+		if err = ensureTeleportDir(tpDir); err != nil {
+			return Result{}, err
+		}
+		if err = os.Setenv("CSPACE_TELEPORT_DIR", tpDir); err != nil {
+			return Result{}, fmt.Errorf("exporting CSPACE_TELEPORT_DIR: %w", err)
+		}
+		if err = ensureMemoryDir(cfg.ProjectRoot); err != nil {
+			return Result{}, err
+		}
+		if err = ensureSessionsDir(cfg.SessionsDir()); err != nil {
+			return Result{}, err
+		}
+		if err = ensureContextDir(cfg.ProjectRoot); err != nil {
+			return Result{}, err
+		}
+
+		// Phase 8: compose up
+		reportPhase(8, Phases[7])
+		if err = compose.Run(name, cfg, "up", "-d"); err != nil {
+			return Result{}, fmt.Errorf("starting container: %w", err)
+		}
+
+		// Phase 9: readiness
+		reportPhase(9, Phases[8])
+		if err = WaitForReady(composeName, 120*time.Second); err != nil {
+			return Result{}, err
+		}
+
+		// Phase 10: hosts
+		reportPhase(10, Phases[9])
+		if herr := docker.InjectHosts(composeName, cfg.ProjectNetwork()); herr != nil {
+			reportWarn(fmt.Sprintf("hosts injection: %v", herr))
+		}
+
+		// Phase 11: permissions
+		reportPhase(11, Phases[10])
+		if _, err = instance.DcExecRoot(composeName, "chown", "-R", "dev:dev", "/workspace", "/home/dev/.claude", "/teleport"); err != nil {
+			return Result{}, fmt.Errorf("fixing ownership: %w", err)
+		}
+
+		// Phase 12: workspace
+		reportPhase(12, Phases[11])
+		if err = initWorkspace(composeName, bundlePath, branch, remoteURL); err != nil {
+			return Result{}, fmt.Errorf("initializing workspace: %w", err)
+		}
+
+		// Phase 13: git & env & GH
+		reportPhase(13, Phases[12])
+		configureGit(composeName, cfg.ProjectRoot)
+		copyEnvFile(composeName, cfg.ProjectRoot, ".env")
+		copyEnvFile(composeName, cfg.ProjectRoot, ".env.local")
+		if gerr := setupGHAuth(composeName, cfg.ProjectRoot); gerr != nil {
+			reportWarn(gerr.Error())
+		}
+	}
+
+	// Phase 14: idempotent tail (marketplace + plugins + post-setup)
+	reportPhase(14, Phases[13])
+	if merr := ensureMarketplace(composeName); merr != nil {
+		reportWarn(fmt.Sprintf("marketplace setup: %v", merr))
+	}
+	if ierr := installPlugins(composeName, cfg); ierr != nil {
+		reportWarn(fmt.Sprintf("plugin installation: %v", ierr))
+	}
+	if perr := runPostSetup(composeName, cfg); perr != nil {
+		reportWarn(fmt.Sprintf("post-setup: %v", perr))
+	}
+
+	return Result{Created: created, Name: name}, nil
+}
+```
+
+- [ ] **Step 6: Update `gitBundleCreate` to accept explicit writers**
+
+Replace the existing function (line ~361):
+
+```go
+func gitBundleCreate(projectRoot, bundlePath string, stdout, stderr io.Writer) error {
+	cmd := exec.Command("git", "-C", projectRoot, "bundle", "create", bundlePath, "--all")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+```
+
+- [ ] **Step 7: Add `ensureVolumesReported` helper**
+
+The current `ensureVolumes` writes warnings directly to `os.Stderr`. Add a parallel helper that forwards through the reporter:
+
+```go
+func ensureVolumesReported(cfg *config.Config, warn func(string)) error {
+	for _, vol := range []string{cfg.LogsVolume()} {
+		if err := docker.VolumeCreate(vol); err != nil {
+			warn(err.Error())
+		}
+	}
+	return nil
+}
+```
+
+Leave the original `ensureVolumes` untouched for backward compatibility (or delete it if no other caller — grep confirms: `grep -n 'ensureVolumes' internal/provision/*.go`).
+
+- [ ] **Step 8: Run targeted tests**
+
+```bash
+make sync-embedded
+go test ./internal/provision/... -run "TestReporterInterfaceImplementations|TestPhasesReference"
+go vet ./...
+```
+
+Expected: PASS on both tests; clean vet.
+
+- [ ] **Step 9: Run the full build and all tests**
+
+```bash
+make build
+make test
+```
+
+Expected: binary built, all tests pass. (Existing provision tests should still pass since behavior is equivalent when Reporter is nil.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/provision/
+git commit -m "Add Reporter interface to provision.Run for overlay support"
+```
+
+---
+
+## Task 6: Wire overlay into cspace up
+
+**Files:**
+- Modify: `internal/cli/up.go`
+
+- [ ] **Step 1: Add `--verbose` flag and the shared helper**
+
+Edit `newUpCmd()` in `internal/cli/up.go` to add the verbose flag after the existing flag declarations (around line 39):
+
+```go
+	cmd.Flags().Bool("verbose", false,
+		"Stream raw provisioning output instead of showing the planet overlay. "+
+			"Use when debugging provisioning failures or when piping output.")
+```
+
+And parse it in `runUp` (around line 50):
+
+```go
+	verbose, _ := cmd.Flags().GetBool("verbose")
+```
+
+- [ ] **Step 2: Pass `verbose` through to `runUpWithArgs`**
+
+Change the signature from:
+
+```go
+func runUpWithArgs(name, branch string, noClaude bool, prompt, promptFile, teleportFrom string, persistent bool) error {
+```
+
+to:
+
+```go
+func runUpWithArgs(name, branch string, noClaude, verbose bool, prompt, promptFile, teleportFrom string, persistent bool) error {
+```
+
+Update the call site inside `runUp` (line 104):
+
+```go
+	return runUpWithArgs(name, branch, noClaude, verbose, prompt, promptFile, teleportFrom, persistent)
+```
+
+If the TUI calls `runUpWithArgs` elsewhere (check with `grep -rn 'runUpWithArgs' internal/cli/`), pass `false` for verbose from those sites — the TUI is already interactive so overlay is the default.
+
+- [ ] **Step 3: Replace the provision call with overlay-aware wiring**
+
+Inside `runUpWithArgs`, replace the current `provision.Run(...)` call (lines 118-126) with:
+
+```go
+	if err := provisionWithUI(name, branch, verbose); err != nil {
+		return err
+	}
+```
+
+Add the helper at the bottom of `up.go`:
+
+```go
+// provisionWithUI dispatches to the overlay or the raw log stream based on
+// TTY, --verbose, and terminal size. The overlay path runs provision in a
+// goroutine while a bubbletea Program consumes a buffered event channel;
+// returns the provisioning error (if any) after the overlay exits.
+func provisionWithUI(name, branch string, verbose bool) error {
+	if shouldUseOverlay(verbose) {
+		return provisionWithOverlay(name, branch)
+	}
+	_, err := provision.Run(provision.Params{
+		Name:   name,
+		Branch: branch,
+		Cfg:    cfg,
+	})
+	return err
+}
+
+func shouldUseOverlay(verbose bool) bool {
+	if verbose {
+		return false
+	}
+	if !isInteractive() {
+		return false
+	}
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w < 40 || h < 30 {
+		return false
+	}
+	return true
+}
+
+func provisionWithOverlay(name, branch string) error {
+	events := make(chan overlay.ProvisionEvent, 16)
+	reporter := overlay.NewChannelReporter(events, len(provision.Phases))
+
+	var provErr error
+	go func() {
+		_, provErr = provision.Run(provision.Params{
+			Name:     name,
+			Branch:   branch,
+			Cfg:      cfg,
+			Reporter: reporter,
+			Stdout:   io.Discard,
+			Stderr:   io.Discard,
+		})
+		close(events)
+	}()
+
+	planet := planets.MustGet(name)
+	model := overlay.ModelConfig{
+		Name:   name,
+		Planet: planet,
+		Total:  len(provision.Phases),
+		Events: events,
+	}
+	if err := overlay.Run(context.Background(), model); err != nil {
+		return err
+	}
+	return provErr
+}
+```
+
+- [ ] **Step 4: Add the new imports**
+
+Add to the import block at the top of `internal/cli/up.go`:
+
+```go
+	"context"
+	"io"
+
+	"golang.org/x/term"
+
+	"github.com/elliottregan/cspace/internal/overlay"
+	"github.com/elliottregan/cspace/internal/planets"
+```
+
+- [ ] **Step 5: Build**
+
+```bash
+make build
+```
+
+Expected: binary compiles.
+
+- [ ] **Step 6: Run vet and tests**
+
+```bash
+make vet
+make test
+```
+
+Expected: clean vet; all tests pass.
+
+- [ ] **Step 7: Smoke test the verbose path (no overlay)**
+
+```bash
+./bin/cspace-go up --verbose some-test-name --no-claude
+```
+
+Expected: plain-text progress lines like `[1/14] Validating name...` through `[14/14] Installing plugins...` then `Setup complete.`. Teardown: `cspace down some-test-name`.
+
+- [ ] **Step 8: Smoke test the overlay path**
+
+Ensure the terminal is at least 80×40, then:
+
+```bash
+./bin/cspace-go up --no-claude
+```
+
+Expected: alt-screen takes over, planet art (mercury) appears dim grey and blurry, sharpens as phases advance, instance name shown in mercury color, spinner + phase text + elapsed timer centered. At completion: alt-screen exits, control returns to the terminal, "Instance 'mercury' is ready..." line prints normally. Teardown: `cspace down mercury`.
+
+- [ ] **Step 9: Smoke test the error path**
+
+Simulate a failure by pointing cspace at a broken compose file or interrupting docker mid-run. Alternatively, test with a name that collides:
+
+```bash
+./bin/cspace-go up --no-claude mercury
+# (leave running)
+./bin/cspace-go up --no-claude mercury  # second invocation should fail at orphan-removal
+```
+
+Expected: the second invocation shows the error panel with "Provisioning failed", the failing phase name, `cspace up mercury --verbose` hint, and "Press any key to exit". Press any key → alt-screen exits, non-zero exit code.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/cli/up.go go.mod go.sum
+git commit -m "Wire planet focus-pull overlay into cspace up"
+```
+
+---
+
+## Task 7: Final verification pass
+
+**Files:** none modified.
+
+- [ ] **Step 1: `make check`**
+
+```bash
+make check
+```
+
+Expected: all targets (fmt-check, vet, lint, test) pass. If `make check` is not defined, run each individually:
+
+```bash
+make fmt-check
+make vet
+make test
+make lint
+```
+
+- [ ] **Step 2: Manually verify rendering across every planet**
+
+For each planet, run `cspace up --no-claude NAME` and visually confirm:
+- mercury → silvery-grey disk
+- venus → warm pale-yellow disk
+- earth → blue-green with irregular shading
+- mars → rusty red with hint of polar brightness
+- jupiter → orange with visible horizontal banding
+- saturn → golden tan with ring protrusion on cols 0-1 and 10-11
+- uranus → pale cyan, smaller disk
+- neptune → deep blue, dense core
+
+Tear each down with `cspace down NAME` between runs.
+
+- [ ] **Step 3: Verify non-TTY fallback**
+
+```bash
+./bin/cspace-go up --no-claude some-test | cat
+```
+
+Expected: plain-text log lines (overlay suppressed because stdout isn't a TTY). Teardown: `cspace down some-test`.
+
+- [ ] **Step 4: Verify small-terminal fallback**
+
+Shrink the terminal to ~30 cols × 20 rows, then run `./bin/cspace-go up --no-claude`. Expected: plain-text log lines (overlay suppressed because terminal is too small).
+
+- [ ] **Step 5: Done**
+
+No further commits. The feature is ready. Open a PR with:
+
+```bash
+git log --oneline main..HEAD
+gh pr create --title "Planet focus-pull overlay during provisioning" --body-file - <<'EOF'
+## Summary
+- Replaces raw Docker/compose output with a bubbletea alt-screen overlay during `cspace up`.
+- Animates the instance's planet "coming into focus" across 14 phases.
+- Falls back to verbose output with `--verbose`, non-TTY stdout, or terminals smaller than 40×30.
+
+## Test plan
+- [ ] `make check` passes
+- [ ] Overlay renders cleanly for all eight planet names
+- [ ] `--verbose` streams the original log output
+- [ ] Piped stdout (`cspace up | cat`) uses the log path
+- [ ] Error panel renders and exits non-zero on provisioning failure
+
+Closes #41
+EOF
+```
+
+---
+
+## Self-review notes
+
+Re-reading the issue against this plan:
+
+- ✅ Alt-screen (`tea.WithAltScreen()`): Task 4.
+- ✅ No boot-log persistence: `io.Discard` for `Stdout`/`Stderr` on overlay path; `--verbose` restores.
+- ✅ No progress bar: the view shows spinner + phase text + elapsed, no ratio bar.
+- ✅ Non-TTY auto-fallback: `shouldUseOverlay` checks `isInteractive()`.
+- ✅ Ctrl+C exits alt-screen: bubbletea handles `tea.KeyCtrlC` → `tea.Quit` in Update.
+- ✅ `lib/planets.json` as canonical: Task 1.
+- ✅ Focus-pull axes: color lerp (Task 3 `LerpColor`) + palette densification (`phaseStage` + `palettes`).
+- ✅ Layout: planet art, instance name, spinner+phase, elapsed, centered with `lipgloss.Place`.
+- ✅ Error panel: bordered red box with `cspace up <name> --verbose` hint (Task 4 `errorView`).
+- ✅ Build order matches issue: config (T1) → overlay scaffold (T4) → mercury (T2+T3) → remaining planets (T2 covers all eight in one shot because the shape arrays are small and trivial to author together).
+
+- ⚠️ Statusline.sh refactor deferred (issue noted this is optional: "or keep duplicated for now"). The shell still hardcodes colors; future PR can switch to `jq` over `lib/planets.json` once the file is shipped.
+
+- ⚠️ Tier 5 image-based rendering explicitly out of scope per the issue.
+
+- ⚠️ Half-blocks / braille visual consistency is a known open question; the plan commits to the simple ordering `█ → ▓ → ▒ → ░ → ▌ → ⠂` and can be tuned visually after the first end-to-end run.
+
+No placeholder steps remain. Type and method names are consistent across tasks:
+- `Reporter` interface (provision) / `ChannelReporter` type (overlay) / `logReporter` type (provision).
+- `ProvisionEvent` struct with `EventKind` enum (overlay package).
+- `Shape`, `Get`, `MustGet`, `GetShape` in planets package.
+- `LerpColor`, `ShadeToChar`, `RenderPlanet` exported from overlay package.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/elliottregan/cspace
 go 1.25.8
 
 require (
+	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
+	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/modelcontextprotocol/go-sdk v1.5.0
@@ -14,8 +16,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
-	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/net v0.53.0
 )
 
 require (
@@ -39,7 +40,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/net v0.53.0
+	golang.org/x/term v0.42.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -97,11 +97,8 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
-golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
-golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
-golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
+golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
+golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -155,7 +155,7 @@ func tuiNew() error {
 		fmt.Printf("Instance name: %s\n", name)
 	}
 
-	return runUpWithArgs(name, "", false, "", "", "", false)
+	return runUpWithArgs(name, "", false, false, "", "", "", false)
 }
 
 // tuiConnect shows a sub-menu for connecting to a running instance.
@@ -186,7 +186,7 @@ func tuiConnect(details []instance.Detail) error {
 	composeName := cfg.ComposeName(name)
 	switch action {
 	case tuiActionConnect:
-		return runUpWithArgs(name, "", false, "", "", "", false)
+		return runUpWithArgs(name, "", false, false, "", "", "", false)
 	case tuiActionSSH:
 		return instance.DcExecInteractive(composeName, "bash")
 	case tuiActionPorts:

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -210,7 +210,7 @@ func shouldUseOverlay(verbose bool) bool {
 		return false
 	}
 	w, h, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil || w < 40 || h < 30 {
+	if err != nil || w < 64 || h < 36 {
 		return false
 	}
 	return true

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -238,7 +238,7 @@ func provisionWithOverlay(name, branch string) error {
 	defer func() {
 		os.Stdout = origStdout
 		os.Stderr = origStderr
-		devNull.Close()
+		_ = devNull.Close()
 	}()
 
 	done := make(chan error, 1)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -220,6 +220,27 @@ func provisionWithOverlay(name, branch string) error {
 	events := make(chan overlay.ProvisionEvent, 16)
 	reporter := overlay.NewChannelReporter(events)
 
+	// provision.Run delegates to subprocesses (docker compose, git,
+	// docker exec) and helpers (configureGit, runPostSetup) that write
+	// directly to os.Stdout/os.Stderr, bypassing Params.Stdout/Stderr.
+	// Redirect the process's stdout/stderr to /dev/null for the lifetime
+	// of the overlay so none of that leaks into the alt-screen. We hand
+	// the original stdout to bubbletea explicitly so the overlay still
+	// renders on the real terminal.
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("opening /dev/null: %w", err)
+	}
+	os.Stdout = devNull
+	os.Stderr = devNull
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		devNull.Close()
+	}()
+
 	done := make(chan error, 1)
 	go func() {
 		_, err := provision.Run(provision.Params{
@@ -241,7 +262,7 @@ func provisionWithOverlay(name, branch string) error {
 		Total:  len(provision.Phases),
 		Events: events,
 	}
-	if err := overlay.Run(model); err != nil {
+	if err := overlay.RunOn(model, origStdout); err != nil {
 		// Drain the channel so the provision goroutine doesn't block on
 		// its buffered reporter sends when the overlay couldn't render.
 		go func() {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -210,7 +210,7 @@ func shouldUseOverlay(verbose bool) bool {
 		return false
 	}
 	w, h, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil || w < 64 || h < 36 {
+	if err != nil || w < 96 || h < 32 {
 		return false
 	}
 	return true

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -206,6 +206,9 @@ func shouldUseOverlay(verbose bool) bool {
 	if !isInteractive() {
 		return false
 	}
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return false
+	}
 	w, h, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil || w < 40 || h < 30 {
 		return false
@@ -217,9 +220,9 @@ func provisionWithOverlay(name, branch string) error {
 	events := make(chan overlay.ProvisionEvent, 16)
 	reporter := overlay.NewChannelReporter(events)
 
-	var provErr error
+	done := make(chan error, 1)
 	go func() {
-		_, provErr = provision.Run(provision.Params{
+		_, err := provision.Run(provision.Params{
 			Name:     name,
 			Branch:   branch,
 			Cfg:      cfg,
@@ -228,6 +231,7 @@ func provisionWithOverlay(name, branch string) error {
 			Stderr:   io.Discard,
 		})
 		close(events)
+		done <- err
 	}()
 
 	planet := planets.MustGet(name)
@@ -238,7 +242,13 @@ func provisionWithOverlay(name, branch string) error {
 		Events: events,
 	}
 	if err := overlay.Run(model); err != nil {
+		// Drain the channel so the provision goroutine doesn't block on
+		// its buffered reporter sends when the overlay couldn't render.
+		go func() {
+			for range events {
+			}
+		}()
 		return err
 	}
-	return provErr
+	return <-done
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -2,14 +2,18 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
 	"github.com/elliottregan/cspace/internal/instance"
+	"github.com/elliottregan/cspace/internal/overlay"
+	"github.com/elliottregan/cspace/internal/planets"
 	"github.com/elliottregan/cspace/internal/ports"
 	"github.com/elliottregan/cspace/internal/provision"
 	"github.com/elliottregan/cspace/internal/supervisor"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 func newUpCmd() *cobra.Command {
@@ -29,6 +33,9 @@ Use --no-claude to provision the container without launching Claude.`,
 	}
 
 	cmd.Flags().Bool("no-claude", false, "Create instance without launching Claude")
+	cmd.Flags().Bool("verbose", false,
+		"Stream raw provisioning output instead of showing the planet overlay. "+
+			"Use when debugging provisioning failures or when piping output.")
 	cmd.Flags().String("prompt", "", "Inline prompt text for autonomous agent")
 	cmd.Flags().String("prompt-file", "", "Path to a prompt file for autonomous agent")
 	cmd.Flags().Bool("persistent", false,
@@ -43,6 +50,7 @@ Use --no-claude to provision the container without launching Claude.`,
 
 func runUp(cmd *cobra.Command, args []string) error {
 	noClaude, _ := cmd.Flags().GetBool("no-claude")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 	prompt, _ := cmd.Flags().GetString("prompt")
 	promptFile, _ := cmd.Flags().GetString("prompt-file")
 	persistent, _ := cmd.Flags().GetBool("persistent")
@@ -101,12 +109,12 @@ func runUp(cmd *cobra.Command, args []string) error {
 		branch = baseOverride
 	}
 
-	return runUpWithArgs(name, branch, noClaude, prompt, promptFile, teleportFrom, persistent)
+	return runUpWithArgs(name, branch, noClaude, verbose, prompt, promptFile, teleportFrom, persistent)
 }
 
 // runUpWithArgs is the shared implementation for the up command, callable from
 // both the CLI handler and the TUI menu.
-func runUpWithArgs(name, branch string, noClaude bool, prompt, promptFile, teleportFrom string, persistent bool) error {
+func runUpWithArgs(name, branch string, noClaude, verbose bool, prompt, promptFile, teleportFrom string, persistent bool) error {
 	if teleportFrom != "" {
 		return provision.TeleportRun(provision.TeleportParams{
 			Name:         name,
@@ -115,13 +123,7 @@ func runUpWithArgs(name, branch string, noClaude bool, prompt, promptFile, telep
 		})
 	}
 
-	// Provision the instance
-	_, err := provision.Run(provision.Params{
-		Name:   name,
-		Branch: branch,
-		Cfg:    cfg,
-	})
-	if err != nil {
+	if err := provisionWithUI(name, branch, verbose); err != nil {
 		return err
 	}
 
@@ -179,4 +181,64 @@ func runUpWithArgs(name, branch string, noClaude bool, prompt, promptFile, telep
 		StderrLog:  supervisor.ContainerAgentStderrLog,
 		Persistent: persistent,
 	}, cfg)
+}
+
+// provisionWithUI dispatches to the overlay or the raw log stream based on
+// TTY, --verbose, and terminal size. The overlay path runs provision in a
+// goroutine while a bubbletea Program consumes a buffered event channel;
+// returns the provisioning error (if any) after the overlay exits.
+func provisionWithUI(name, branch string, verbose bool) error {
+	if shouldUseOverlay(verbose) {
+		return provisionWithOverlay(name, branch)
+	}
+	_, err := provision.Run(provision.Params{
+		Name:   name,
+		Branch: branch,
+		Cfg:    cfg,
+	})
+	return err
+}
+
+func shouldUseOverlay(verbose bool) bool {
+	if verbose {
+		return false
+	}
+	if !isInteractive() {
+		return false
+	}
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w < 40 || h < 30 {
+		return false
+	}
+	return true
+}
+
+func provisionWithOverlay(name, branch string) error {
+	events := make(chan overlay.ProvisionEvent, 16)
+	reporter := overlay.NewChannelReporter(events)
+
+	var provErr error
+	go func() {
+		_, provErr = provision.Run(provision.Params{
+			Name:     name,
+			Branch:   branch,
+			Cfg:      cfg,
+			Reporter: reporter,
+			Stdout:   io.Discard,
+			Stderr:   io.Discard,
+		})
+		close(events)
+	}()
+
+	planet := planets.MustGet(name)
+	model := overlay.ModelConfig{
+		Name:   name,
+		Planet: planet,
+		Total:  len(provision.Phases),
+		Events: events,
+	}
+	if err := overlay.Run(model); err != nil {
+		return err
+	}
+	return provErr
 }

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -202,7 +202,6 @@ func TestComposeEnvNoFirewallDomains(t *testing.T) {
 	}
 }
 
-
 func TestWriteServiceURLsOverrideNoopWhenEmpty(t *testing.T) {
 	cfg := &config.Config{Project: config.ProjectConfig{Name: "p", Prefix: "p"}}
 

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -1,7 +1,6 @@
 package overlay
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -40,17 +39,16 @@ type ProvisionEvent struct {
 
 // ChannelReporter implements provision.Reporter by pushing events into a
 // buffered channel. It tracks the most-recent phase name so Error() can
-// report which phase failed.
+// report which phase failed. Not safe for concurrent use — callers must
+// serialize reporter calls.
 type ChannelReporter struct {
 	events    chan<- ProvisionEvent
 	lastPhase string
-	totalHint int
 }
 
-// NewChannelReporter builds a reporter that writes into events. The total
-// hint is the total number of expected phases; callers pass 14 today.
-func NewChannelReporter(events chan<- ProvisionEvent, total int) *ChannelReporter {
-	return &ChannelReporter{events: events, totalHint: total}
+// NewChannelReporter builds a reporter that writes into events.
+func NewChannelReporter(events chan<- ProvisionEvent) *ChannelReporter {
+	return &ChannelReporter{events: events}
 }
 
 // Phase records the current phase name and dispatches a PhaseEvent.
@@ -110,9 +108,7 @@ type Model struct {
 
 // NewModel constructs a Model with sensible defaults. Events must be a
 // channel the caller feeds from provision.Run goroutines. start is seeded
-// to the Unix epoch so tests that bypass Init and render immediately see
-// elapsed computed against cfg.Now()'s absolute value. Init() overwrites
-// start with cfg.Now() so the production timer counts up from zero.
+// from cfg.Now() so the elapsed timer counts up from model construction.
 func NewModel(cfg ModelConfig) Model {
 	if cfg.Now == nil {
 		cfg.Now = time.Now
@@ -124,7 +120,7 @@ func NewModel(cfg ModelConfig) Model {
 	sp.Spinner = spinner.Dot
 	return Model{
 		cfg:     cfg,
-		start:   time.Unix(0, 0),
+		start:   cfg.Now(),
 		spinner: sp,
 	}
 }
@@ -132,17 +128,8 @@ func NewModel(cfg ModelConfig) Model {
 // tickMsg fires once per second to keep the elapsed timer fresh.
 type tickMsg time.Time
 
-// startMsg carries the real start time captured at Init to replace the
-// Unix-epoch seed set by NewModel.
-type startMsg time.Time
-
 func tickCmd() tea.Cmd {
 	return tea.Tick(time.Second, func(t time.Time) tea.Msg { return tickMsg(t) })
-}
-
-// startCmd returns a command that emits a startMsg with cfg.Now().
-func startCmd(now func() time.Time) tea.Cmd {
-	return func() tea.Msg { return startMsg(now()) }
 }
 
 // waitForEvent returns a command that blocks on the events channel and
@@ -163,7 +150,6 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		m.spinner.Tick,
 		tickCmd(),
-		startCmd(m.cfg.Now),
 		waitForEvent(m.cfg.Events),
 	)
 }
@@ -194,10 +180,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tickCmd()
 
-	case startMsg:
-		m.start = time.Time(msg)
-		return m, nil
-
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
@@ -221,7 +203,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case ErrorEvent:
 			m.err = msg.Err
 			m.errPhase = msg.Phase
-			// Stay on screen until keypress.
+			// Stop draining events; stay on screen until keypress.
+			// Further events pushed into the channel are dropped.
 			return m, nil
 		}
 	}
@@ -296,12 +279,9 @@ func (m Model) errorView() string {
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, panel)
 }
 
-// Run starts the bubbletea program in alt-screen mode and returns when the
-// user dismisses the error panel or the provisioning completes. The ctx is
-// currently advisory — bubbletea exits on its own signals — but is reserved
-// for future graceful-cancel support.
-func Run(ctx context.Context, cfg ModelConfig) error {
-	_ = ctx
+// Run starts the bubbletea program in alt-screen mode and blocks until
+// the user dismisses the error panel or provisioning completes.
+func Run(cfg ModelConfig) error {
 	p := tea.NewProgram(NewModel(cfg), tea.WithAltScreen())
 	_, err := p.Run()
 	return err

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -248,6 +248,13 @@ var sciFiLabels = map[string]string{
 }
 
 func sciFiLabelFor(phase string) string {
+	return SciFiLabelFor(phase)
+}
+
+// SciFiLabelFor returns the stylized status word the overlay shows for a
+// provisioning phase (e.g. "Configuring hosts" → "CROSSLINK"). Exported
+// so the preview tool in cmd/overlay-web can label frames consistently.
+func SciFiLabelFor(phase string) string {
 	if s, ok := sciFiLabels[phase]; ok {
 		return s
 	}

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -1,0 +1,308 @@
+package overlay
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/elliottregan/cspace/internal/planets"
+)
+
+// EventKind distinguishes provisioning events received by the overlay.
+type EventKind int
+
+const (
+	// PhaseEvent announces that provisioning has entered a new phase.
+	PhaseEvent EventKind = iota
+	// WarnEvent carries a provisioning warning (non-fatal).
+	WarnEvent
+	// DoneEvent signals successful completion.
+	DoneEvent
+	// ErrorEvent signals a fatal provisioning failure.
+	ErrorEvent
+)
+
+// ProvisionEvent is the message sent from provision.Run to the overlay over
+// a buffered channel. One goroutine writes; bubbletea reads.
+type ProvisionEvent struct {
+	Kind    EventKind
+	Phase   string
+	Num     int
+	Total   int
+	Message string
+	Err     error
+}
+
+// ChannelReporter implements provision.Reporter by pushing events into a
+// buffered channel. It tracks the most-recent phase name so Error() can
+// report which phase failed.
+type ChannelReporter struct {
+	events    chan<- ProvisionEvent
+	lastPhase string
+	totalHint int
+}
+
+// NewChannelReporter builds a reporter that writes into events. The total
+// hint is the total number of expected phases; callers pass 14 today.
+func NewChannelReporter(events chan<- ProvisionEvent, total int) *ChannelReporter {
+	return &ChannelReporter{events: events, totalHint: total}
+}
+
+// Phase records the current phase name and dispatches a PhaseEvent.
+func (r *ChannelReporter) Phase(name string, num, total int) {
+	r.lastPhase = name
+	r.events <- ProvisionEvent{
+		Kind:  PhaseEvent,
+		Phase: name,
+		Num:   num,
+		Total: total,
+	}
+}
+
+// Warn dispatches a WarnEvent. The overlay currently ignores warnings, but
+// they're captured so a future version could render a warning stack.
+func (r *ChannelReporter) Warn(msg string) {
+	r.events <- ProvisionEvent{Kind: WarnEvent, Message: msg}
+}
+
+// Done dispatches a DoneEvent. Caller should not send further events.
+func (r *ChannelReporter) Done() {
+	r.events <- ProvisionEvent{Kind: DoneEvent}
+}
+
+// Error dispatches an ErrorEvent using the most recently reported phase
+// when phase is empty (e.g. when called from a deferred error handler).
+func (r *ChannelReporter) Error(phase string, err error) {
+	if phase == "" {
+		phase = r.lastPhase
+	}
+	r.events <- ProvisionEvent{Kind: ErrorEvent, Phase: phase, Err: err}
+}
+
+// ModelConfig bundles the constructor arguments for NewModel so callers
+// (and tests) do not need to remember field order.
+type ModelConfig struct {
+	Name   string
+	Planet planets.Planet
+	Total  int
+	Events <-chan ProvisionEvent
+	Now    func() time.Time // injectable for tests
+}
+
+// Model is the bubbletea model driving the provisioning overlay.
+type Model struct {
+	cfg      ModelConfig
+	phase    string
+	phaseNum int
+	start    time.Time
+	err      error
+	errPhase string
+	done     bool
+	spinner  spinner.Model
+	width    int
+	height   int
+}
+
+// NewModel constructs a Model with sensible defaults. Events must be a
+// channel the caller feeds from provision.Run goroutines. start is seeded
+// to the Unix epoch so tests that bypass Init and render immediately see
+// elapsed computed against cfg.Now()'s absolute value. Init() overwrites
+// start with cfg.Now() so the production timer counts up from zero.
+func NewModel(cfg ModelConfig) Model {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Total <= 0 {
+		cfg.Total = 14
+	}
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	return Model{
+		cfg:     cfg,
+		start:   time.Unix(0, 0),
+		spinner: sp,
+	}
+}
+
+// tickMsg fires once per second to keep the elapsed timer fresh.
+type tickMsg time.Time
+
+// startMsg carries the real start time captured at Init to replace the
+// Unix-epoch seed set by NewModel.
+type startMsg time.Time
+
+func tickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+// startCmd returns a command that emits a startMsg with cfg.Now().
+func startCmd(now func() time.Time) tea.Cmd {
+	return func() tea.Msg { return startMsg(now()) }
+}
+
+// waitForEvent returns a command that blocks on the events channel and
+// converts the next event into a tea.Msg so bubbletea can dispatch it.
+func waitForEvent(events <-chan ProvisionEvent) tea.Cmd {
+	return func() tea.Msg {
+		ev, ok := <-events
+		if !ok {
+			// Channel closed without a Done event — treat as done.
+			return ProvisionEvent{Kind: DoneEvent}
+		}
+		return ev
+	}
+}
+
+// Init is part of the tea.Model interface.
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(
+		m.spinner.Tick,
+		tickCmd(),
+		startCmd(m.cfg.Now),
+		waitForEvent(m.cfg.Events),
+	)
+}
+
+// Update is part of the tea.Model interface.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.err != nil {
+			// Any key dismisses the error panel.
+			m.done = true
+			return m, tea.Quit
+		}
+		if msg.Type == tea.KeyCtrlC {
+			m.done = true
+			return m, tea.Quit
+		}
+		return m, nil
+
+	case tickMsg:
+		if m.done {
+			return m, nil
+		}
+		return m, tickCmd()
+
+	case startMsg:
+		m.start = time.Time(msg)
+		return m, nil
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case ProvisionEvent:
+		switch msg.Kind {
+		case PhaseEvent:
+			m.phase = msg.Phase
+			m.phaseNum = msg.Num
+			if msg.Total > 0 {
+				m.cfg.Total = msg.Total
+			}
+			return m, waitForEvent(m.cfg.Events)
+		case WarnEvent:
+			// Drop silently for now.
+			return m, waitForEvent(m.cfg.Events)
+		case DoneEvent:
+			m.done = true
+			return m, tea.Quit
+		case ErrorEvent:
+			m.err = msg.Err
+			m.errPhase = msg.Phase
+			// Stay on screen until keypress.
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+// View is part of the tea.Model interface.
+func (m Model) View() string {
+	if m.done && m.err == nil {
+		return ""
+	}
+	if m.err != nil {
+		return m.errorView()
+	}
+	return m.loadingView()
+}
+
+var nameStyle = lipgloss.NewStyle().Bold(true)
+
+func (m Model) loadingView() string {
+	shape := planets.GetShape(m.cfg.Name)
+	art := RenderPlanet(shape, m.cfg.Planet, m.phaseNum, m.cfg.Total)
+
+	elapsed := m.cfg.Now().Sub(m.start)
+	mm := int(elapsed.Minutes())
+	ss := int(elapsed.Seconds()) % 60
+	timer := fmt.Sprintf("%02d:%02d", mm, ss)
+
+	planetColor := lipgloss.Color(fmt.Sprintf("#%02x%02x%02x",
+		m.cfg.Planet.Color[0], m.cfg.Planet.Color[1], m.cfg.Planet.Color[2]))
+	nameLine := nameStyle.Foreground(planetColor).Render(m.cfg.Name)
+
+	phaseLine := fmt.Sprintf("%s  %s", m.spinner.View(), m.phase)
+
+	content := strings.Join([]string{
+		art,
+		"",
+		nameLine,
+		"",
+		phaseLine,
+		"",
+		timer,
+	}, "\n")
+
+	if m.width == 0 || m.height == 0 {
+		// No WindowSizeMsg yet; return un-centered.
+		return content
+	}
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+}
+
+var errorPanelStyle = lipgloss.NewStyle().
+	Border(lipgloss.RoundedBorder()).
+	BorderForeground(lipgloss.Color("9")).
+	Padding(1, 2)
+
+func (m Model) errorView() string {
+	lines := []string{
+		"✗  Provisioning failed",
+		"",
+		fmt.Sprintf("Phase: %s", m.errPhase),
+		"",
+		"For the full log, run:",
+		fmt.Sprintf("  cspace up %s --verbose", m.cfg.Name),
+		"",
+		"Press any key to exit",
+	}
+	panel := errorPanelStyle.Render(strings.Join(lines, "\n"))
+	if m.width == 0 || m.height == 0 {
+		return panel
+	}
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, panel)
+}
+
+// Run starts the bubbletea program in alt-screen mode and returns when the
+// user dismisses the error panel or the provisioning completes. The ctx is
+// currently advisory — bubbletea exits on its own signals — but is reserved
+// for future graceful-cancel support.
+func Run(ctx context.Context, cfg ModelConfig) error {
+	_ = ctx
+	p := tea.NewProgram(NewModel(cfg), tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -265,13 +265,16 @@ func (m Model) errorView() string {
 	lines := []string{
 		"✗  Provisioning failed",
 		"",
-		fmt.Sprintf("Phase: %s", m.errPhase),
-		"",
+	}
+	if m.errPhase != "" {
+		lines = append(lines, fmt.Sprintf("Phase: %s", m.errPhase), "")
+	}
+	lines = append(lines,
 		"For the full log, run:",
 		fmt.Sprintf("  cspace up %s --verbose", m.cfg.Name),
 		"",
 		"Press any key to exit",
-	}
+	)
 	panel := errorPanelStyle.Render(strings.Join(lines, "\n"))
 	if m.width == 0 || m.height == 0 {
 		return panel

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -413,7 +413,9 @@ func (m Model) hudLines() []string {
 
 func (m Model) loadingView() string {
 	shape := planets.GetShape(m.cfg.Name)
-	art := RenderPlanet(shape, m.cfg.Planet, m.phaseNum, m.cfg.Total)
+	opts := DefaultRenderOptions()
+	opts.Overlays = planets.GetOverlays(m.cfg.Name)
+	art := RenderPlanetWith(shape, m.cfg.Planet, m.phaseNum, m.cfg.Total, opts)
 
 	artHeight := planets.ShapeRows / 2
 	hud := m.hudLines()

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -2,6 +2,8 @@ package overlay
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -474,7 +476,15 @@ func (m Model) errorView() string {
 // Run starts the bubbletea program in alt-screen mode and blocks until
 // the user dismisses the error panel or provisioning completes.
 func Run(cfg ModelConfig) error {
-	p := tea.NewProgram(NewModel(cfg), tea.WithAltScreen())
+	return RunOn(cfg, os.Stdout)
+}
+
+// RunOn is Run with an explicit output writer. Callers that need to
+// redirect the process's os.Stdout (e.g. to silence leaking subprocess
+// output) pass the original os.Stdout here so bubbletea keeps writing
+// to the real terminal.
+func RunOn(cfg ModelConfig, out io.Writer) error {
+	p := tea.NewProgram(NewModel(cfg), tea.WithAltScreen(), tea.WithOutput(out))
 	_, err := p.Run()
 	return err
 }

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -117,7 +117,11 @@ func NewModel(cfg ModelConfig) Model {
 		cfg.Total = 14
 	}
 	sp := spinner.New()
-	sp.Spinner = spinner.Dot
+	sp.Spinner = spinner.Spinner{
+		Frames: []string{"◐", "◓", "◑", "◒"},
+		FPS:    time.Second / 4,
+	}
+	sp.Style = hudAccentStyle
 	return Model{
 		cfg:     cfg,
 		start:   cfg.Now(),
@@ -222,58 +226,170 @@ func (m Model) View() string {
 	return m.loadingView()
 }
 
-var nameStyle = lipgloss.NewStyle().Bold(true)
+// sciFiLabels styles each provisioning phase as a terse 2001-style status
+// word. Falls back to the raw phase name when unknown (e.g. custom labels
+// like "Reusing running container" that are also present in the map).
+var sciFiLabels = map[string]string{
+	"Validating name":           "DESIGNATE",
+	"Reusing running container": "RESUME SEQUENCE",
+	"Removing orphans":          "CLEARING VECTOR",
+	"Bundling repo":             "PACKAGE PAYLOAD",
+	"Creating volumes":          "FORMAT BANKS",
+	"Creating network":          "LINK SUBSTRATE",
+	"Starting reverse proxy":    "ENGAGE UPLINK",
+	"Setting up directories":    "ALIGN BULKHEAD",
+	"Starting containers":       "IGNITION",
+	"Waiting for container":     "HANDSHAKE",
+	"Configuring hosts":         "CROSSLINK",
+	"Setting permissions":       "ACCESS CALIBRATE",
+	"Initializing workspace":    "BOOT SEQUENCE",
+	"Configuring git & env":     "CODE UPLINK",
+	"Installing plugins":        "LOAD MODULES",
+}
+
+func sciFiLabelFor(phase string) string {
+	if s, ok := sciFiLabels[phase]; ok {
+		return s
+	}
+	return strings.ToUpper(phase)
+}
+
+// Cold monochrome HUD palette. Planet art carries per-planet color; every
+// other chrome element uses these greys so the interface feels like a
+// single cold instrument panel.
+var (
+	viewportBgColor = lipgloss.Color("#000000")
+	hudAccent       = lipgloss.Color("#d4d4d4") // bright silver — borders, focus words
+	hudBase         = lipgloss.Color("#9a9a9a") // mid silver — regular text
+	hudDim          = lipgloss.Color("#606060") // dim silver — subtext, empty bar cells
+	errorAccent     = lipgloss.Color("#e05555") // warm red — fault chrome only
+)
+
+var (
+	panelStyle = lipgloss.NewStyle().
+			Border(lipgloss.DoubleBorder()).
+			BorderForeground(hudAccent).
+			BorderBackground(viewportBgColor).
+			Background(viewportBgColor).
+			Padding(1, 4)
+
+	panelInnerStyle = lipgloss.NewStyle().
+			Background(viewportBgColor)
+
+	hudBaseStyle = lipgloss.NewStyle().
+			Foreground(hudBase).
+			Background(viewportBgColor)
+
+	hudAccentStyle = lipgloss.NewStyle().
+			Foreground(hudAccent).
+			Background(viewportBgColor).
+			Bold(true)
+
+	hudDimStyle = lipgloss.NewStyle().
+			Foreground(hudDim).
+			Background(viewportBgColor)
+
+	nameStyle = lipgloss.NewStyle().
+			Bold(true).
+			Background(viewportBgColor)
+
+	errorPanelStyle = lipgloss.NewStyle().
+			Border(lipgloss.DoubleBorder()).
+			BorderForeground(errorAccent).
+			BorderBackground(viewportBgColor).
+			Background(viewportBgColor).
+			Padding(1, 4)
+)
+
+// progressBarWidth is the character count of the filled+empty segments
+// (brackets excluded). 24 fits comfortably under a 48-col planet.
+const progressBarWidth = 24
+
+// renderProgressBar draws a solid-filled bar: [██████████░░░░░░░░░░░░░░]
+// with bright silver for filled cells and dim silver for empty ones, plus
+// a trailing percentage. Progress is clamped to [0, 1].
+func renderProgressBar(progress float64) string {
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 1 {
+		progress = 1
+	}
+	filled := int(progress * float64(progressBarWidth))
+	if filled > progressBarWidth {
+		filled = progressBarWidth
+	}
+	empty := progressBarWidth - filled
+
+	filledStr := hudAccentStyle.Render(strings.Repeat("█", filled))
+	emptyStr := hudDimStyle.Render(strings.Repeat("░", empty))
+	bracket := hudBaseStyle.Render
+	pct := hudAccentStyle.Render(fmt.Sprintf(" %05.1f%%", progress*100))
+
+	return bracket("[") + filledStr + emptyStr + bracket("]") + pct
+}
 
 func (m Model) loadingView() string {
 	shape := planets.GetShape(m.cfg.Name)
 	art := RenderPlanet(shape, m.cfg.Planet, m.phaseNum, m.cfg.Total)
 
+	planetColor := lipgloss.Color(fmt.Sprintf("#%02x%02x%02x",
+		m.cfg.Planet.Color[0], m.cfg.Planet.Color[1], m.cfg.Planet.Color[2]))
+	nameLine := nameStyle.Foreground(planetColor).
+		Render(strings.ToUpper(m.cfg.Name))
+
+	progress := 0.0
+	if m.cfg.Total > 0 {
+		progress = float64(m.phaseNum) / float64(m.cfg.Total)
+	}
+	progressLine := renderProgressBar(progress)
+
+	sciFi := sciFiLabelFor(m.phase)
+	statusTop := hudAccentStyle.Render(m.spinner.View()+"  ") + hudAccentStyle.Render(sciFi)
+	statusBot := hudDimStyle.Render("    " + m.phase)
+
 	elapsed := m.cfg.Now().Sub(m.start)
 	mm := int(elapsed.Minutes())
 	ss := int(elapsed.Seconds()) % 60
-	timer := fmt.Sprintf("%02d:%02d", mm, ss)
+	stats := hudBaseStyle.Render(fmt.Sprintf("PH %02d/%02d    T+ %02d:%02d",
+		m.phaseNum, m.cfg.Total, mm, ss))
 
-	planetColor := lipgloss.Color(fmt.Sprintf("#%02x%02x%02x",
-		m.cfg.Planet.Color[0], m.cfg.Planet.Color[1], m.cfg.Planet.Color[2]))
-	nameLine := nameStyle.Foreground(planetColor).Render(m.cfg.Name)
-
-	phaseLine := fmt.Sprintf("%s  %s", m.spinner.View(), m.phase)
-
-	content := strings.Join([]string{
+	inner := lipgloss.JoinVertical(lipgloss.Center,
 		art,
-		"",
+		panelInnerStyle.Render(""),
 		nameLine,
-		"",
-		phaseLine,
-		"",
-		timer,
-	}, "\n")
+		panelInnerStyle.Render(""),
+		progressLine,
+		panelInnerStyle.Render(""),
+		statusTop,
+		statusBot,
+		panelInnerStyle.Render(""),
+		stats,
+	)
 
+	panel := panelStyle.Render(inner)
 	if m.width == 0 || m.height == 0 {
-		// No WindowSizeMsg yet; return un-centered.
-		return content
+		return panel
 	}
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, panel)
 }
-
-var errorPanelStyle = lipgloss.NewStyle().
-	Border(lipgloss.RoundedBorder()).
-	BorderForeground(lipgloss.Color("9")).
-	Padding(1, 2)
 
 func (m Model) errorView() string {
 	lines := []string{
-		"✗  Provisioning failed",
-		"",
+		hudAccentStyle.Render("✕  MISSION ABORT"),
+		panelInnerStyle.Render(""),
 	}
 	if m.errPhase != "" {
-		lines = append(lines, fmt.Sprintf("Phase: %s", m.errPhase), "")
+		lines = append(lines,
+			hudBaseStyle.Render("FAULT IN PHASE: "+strings.ToUpper(sciFiLabelFor(m.errPhase))),
+			hudDimStyle.Render(m.errPhase),
+			panelInnerStyle.Render(""),
+		)
 	}
 	lines = append(lines,
-		"For the full log, run:",
-		fmt.Sprintf("  cspace up %s --verbose", m.cfg.Name),
-		"",
-		"Press any key to exit",
+		hudBaseStyle.Render("»  cspace up "+m.cfg.Name+" --verbose"),
+		panelInnerStyle.Render(""),
+		hudDimStyle.Render("[ANY KEY] TO DISENGAGE"),
 	)
 	panel := errorPanelStyle.Render(strings.Join(lines, "\n"))
 	if m.width == 0 || m.height == 0 {

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -265,16 +265,38 @@ var (
 	errorAccent     = lipgloss.Color("#e05555") // warm red — fault chrome only
 )
 
+// Panel geometry. Planet art is ShapeCols wide × ShapeRows/2 rows tall.
+// HUD column sits to its right. Panel width = planet + gap + hud + padding
+// + border; the outer frame renders in a 4:3-ish landscape proportion.
+const (
+	hudColWidth    = 32
+	gapWidth       = 4
+	panelPaddingX  = 3
+	panelPaddingY  = 1
+	labelColWidth  = 10 // left column in the stat grid
+	valueColWidth  = hudColWidth - labelColWidth
+	progressBarLen = hudColWidth - 12 // leave room for percentage
+)
+
 var (
 	panelStyle = lipgloss.NewStyle().
 			Border(lipgloss.DoubleBorder()).
 			BorderForeground(hudAccent).
 			BorderBackground(viewportBgColor).
 			Background(viewportBgColor).
-			Padding(1, 4)
+			Padding(panelPaddingY, panelPaddingX)
 
-	panelInnerStyle = lipgloss.NewStyle().
-			Background(viewportBgColor)
+	// panelFill paints the viewport black across the exact cell width so
+	// there's no transparent gutter between styled text and panel border.
+	panelFill = lipgloss.NewStyle().Background(viewportBgColor)
+
+	hudColStyle = lipgloss.NewStyle().
+			Background(viewportBgColor).
+			Width(hudColWidth)
+
+	gapStyle = lipgloss.NewStyle().
+			Background(viewportBgColor).
+			Width(gapWidth)
 
 	hudBaseStyle = lipgloss.NewStyle().
 			Foreground(hudBase).
@@ -289,25 +311,33 @@ var (
 			Foreground(hudDim).
 			Background(viewportBgColor)
 
-	nameStyle = lipgloss.NewStyle().
+	labelStyle = lipgloss.NewStyle().
+			Foreground(hudDim).
+			Background(viewportBgColor).
+			Width(labelColWidth)
+
+	valueStyle = lipgloss.NewStyle().
+			Foreground(hudAccent).
+			Background(viewportBgColor).
 			Bold(true).
-			Background(viewportBgColor)
+			Width(valueColWidth)
+
+	nameValueStyle = lipgloss.NewStyle().
+			Background(viewportBgColor).
+			Bold(true).
+			Width(valueColWidth)
 
 	errorPanelStyle = lipgloss.NewStyle().
 			Border(lipgloss.DoubleBorder()).
 			BorderForeground(errorAccent).
 			BorderBackground(viewportBgColor).
 			Background(viewportBgColor).
-			Padding(1, 4)
+			Padding(panelPaddingY, panelPaddingX).
+			Width(hudColWidth + gapWidth + planets.ShapeCols)
 )
 
-// progressBarWidth is the character count of the filled+empty segments
-// (brackets excluded). 24 fits comfortably under a 48-col planet.
-const progressBarWidth = 24
-
-// renderProgressBar draws a solid-filled bar: [██████████░░░░░░░░░░░░░░]
-// with bright silver for filled cells and dim silver for empty ones, plus
-// a trailing percentage. Progress is clamped to [0, 1].
+// renderProgressBar draws a solid-filled bar: [██████████░░░░░░░░]  050.0%
+// with bright silver filled cells and dim silver empty cells.
 func renderProgressBar(progress float64) string {
 	if progress < 0 {
 		progress = 0
@@ -315,87 +345,121 @@ func renderProgressBar(progress float64) string {
 	if progress > 1 {
 		progress = 1
 	}
-	filled := int(progress * float64(progressBarWidth))
-	if filled > progressBarWidth {
-		filled = progressBarWidth
+	filled := int(progress * float64(progressBarLen))
+	if filled > progressBarLen {
+		filled = progressBarLen
 	}
-	empty := progressBarWidth - filled
+	empty := progressBarLen - filled
 
-	filledStr := hudAccentStyle.Render(strings.Repeat("█", filled))
-	emptyStr := hudDimStyle.Render(strings.Repeat("░", empty))
-	bracket := hudBaseStyle.Render
-	pct := hudAccentStyle.Render(fmt.Sprintf(" %05.1f%%", progress*100))
+	return hudBaseStyle.Render("[") +
+		hudAccentStyle.Render(strings.Repeat("█", filled)) +
+		hudDimStyle.Render(strings.Repeat("░", empty)) +
+		hudBaseStyle.Render("]") +
+		hudBaseStyle.Render(" ") +
+		hudAccentStyle.Render(fmt.Sprintf("%05.1f%%", progress*100))
+}
 
-	return bracket("[") + filledStr + emptyStr + bracket("]") + pct
+// renderStatRow produces one `LABEL    value` line sized to the HUD column.
+func renderStatRow(label, value string, accent lipgloss.Style) string {
+	labelPart := labelStyle.Render(label)
+	valuePart := accent.Render(value)
+	return hudColStyle.Render(labelPart + valuePart)
+}
+
+// hudLines returns the stacked HUD rows used in the loading view.
+func (m Model) hudLines() []string {
+	planetHex := fmt.Sprintf("#%02x%02x%02x",
+		m.cfg.Planet.Color[0], m.cfg.Planet.Color[1], m.cfg.Planet.Color[2])
+	planetStyle := nameValueStyle.Foreground(lipgloss.Color(planetHex))
+
+	progress := 0.0
+	if m.cfg.Total > 0 {
+		progress = float64(m.phaseNum) / float64(m.cfg.Total)
+	}
+	elapsed := m.cfg.Now().Sub(m.start)
+	mm := int(elapsed.Minutes())
+	ss := int(elapsed.Seconds()) % 60
+
+	blank := hudColStyle.Render("")
+	header := hudColStyle.Render(
+		hudAccentStyle.Render(m.spinner.View()+"  ") +
+			hudAccentStyle.Render("CSPACE // ORBITAL INIT"),
+	)
+	rule := hudColStyle.Render(hudDimStyle.Render(strings.Repeat("─", hudColWidth-2)))
+
+	return []string{
+		blank,
+		header,
+		blank,
+		rule,
+		blank,
+		renderStatRow("TARGET", strings.ToUpper(m.cfg.Name), planetStyle),
+		renderStatRow("PHASE", fmt.Sprintf("%02d / %02d", m.phaseNum, m.cfg.Total), valueStyle),
+		renderStatRow("T+", fmt.Sprintf("%02d:%02d", mm, ss), valueStyle),
+		renderStatRow("STATE", sciFiLabelFor(m.phase), valueStyle),
+		blank,
+		hudColStyle.Render(renderProgressBar(progress)),
+		blank,
+		hudColStyle.Render(hudBaseStyle.Render("›  ") + hudBaseStyle.Render(m.phase)),
+	}
 }
 
 func (m Model) loadingView() string {
 	shape := planets.GetShape(m.cfg.Name)
 	art := RenderPlanet(shape, m.cfg.Planet, m.phaseNum, m.cfg.Total)
 
-	planetColor := lipgloss.Color(fmt.Sprintf("#%02x%02x%02x",
-		m.cfg.Planet.Color[0], m.cfg.Planet.Color[1], m.cfg.Planet.Color[2]))
-	nameLine := nameStyle.Foreground(planetColor).
-		Render(strings.ToUpper(m.cfg.Name))
-
-	progress := 0.0
-	if m.cfg.Total > 0 {
-		progress = float64(m.phaseNum) / float64(m.cfg.Total)
+	artHeight := planets.ShapeRows / 2
+	hud := m.hudLines()
+	// Pad HUD to match planet height so JoinHorizontal aligns cleanly and
+	// the black viewport fills from planet-top to planet-bottom.
+	for len(hud) < artHeight {
+		hud = append(hud, hudColStyle.Render(""))
 	}
-	progressLine := renderProgressBar(progress)
+	if len(hud) > artHeight {
+		hud = hud[:artHeight]
+	}
+	hudBlock := strings.Join(hud, "\n")
 
-	sciFi := sciFiLabelFor(m.phase)
-	statusTop := hudAccentStyle.Render(m.spinner.View()+"  ") + hudAccentStyle.Render(sciFi)
-	statusBot := hudDimStyle.Render("    " + m.phase)
+	gap := strings.Repeat(gapStyle.Render("")+"\n", artHeight-1) + gapStyle.Render("")
 
-	elapsed := m.cfg.Now().Sub(m.start)
-	mm := int(elapsed.Minutes())
-	ss := int(elapsed.Seconds()) % 60
-	stats := hudBaseStyle.Render(fmt.Sprintf("PH %02d/%02d    T+ %02d:%02d",
-		m.phaseNum, m.cfg.Total, mm, ss))
+	combined := lipgloss.JoinHorizontal(lipgloss.Top, art, gap, hudBlock)
+	panel := panelStyle.Render(combined)
 
-	inner := lipgloss.JoinVertical(lipgloss.Center,
-		art,
-		panelInnerStyle.Render(""),
-		nameLine,
-		panelInnerStyle.Render(""),
-		progressLine,
-		panelInnerStyle.Render(""),
-		statusTop,
-		statusBot,
-		panelInnerStyle.Render(""),
-		stats,
-	)
-
-	panel := panelStyle.Render(inner)
 	if m.width == 0 || m.height == 0 {
 		return panel
 	}
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, panel)
+	return lipgloss.Place(m.width, m.height,
+		lipgloss.Center, lipgloss.Center,
+		panel,
+		lipgloss.WithWhitespaceBackground(lipgloss.Color("#000000")),
+	)
 }
 
 func (m Model) errorView() string {
 	lines := []string{
 		hudAccentStyle.Render("✕  MISSION ABORT"),
-		panelInnerStyle.Render(""),
+		panelFill.Render(""),
 	}
 	if m.errPhase != "" {
 		lines = append(lines,
-			hudBaseStyle.Render("FAULT IN PHASE: "+strings.ToUpper(sciFiLabelFor(m.errPhase))),
+			hudBaseStyle.Render("FAULT IN PHASE: ")+hudAccentStyle.Render(strings.ToUpper(sciFiLabelFor(m.errPhase))),
 			hudDimStyle.Render(m.errPhase),
-			panelInnerStyle.Render(""),
+			panelFill.Render(""),
 		)
 	}
 	lines = append(lines,
-		hudBaseStyle.Render("»  cspace up "+m.cfg.Name+" --verbose"),
-		panelInnerStyle.Render(""),
+		hudBaseStyle.Render("»  ")+hudAccentStyle.Render("cspace up "+m.cfg.Name+" --verbose"),
+		panelFill.Render(""),
 		hudDimStyle.Render("[ANY KEY] TO DISENGAGE"),
 	)
 	panel := errorPanelStyle.Render(strings.Join(lines, "\n"))
 	if m.width == 0 || m.height == 0 {
 		return panel
 	}
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, panel)
+	return lipgloss.Place(m.width, m.height,
+		lipgloss.Center, lipgloss.Center,
+		panel,
+	)
 }
 
 // Run starts the bubbletea program in alt-screen mode and blocks until

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -24,8 +24,8 @@ func TestViewShowsInstanceName(t *testing.T) {
 	m.phase = "Validating"
 	m.phaseNum = 1
 	out := m.View()
-	if !strings.Contains(out, "mercury") {
-		t.Error("expected instance name in view")
+	if !strings.Contains(out, "MERCURY") {
+		t.Error("expected instance name (upper-cased) in view")
 	}
 }
 
@@ -68,10 +68,10 @@ func TestViewErrorPanel(t *testing.T) {
 	m.errPhase = "Starting containers"
 	out := m.View()
 	for _, want := range []string{
-		"Provisioning failed",
+		"MISSION ABORT",
 		"Starting containers",
 		"--verbose",
-		"Press any key",
+		"DISENGAGE",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("error panel missing %q\nfull view:\n%s", want, out)

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -40,13 +40,19 @@ func TestViewShowsPhaseName(t *testing.T) {
 }
 
 func TestViewShowsElapsed(t *testing.T) {
-	now := time.Unix(0, 0)
+	calls := 0
 	m := NewModel(ModelConfig{
 		Name:   "mercury",
 		Planet: planets.MustGet("mercury"),
 		Total:  14,
 		Events: make(chan ProvisionEvent, 4),
-		Now:    func() time.Time { return now.Add(107 * time.Second) },
+		Now: func() time.Time {
+			defer func() { calls++ }()
+			if calls == 0 {
+				return time.Unix(0, 0) // seeds start at NewModel construction
+			}
+			return time.Unix(107, 0) // every subsequent call (including View)
+		},
 	})
 	m.phase = "Validating"
 	m.phaseNum = 1

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -1,0 +1,74 @@
+package overlay
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elliottregan/cspace/internal/planets"
+)
+
+func newTestModel() Model {
+	return NewModel(ModelConfig{
+		Name:   "mercury",
+		Planet: planets.MustGet("mercury"),
+		Total:  14,
+		Events: make(chan ProvisionEvent, 4),
+		Now:    func() time.Time { return time.Unix(0, 0) },
+	})
+}
+
+func TestViewShowsInstanceName(t *testing.T) {
+	m := newTestModel()
+	m.phase = "Validating"
+	m.phaseNum = 1
+	out := m.View()
+	if !strings.Contains(out, "mercury") {
+		t.Error("expected instance name in view")
+	}
+}
+
+func TestViewShowsPhaseName(t *testing.T) {
+	m := newTestModel()
+	m.phase = "Installing plugins"
+	m.phaseNum = 14
+	out := m.View()
+	if !strings.Contains(out, "Installing plugins") {
+		t.Error("expected phase name in view")
+	}
+}
+
+func TestViewShowsElapsed(t *testing.T) {
+	now := time.Unix(0, 0)
+	m := NewModel(ModelConfig{
+		Name:   "mercury",
+		Planet: planets.MustGet("mercury"),
+		Total:  14,
+		Events: make(chan ProvisionEvent, 4),
+		Now:    func() time.Time { return now.Add(107 * time.Second) },
+	})
+	m.phase = "Validating"
+	m.phaseNum = 1
+	out := m.View()
+	if !strings.Contains(out, "01:47") {
+		t.Errorf("expected elapsed 01:47 in view, got:\n%s", out)
+	}
+}
+
+func TestViewErrorPanel(t *testing.T) {
+	m := newTestModel()
+	m.err = errors.New("compose up failed: exit 1")
+	m.errPhase = "Starting containers"
+	out := m.View()
+	for _, want := range []string{
+		"Provisioning failed",
+		"Starting containers",
+		"--verbose",
+		"Press any key",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("error panel missing %q\nfull view:\n%s", want, out)
+		}
+	}
+}

--- a/internal/overlay/render.go
+++ b/internal/overlay/render.go
@@ -7,13 +7,15 @@
 //     block size drops linearly to 1 at phase=total.
 //   - Color saturation: base color lerps from dim grey toward the planet's
 //     canonical RGB as phase advances.
-//   - Surface texture: past 70% focus, a braille-dither overlay stipples
-//     subtle shadow/highlight variation across lit cells, ramping up with
-//     focus. Contrast is intentionally small — just enough to suggest
-//     surface detail without looking like random noise.
+//   - Surface texture: past TextureStart focus, a braille-dither overlay
+//     stipples subtle shading across lit cells to suggest surface detail.
+//     Dots are slightly DARKER than the cell they sit in so the texture
+//     reads as shadow rather than glint.
 //
-// Every cell paints explicit black bg so the planet always sits inside a
-// consistent black viewport regardless of terminal theme.
+// Planets may carry color Overlays (clouds, Great Red Spot, etc.) whose
+// per-cell shade controls how much the base color blends toward the
+// overlay's color. Overlays are pixelated in lockstep with the base
+// shape so they resolve with the planet during the focus pull.
 package overlay
 
 import (
@@ -24,45 +26,66 @@ import (
 	"github.com/elliottregan/cspace/internal/planets"
 )
 
-// greyStart is the washed-out grey the focus-pull begins with before
-// interpolating toward the planet's canonical color as phases advance.
+// Default tuning constants. Exposed as variables through
+// DefaultRenderOptions so the preview tool can override per-request.
 var greyStart = [3]uint8{110, 110, 110}
 
-// haloThreshold suppresses dim tails below this shade so the silhouette
-// collapses cleanly to black rather than fringing.
-const haloThreshold = 0.08
-
-// maxBlockSize is the pixelation block size used at phase 1 — big solid
-// squares that shrink toward 1 as focus approaches 1. 8 means at phase 1
-// the planet is effectively rendered at ShapeRows/8 × ShapeCols/8 resolution.
-const maxBlockSize = 8
-
-// textureStart is the focus value at which braille dither kicks in.
-// Below this focus we render only half-block shapes; above, a growing
-// fraction of lit cells are painted with a braille character to suggest
-// surface texture.
-const textureStart = 0.70
-
-// textureDensity is the fraction of cells that receive braille treatment
-// when focus hits 1.0. Below, the fraction scales linearly from 0.
-const textureDensity = 0.28
-
-// textureContrast is the fg/bg shade differential used by braille cells.
-// Small (fg slightly brighter than bg), so the texture reads as surface
-// detail rather than discrete dots.
-const textureContrast = 0.12
+const (
+	haloThreshold   = 0.08
+	maxBlockSize    = 8
+	textureStart    = 0.85 // kick in only near the end of the pull
+	textureDensity  = 0.30
+	textureContrast = 0.09 // small — dots sit just slightly below base
+)
 
 // viewportBg is the panel-interior background every cell paints.
 var viewportBg = [3]uint8{0, 0, 0}
 
-// upperHalf / lowerHalf / fullBlock pack two stacked sub-pixels per cell.
+// upperHalf / lowerHalf pack two stacked sub-pixels per cell.
 const (
 	upperHalf = "▀"
 	lowerHalf = "▄"
 )
 
+const ansiReset = "\x1b[0m"
+
+// brailleTextures is a curated pool of braille patterns with 2–5 dots
+// scattered across the 2×4 cell grid. Picking from a varied pool gives
+// the surface a stippled texture rather than repeating rows of the
+// same two dots.
+var brailleTextures = []string{
+	"⠃", "⠅", "⠆", "⠉", "⠊", "⠌", "⠑", "⠒",
+	"⠔", "⠘", "⠙", "⠚", "⠜", "⡀", "⡁", "⡂",
+	"⡃", "⡉", "⡐", "⡘", "⢁", "⢂", "⢄", "⢈",
+	"⢉", "⢐", "⢘", "⣀", "⣁", "⣂", "⣄", "⣈",
+	"⣐", "⣒", "⣡", "⣢", "⣤", "⣨", "⣪", "⣰",
+}
+
+// RenderOptions lets callers tweak image parameters per-render without
+// editing constants and rebuilding.
+type RenderOptions struct {
+	MaxBlockSize    int
+	HaloThreshold   float64
+	TextureStart    float64
+	TextureDensity  float64
+	TextureContrast float64
+	GreyStart       [3]uint8
+	Overlays        []planets.Overlay
+}
+
+// DefaultRenderOptions returns the package defaults used by RenderPlanet.
+func DefaultRenderOptions() RenderOptions {
+	return RenderOptions{
+		MaxBlockSize:    maxBlockSize,
+		HaloThreshold:   haloThreshold,
+		TextureStart:    textureStart,
+		TextureDensity:  textureDensity,
+		TextureContrast: textureContrast,
+		GreyStart:       greyStart,
+	}
+}
+
 // LerpColor linearly interpolates each channel of from→to by t∈[0,1].
-// Values outside [0,1] are clamped.
 func LerpColor(from, to [3]uint8, t float64) [3]uint8 {
 	if t < 0 {
 		t = 0
@@ -102,8 +125,6 @@ func scaleColor(rgb [3]uint8, shade float64) [3]uint8 {
 	}
 }
 
-const ansiReset = "\x1b[0m"
-
 func fgBgAnsi(fg, bg [3]uint8) string {
 	return fmt.Sprintf("\x1b[38;2;%d;%d;%d;48;2;%d;%d;%dm",
 		fg[0], fg[1], fg[2], bg[0], bg[1], bg[2])
@@ -113,9 +134,8 @@ func bgAnsi(bg [3]uint8) string {
 	return fmt.Sprintf("\x1b[48;2;%d;%d;%dm", bg[0], bg[1], bg[2])
 }
 
-// hash2 is a cheap deterministic float in [0,1) keyed on (r, c). Used for
-// per-cell texture decisions so the stipple pattern stays stable across
-// frames instead of twinkling.
+// hash2 is a deterministic per-cell float used for both braille
+// character selection and texture placement.
 func hash2(r, c int) float64 {
 	h := uint32(r)*73856093 ^ uint32(c)*19349663
 	h ^= h >> 13
@@ -124,45 +144,12 @@ func hash2(r, c int) float64 {
 	return float64(h%10000) / 10000.0
 }
 
-// pickBraille chooses a braille character (U+2800..U+28FF) whose dot
-// pattern is a stable function of (r, c). Dot count is biased by the
-// per-cell noise so textured regions vary visibly without clumping.
 func pickBraille(r, c int) string {
-	h := hash2(r, c)
-	// 2..6 dots keeps texture visible without turning cells into solid
-	// blocks (which would defeat the purpose).
-	dots := 2 + int(h*5)
-	mask := 0
-	// Use every other bit position so the resulting braille pattern
-	// spreads across both columns of the 2x4 dot grid.
-	for i := 0; i < dots; i++ {
-		mask |= 1 << ((i * 3) % 8)
+	idx := int(hash2(r, c) * float64(len(brailleTextures)))
+	if idx >= len(brailleTextures) {
+		idx = len(brailleTextures) - 1
 	}
-	return string(rune(0x2800 + mask))
-}
-
-// RenderOptions lets the preview tool tweak the image parameters at
-// request time without recompiling. Zero values are replaced with the
-// package defaults by DefaultRenderOptions.
-type RenderOptions struct {
-	MaxBlockSize    int
-	HaloThreshold   float64
-	TextureStart    float64
-	TextureDensity  float64
-	TextureContrast float64
-	GreyStart       [3]uint8
-}
-
-// DefaultRenderOptions returns the package defaults used by RenderPlanet.
-func DefaultRenderOptions() RenderOptions {
-	return RenderOptions{
-		MaxBlockSize:    maxBlockSize,
-		HaloThreshold:   haloThreshold,
-		TextureStart:    textureStart,
-		TextureDensity:  textureDensity,
-		TextureContrast: textureContrast,
-		GreyStart:       greyStart,
-	}
+	return brailleTextures[idx]
 }
 
 // RenderPlanet returns one frame of the focus-pull animation using the
@@ -171,8 +158,7 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 	return RenderPlanetWith(shape, p, phase, total, DefaultRenderOptions())
 }
 
-// RenderPlanetWith is RenderPlanet with tweakable options — useful for
-// the preview server at cmd/overlay-web.
+// RenderPlanetWith is RenderPlanet with tweakable options.
 func RenderPlanetWith(shape planets.Shape, p planets.Planet, phase, total int, opts RenderOptions) string {
 	if total <= 0 {
 		total = 1
@@ -185,19 +171,37 @@ func RenderPlanetWith(shape planets.Shape, p planets.Planet, phase, total int, o
 		focus = 1
 	}
 
-	// Pixelation: chunky at phase 1, pixel-perfect at phase total.
 	blockSize := int(math.Round(float64(opts.MaxBlockSize) * (1 - focus)))
 	if blockSize < 1 {
 		blockSize = 1
 	}
 	frame := pixelateShape(shape, blockSize)
 
+	// Pixelate overlay shapes in lockstep so they resolve with the base.
+	overlayFrames := make([]planets.Shape, len(opts.Overlays))
+	for i, ov := range opts.Overlays {
+		overlayFrames[i] = pixelateShape(ov.Shape, blockSize)
+	}
+
 	baseColor := LerpColor(opts.GreyStart, p.Color, focus)
 
-	// Texture ramp: 0 until TextureStart, then linearly up to TextureDensity.
 	var textureFrac float64
 	if focus > opts.TextureStart && opts.TextureStart < 1 {
 		textureFrac = (focus - opts.TextureStart) / (1 - opts.TextureStart) * opts.TextureDensity
+	}
+
+	// blendSub takes a base shade and the sub-pixel's (row, col) in the
+	// shape grid, returns the final cell color with overlay blending
+	// applied.
+	blendSub := func(shade float64, row, col int) [3]uint8 {
+		col0 := scaleColor(baseColor, shade)
+		for i, ov := range opts.Overlays {
+			ovShade := overlayFrames[i][row][col]
+			if ovShade > 0 {
+				col0 = LerpColor(col0, ov.Color, ovShade)
+			}
+		}
+		return col0
 	}
 
 	termRows := planets.ShapeRows / 2
@@ -205,8 +209,9 @@ func RenderPlanetWith(shape planets.Shape, p planets.Planet, phase, total int, o
 	for r := 0; r < termRows; r++ {
 		var line strings.Builder
 		for c := 0; c < planets.ShapeCols; c++ {
-			top := frame[r*2][c]
-			bot := frame[r*2+1][c]
+			topRow, botRow := r*2, r*2+1
+			top := frame[topRow][c]
+			bot := frame[botRow][c]
 			topOn := top >= opts.HaloThreshold
 			botOn := bot >= opts.HaloThreshold
 
@@ -215,28 +220,38 @@ func RenderPlanetWith(shape planets.Shape, p planets.Planet, phase, total int, o
 				line.WriteString(bgAnsi(viewportBg))
 				line.WriteByte(' ')
 				line.WriteString(ansiReset)
+
 			case topOn && botOn:
-				// Braille texture overlay on fully-lit cells past TextureStart.
 				if textureFrac > 0 && hash2(r, c) < textureFrac {
+					// Braille dither: fg slightly darker than bg, both
+					// sharing the same (overlay-blended) base color.
 					mid := (top + bot) * 0.5
-					bg := scaleColor(baseColor, mid)
-					fg := scaleColor(baseColor, math.Min(1, mid+opts.TextureContrast))
+					bg := blendSub(mid, topRow, c)
+					// Blend the fg's darker shade with the SAME overlay
+					// shade as the bg so only lightness differs.
+					fgShade := mid - opts.TextureContrast
+					if fgShade < 0 {
+						fgShade = 0
+					}
+					fg := blendSub(fgShade, topRow, c)
 					line.WriteString(fgBgAnsi(fg, bg))
 					line.WriteString(pickBraille(r, c))
 				} else {
-					topColor := scaleColor(baseColor, top)
-					botColor := scaleColor(baseColor, bot)
+					topColor := blendSub(top, topRow, c)
+					botColor := blendSub(bot, botRow, c)
 					line.WriteString(fgBgAnsi(topColor, botColor))
 					line.WriteString(upperHalf)
 				}
 				line.WriteString(ansiReset)
+
 			case topOn:
-				topColor := scaleColor(baseColor, top)
+				topColor := blendSub(top, topRow, c)
 				line.WriteString(fgBgAnsi(topColor, viewportBg))
 				line.WriteString(upperHalf)
 				line.WriteString(ansiReset)
+
 			case botOn:
-				botColor := scaleColor(baseColor, bot)
+				botColor := blendSub(bot, botRow, c)
 				line.WriteString(fgBgAnsi(botColor, viewportBg))
 				line.WriteString(lowerHalf)
 				line.WriteString(ansiReset)
@@ -248,8 +263,7 @@ func RenderPlanetWith(shape planets.Shape, p planets.Planet, phase, total int, o
 }
 
 // pixelateShape returns a new shape where every blockSize×blockSize region
-// of the input is flattened to the region's mean shade. blockSize <= 1
-// returns the input unchanged.
+// of the input is flattened to the region's mean shade.
 func pixelateShape(s planets.Shape, blockSize int) planets.Shape {
 	if blockSize <= 1 {
 		return s

--- a/internal/overlay/render.go
+++ b/internal/overlay/render.go
@@ -29,8 +29,14 @@ const haloThreshold = 0.08
 
 // maxBlurIters caps the iterative 3x3 box-blur passes applied to the
 // target shape at phase 1 (the most defocused frame). 0 iterations at
-// phase == total gives the sharp target image.
-const maxBlurIters = 6
+// phase == total gives the sharp target image. Scales roughly with grid
+// size — doubled from 6 when the shape grid grew from 24² to 48².
+const maxBlurIters = 12
+
+// viewportBg is the panel-interior background every planet cell paints,
+// so the blur tails blend into the enclosing black viewport regardless
+// of the user's terminal theme.
+var viewportBg = [3]uint8{0, 0, 0}
 
 // upperHalf and lowerHalf are the Unicode half-block characters we use
 // to pack two vertical sub-pixels into one terminal cell. upperHalf
@@ -85,13 +91,13 @@ func scaleColor(rgb [3]uint8, shade float64) [3]uint8 {
 
 const ansiReset = "\x1b[0m"
 
-func fgAnsi(rgb [3]uint8) string {
-	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm", rgb[0], rgb[1], rgb[2])
-}
-
 func fgBgAnsi(fg, bg [3]uint8) string {
 	return fmt.Sprintf("\x1b[38;2;%d;%d;%d;48;2;%d;%d;%dm",
 		fg[0], fg[1], fg[2], bg[0], bg[1], bg[2])
+}
+
+func bgAnsi(bg [3]uint8) string {
+	return fmt.Sprintf("\x1b[48;2;%d;%d;%dm", bg[0], bg[1], bg[2])
 }
 
 // RenderPlanet returns one frame of the focus-pull animation. Blur
@@ -127,7 +133,9 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 
 			switch {
 			case !topOn && !botOn:
+				line.WriteString(bgAnsi(viewportBg))
 				line.WriteByte(' ')
+				line.WriteString(ansiReset)
 			case topOn && botOn:
 				topColor := scaleColor(baseColor, top)
 				botColor := scaleColor(baseColor, bot)
@@ -136,12 +144,12 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 				line.WriteString(ansiReset)
 			case topOn:
 				topColor := scaleColor(baseColor, top)
-				line.WriteString(fgAnsi(topColor))
+				line.WriteString(fgBgAnsi(topColor, viewportBg))
 				line.WriteString(upperHalf)
 				line.WriteString(ansiReset)
 			case botOn:
 				botColor := scaleColor(baseColor, bot)
-				line.WriteString(fgAnsi(botColor))
+				line.WriteString(fgBgAnsi(botColor, viewportBg))
 				line.WriteString(lowerHalf)
 				line.WriteString(ansiReset)
 			}

--- a/internal/overlay/render.go
+++ b/internal/overlay/render.go
@@ -1,36 +1,42 @@
 // Package overlay renders the bubbletea provisioning overlay — a planet
-// "coming into focus" through six palette stages while color lerps from
-// grey to the planet's canonical RGB.
+// "coming into focus" as provisioning advances. The focus-pull effect uses
+// two axes: (1) the shape is blurred heavily at phase 1 and iteratively
+// sharpened toward the target image, and (2) the color lerps from a dim
+// grey toward the planet's canonical RGB. The character palette is a
+// static 4-step density ramp (no half-blocks, no braille — those looked
+// like noise rather than detail).
 package overlay
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/elliottregan/cspace/internal/planets"
 )
 
-// greyStart is the dim grey color the focus-pull begins with before
+// greyStart is the washed-out grey the focus-pull begins with before
 // interpolating toward the planet's canonical color as phases advance.
-var greyStart = [3]uint8{85, 85, 85}
+var greyStart = [3]uint8{110, 110, 110}
 
-// palettes[phase-1] is the lookup table used during phase N (1..6).
-// Index 0 is always the space rendered for shade 0; subsequent indices
-// map non-zero shade values (split evenly across [0,1]) to progressively
-// denser characters. See the issue for the "block → half-block → braille"
-// progression.
-var palettes = [6][]string{
-	{" ", "█"},
-	{" ", "▓", "█"},
-	{" ", "▒", "▓", "█"},
-	{" ", "░", "▒", "▓", "█"},
-	{" ", "░", "▒", "▓", "▌", "█"},
-	{" ", "⠂", "░", "▒", "▓", "▌", "█"},
-}
+// palette maps shade magnitude to a block-shading character. Index 0 is
+// always space for shade == 0; subsequent entries span [0, 1] evenly.
+// Intentionally short — extra half-block or braille characters produced
+// visual noise rather than added detail.
+var palette = []string{" ", "░", "▒", "▓", "█"}
+
+// haloThreshold suppresses dim blur tails below this shade value so the
+// halo stays bounded rather than flood-filling the frame at early phases.
+const haloThreshold = 0.08
+
+// maxBlurIters caps the iterative 3x3 box-blur passes applied to the
+// target shape at phase 1 (the most defocused frame). 0 iterations at
+// phase == total gives the sharp target image.
+const maxBlurIters = 6
 
 // LerpColor linearly interpolates each channel of from→to by t∈[0,1].
-// Values outside [0,1] are clamped. Channel arithmetic uses float64 to
-// avoid uint8 underflow when a channel shrinks (e.g. 200 → 50).
+// Values outside [0,1] are clamped. Arithmetic uses float64 to avoid
+// uint8 underflow when a channel shrinks (e.g. 200 → 50).
 func LerpColor(from, to [3]uint8, t float64) [3]uint8 {
 	if t < 0 {
 		t = 0
@@ -55,23 +61,14 @@ func LerpColor(from, to [3]uint8, t float64) [3]uint8 {
 	}
 }
 
-// ShadeToChar maps a shade in [0,1] to a single character chosen from the
-// palette for the given phase (1..6). Phases outside the range are clamped.
-// Shade <= 0 always maps to " ".
-func ShadeToChar(shade float64, phase int) string {
-	if shade <= 0 {
+// ShadeToChar maps a shade in [0,1] to a single character from the density
+// palette. Shade <= 0 and shade below haloThreshold both render as space
+// so blur halos taper cleanly to empty rather than fringing with ░.
+func ShadeToChar(shade float64) string {
+	if shade < haloThreshold {
 		return " "
 	}
-	if phase < 1 {
-		phase = 1
-	}
-	if phase > 6 {
-		phase = 6
-	}
-	pal := palettes[phase-1]
-	// Skip the leading " " for non-zero shades so a low but positive shade
-	// always renders a visible glyph.
-	nonBlank := pal[1:]
+	nonBlank := palette[1:]
 	idx := int(shade * float64(len(nonBlank)))
 	if idx >= len(nonBlank) {
 		idx = len(nonBlank) - 1
@@ -87,23 +84,33 @@ func ansiColor(rgb [3]uint8) string {
 // ansiReset restores default SGR.
 const ansiReset = "\x1b[0m"
 
-// RenderPlanet returns the colored ASCII art for one frame of the focus-pull
-// animation. Color lerps from grey to planet.Color by (phase/total) and the
-// palette densifies as phase grows. The return value is a 6-line string with
-// each non-empty cell wrapped in truecolor ANSI and a trailing reset.
+// RenderPlanet returns one frame of the focus-pull animation. Blur iterations
+// decrease with phase (target shape sharpens); color lerps from grey toward
+// planet.Color. The output is a multi-line string with each non-space cell
+// wrapped in truecolor ANSI + reset.
 func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) string {
 	if total <= 0 {
 		total = 1
 	}
-	t := float64(phase) / float64(total)
-	rgb := LerpColor(greyStart, p.Color, t)
+	focus := float64(phase) / float64(total)
+	if focus < 0 {
+		focus = 0
+	}
+	if focus > 1 {
+		focus = 1
+	}
+
+	iters := int(math.Round(float64(maxBlurIters) * (1 - focus)))
+	frame := blurShape(shape, iters)
+
+	rgb := LerpColor(greyStart, p.Color, focus)
 	color := ansiColor(rgb)
 
 	var rows []string
-	for _, row := range shape {
+	for _, row := range frame {
 		var line strings.Builder
 		for _, shade := range row {
-			ch := ShadeToChar(shade, phaseStage(phase, total))
+			ch := ShadeToChar(shade)
 			if ch == " " {
 				line.WriteByte(' ')
 				continue
@@ -117,22 +124,35 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 	return strings.Join(rows, "\n")
 }
 
-// phaseStage maps the provisioning phase index (1..total) to a 1..6 palette
-// stage. With 14 provisioning phases, each palette stage covers ~2.3 phases.
-// Phase 0 is treated as stage 1.
-func phaseStage(phase, total int) int {
-	if phase < 1 {
-		return 1
+// blurShape applies `iters` passes of a 3x3 box blur to s. Each pass smooths
+// edges and spreads shade outward; iterating many passes approximates a
+// Gaussian with sigma ≈ √iters. Out-of-bounds neighbors are treated as 0
+// so the halo fades to black at the frame edges.
+func blurShape(s planets.Shape, iters int) planets.Shape {
+	for i := 0; i < iters; i++ {
+		s = boxBlur3x3(s)
 	}
-	if total < 1 {
-		total = 1
+	return s
+}
+
+func boxBlur3x3(s planets.Shape) planets.Shape {
+	var out planets.Shape
+	rows := planets.ShapeRows
+	cols := planets.ShapeCols
+	for r := 0; r < rows; r++ {
+		for c := 0; c < cols; c++ {
+			var sum float64
+			for dr := -1; dr <= 1; dr++ {
+				for dc := -1; dc <= 1; dc++ {
+					rr, cc := r+dr, c+dc
+					if rr < 0 || rr >= rows || cc < 0 || cc >= cols {
+						continue
+					}
+					sum += s[rr][cc]
+				}
+			}
+			out[r][c] = sum / 9
+		}
 	}
-	stage := 1 + (phase-1)*6/total
-	if stage < 1 {
-		stage = 1
-	}
-	if stage > 6 {
-		stage = 6
-	}
-	return stage
+	return out
 }

--- a/internal/overlay/render.go
+++ b/internal/overlay/render.go
@@ -2,9 +2,13 @@
 // "coming into focus" as provisioning advances. The focus-pull effect uses
 // two axes: (1) the shape is blurred heavily at phase 1 and iteratively
 // sharpened toward the target image, and (2) the color lerps from a dim
-// grey toward the planet's canonical RGB. The character palette is a
-// static 4-step density ramp (no half-blocks, no braille — those looked
-// like noise rather than detail).
+// grey toward the planet's canonical RGB.
+//
+// Each output cell uses the ▀/▄ half-block character with independent
+// foreground and background truecolors, so every terminal cell encodes
+// TWO vertically stacked sub-pixels — doubling effective vertical
+// resolution. Per-subpixel color is derived from its shade value via
+// truecolor scaling, so gradients are smooth (no density-palette banding).
 package overlay
 
 import (
@@ -19,12 +23,6 @@ import (
 // interpolating toward the planet's canonical color as phases advance.
 var greyStart = [3]uint8{110, 110, 110}
 
-// palette maps shade magnitude to a block-shading character. Index 0 is
-// always space for shade == 0; subsequent entries span [0, 1] evenly.
-// Intentionally short — extra half-block or braille characters produced
-// visual noise rather than added detail.
-var palette = []string{" ", "░", "▒", "▓", "█"}
-
 // haloThreshold suppresses dim blur tails below this shade value so the
 // halo stays bounded rather than flood-filling the frame at early phases.
 const haloThreshold = 0.08
@@ -33,6 +31,14 @@ const haloThreshold = 0.08
 // target shape at phase 1 (the most defocused frame). 0 iterations at
 // phase == total gives the sharp target image.
 const maxBlurIters = 6
+
+// upperHalf and lowerHalf are the Unicode half-block characters we use
+// to pack two vertical sub-pixels into one terminal cell. upperHalf
+// shows fg on top / bg on bottom; lowerHalf is its mirror.
+const (
+	upperHalf = "▀"
+	lowerHalf = "▄"
+)
 
 // LerpColor linearly interpolates each channel of from→to by t∈[0,1].
 // Values outside [0,1] are clamped. Arithmetic uses float64 to avoid
@@ -61,33 +67,37 @@ func LerpColor(from, to [3]uint8, t float64) [3]uint8 {
 	}
 }
 
-// ShadeToChar maps a shade in [0,1] to a single character from the density
-// palette. Shade <= 0 and shade below haloThreshold both render as space
-// so blur halos taper cleanly to empty rather than fringing with ░.
-func ShadeToChar(shade float64) string {
-	if shade < haloThreshold {
-		return " "
+// scaleColor multiplies each channel of rgb by shade ∈ [0,1], producing a
+// darker version of rgb suitable for the unlit portion of a cell.
+func scaleColor(rgb [3]uint8, shade float64) [3]uint8 {
+	if shade <= 0 {
+		return [3]uint8{0, 0, 0}
 	}
-	nonBlank := palette[1:]
-	idx := int(shade * float64(len(nonBlank)))
-	if idx >= len(nonBlank) {
-		idx = len(nonBlank) - 1
+	if shade >= 1 {
+		return rgb
 	}
-	return nonBlank[idx]
+	return [3]uint8{
+		uint8(float64(rgb[0]) * shade),
+		uint8(float64(rgb[1]) * shade),
+		uint8(float64(rgb[2]) * shade),
+	}
 }
 
-// ansiColor returns the 24-bit foreground SGR escape for rgb.
-func ansiColor(rgb [3]uint8) string {
+const ansiReset = "\x1b[0m"
+
+func fgAnsi(rgb [3]uint8) string {
 	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm", rgb[0], rgb[1], rgb[2])
 }
 
-// ansiReset restores default SGR.
-const ansiReset = "\x1b[0m"
+func fgBgAnsi(fg, bg [3]uint8) string {
+	return fmt.Sprintf("\x1b[38;2;%d;%d;%d;48;2;%d;%d;%dm",
+		fg[0], fg[1], fg[2], bg[0], bg[1], bg[2])
+}
 
-// RenderPlanet returns one frame of the focus-pull animation. Blur iterations
-// decrease with phase (target shape sharpens); color lerps from grey toward
-// planet.Color. The output is a multi-line string with each non-space cell
-// wrapped in truecolor ANSI + reset.
+// RenderPlanet returns one frame of the focus-pull animation. Blur
+// iterations decrease with phase (target shape sharpens); color lerps from
+// grey toward planet.Color. Output height is planets.ShapeRows/2 terminal
+// rows because each output row represents two stacked sub-pixels.
 func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) string {
 	if total <= 0 {
 		total = 1
@@ -103,21 +113,38 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 	iters := int(math.Round(float64(maxBlurIters) * (1 - focus)))
 	frame := blurShape(shape, iters)
 
-	rgb := LerpColor(greyStart, p.Color, focus)
-	color := ansiColor(rgb)
+	baseColor := LerpColor(greyStart, p.Color, focus)
 
+	termRows := planets.ShapeRows / 2
 	var rows []string
-	for _, row := range frame {
+	for r := 0; r < termRows; r++ {
 		var line strings.Builder
-		for _, shade := range row {
-			ch := ShadeToChar(shade)
-			if ch == " " {
+		for c := 0; c < planets.ShapeCols; c++ {
+			top := frame[r*2][c]
+			bot := frame[r*2+1][c]
+			topOn := top >= haloThreshold
+			botOn := bot >= haloThreshold
+
+			switch {
+			case !topOn && !botOn:
 				line.WriteByte(' ')
-				continue
+			case topOn && botOn:
+				topColor := scaleColor(baseColor, top)
+				botColor := scaleColor(baseColor, bot)
+				line.WriteString(fgBgAnsi(topColor, botColor))
+				line.WriteString(upperHalf)
+				line.WriteString(ansiReset)
+			case topOn:
+				topColor := scaleColor(baseColor, top)
+				line.WriteString(fgAnsi(topColor))
+				line.WriteString(upperHalf)
+				line.WriteString(ansiReset)
+			case botOn:
+				botColor := scaleColor(baseColor, bot)
+				line.WriteString(fgAnsi(botColor))
+				line.WriteString(lowerHalf)
+				line.WriteString(ansiReset)
 			}
-			line.WriteString(color)
-			line.WriteString(ch)
-			line.WriteString(ansiReset)
 		}
 		rows = append(rows, line.String())
 	}

--- a/internal/overlay/render.go
+++ b/internal/overlay/render.go
@@ -141,8 +141,39 @@ func pickBraille(r, c int) string {
 	return string(rune(0x2800 + mask))
 }
 
-// RenderPlanet returns one frame of the focus-pull animation.
+// RenderOptions lets the preview tool tweak the image parameters at
+// request time without recompiling. Zero values are replaced with the
+// package defaults by DefaultRenderOptions.
+type RenderOptions struct {
+	MaxBlockSize    int
+	HaloThreshold   float64
+	TextureStart    float64
+	TextureDensity  float64
+	TextureContrast float64
+	GreyStart       [3]uint8
+}
+
+// DefaultRenderOptions returns the package defaults used by RenderPlanet.
+func DefaultRenderOptions() RenderOptions {
+	return RenderOptions{
+		MaxBlockSize:    maxBlockSize,
+		HaloThreshold:   haloThreshold,
+		TextureStart:    textureStart,
+		TextureDensity:  textureDensity,
+		TextureContrast: textureContrast,
+		GreyStart:       greyStart,
+	}
+}
+
+// RenderPlanet returns one frame of the focus-pull animation using the
+// package-default RenderOptions.
 func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) string {
+	return RenderPlanetWith(shape, p, phase, total, DefaultRenderOptions())
+}
+
+// RenderPlanetWith is RenderPlanet with tweakable options — useful for
+// the preview server at cmd/overlay-web.
+func RenderPlanetWith(shape planets.Shape, p planets.Planet, phase, total int, opts RenderOptions) string {
 	if total <= 0 {
 		total = 1
 	}
@@ -155,18 +186,18 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 	}
 
 	// Pixelation: chunky at phase 1, pixel-perfect at phase total.
-	blockSize := int(math.Round(float64(maxBlockSize) * (1 - focus)))
+	blockSize := int(math.Round(float64(opts.MaxBlockSize) * (1 - focus)))
 	if blockSize < 1 {
 		blockSize = 1
 	}
 	frame := pixelateShape(shape, blockSize)
 
-	baseColor := LerpColor(greyStart, p.Color, focus)
+	baseColor := LerpColor(opts.GreyStart, p.Color, focus)
 
-	// Texture ramp: 0 until textureStart, then linearly up to textureDensity.
+	// Texture ramp: 0 until TextureStart, then linearly up to TextureDensity.
 	var textureFrac float64
-	if focus > textureStart {
-		textureFrac = (focus - textureStart) / (1 - textureStart) * textureDensity
+	if focus > opts.TextureStart && opts.TextureStart < 1 {
+		textureFrac = (focus - opts.TextureStart) / (1 - opts.TextureStart) * opts.TextureDensity
 	}
 
 	termRows := planets.ShapeRows / 2
@@ -176,8 +207,8 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 		for c := 0; c < planets.ShapeCols; c++ {
 			top := frame[r*2][c]
 			bot := frame[r*2+1][c]
-			topOn := top >= haloThreshold
-			botOn := bot >= haloThreshold
+			topOn := top >= opts.HaloThreshold
+			botOn := bot >= opts.HaloThreshold
 
 			switch {
 			case !topOn && !botOn:
@@ -185,11 +216,11 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 				line.WriteByte(' ')
 				line.WriteString(ansiReset)
 			case topOn && botOn:
-				// Braille texture overlay on fully-lit cells past textureStart.
+				// Braille texture overlay on fully-lit cells past TextureStart.
 				if textureFrac > 0 && hash2(r, c) < textureFrac {
 					mid := (top + bot) * 0.5
 					bg := scaleColor(baseColor, mid)
-					fg := scaleColor(baseColor, math.Min(1, mid+textureContrast))
+					fg := scaleColor(baseColor, math.Min(1, mid+opts.TextureContrast))
 					line.WriteString(fgBgAnsi(fg, bg))
 					line.WriteString(pickBraille(r, c))
 				} else {

--- a/internal/overlay/render.go
+++ b/internal/overlay/render.go
@@ -1,0 +1,138 @@
+// Package overlay renders the bubbletea provisioning overlay — a planet
+// "coming into focus" through six palette stages while color lerps from
+// grey to the planet's canonical RGB.
+package overlay
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elliottregan/cspace/internal/planets"
+)
+
+// greyStart is the dim grey color the focus-pull begins with before
+// interpolating toward the planet's canonical color as phases advance.
+var greyStart = [3]uint8{85, 85, 85}
+
+// palettes[phase-1] is the lookup table used during phase N (1..6).
+// Index 0 is always the space rendered for shade 0; subsequent indices
+// map non-zero shade values (split evenly across [0,1]) to progressively
+// denser characters. See the issue for the "block → half-block → braille"
+// progression.
+var palettes = [6][]string{
+	{" ", "█"},
+	{" ", "▓", "█"},
+	{" ", "▒", "▓", "█"},
+	{" ", "░", "▒", "▓", "█"},
+	{" ", "░", "▒", "▓", "▌", "█"},
+	{" ", "⠂", "░", "▒", "▓", "▌", "█"},
+}
+
+// LerpColor linearly interpolates each channel of from→to by t∈[0,1].
+// Values outside [0,1] are clamped. Channel arithmetic uses float64 to
+// avoid uint8 underflow when a channel shrinks (e.g. 200 → 50).
+func LerpColor(from, to [3]uint8, t float64) [3]uint8 {
+	if t < 0 {
+		t = 0
+	}
+	if t > 1 {
+		t = 1
+	}
+	lerp := func(a, b uint8) uint8 {
+		v := float64(a) + t*(float64(b)-float64(a))
+		if v < 0 {
+			return 0
+		}
+		if v > 255 {
+			return 255
+		}
+		return uint8(v)
+	}
+	return [3]uint8{
+		lerp(from[0], to[0]),
+		lerp(from[1], to[1]),
+		lerp(from[2], to[2]),
+	}
+}
+
+// ShadeToChar maps a shade in [0,1] to a single character chosen from the
+// palette for the given phase (1..6). Phases outside the range are clamped.
+// Shade <= 0 always maps to " ".
+func ShadeToChar(shade float64, phase int) string {
+	if shade <= 0 {
+		return " "
+	}
+	if phase < 1 {
+		phase = 1
+	}
+	if phase > 6 {
+		phase = 6
+	}
+	pal := palettes[phase-1]
+	// Skip the leading " " for non-zero shades so a low but positive shade
+	// always renders a visible glyph.
+	nonBlank := pal[1:]
+	idx := int(shade * float64(len(nonBlank)))
+	if idx >= len(nonBlank) {
+		idx = len(nonBlank) - 1
+	}
+	return nonBlank[idx]
+}
+
+// ansiColor returns the 24-bit foreground SGR escape for rgb.
+func ansiColor(rgb [3]uint8) string {
+	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm", rgb[0], rgb[1], rgb[2])
+}
+
+// ansiReset restores default SGR.
+const ansiReset = "\x1b[0m"
+
+// RenderPlanet returns the colored ASCII art for one frame of the focus-pull
+// animation. Color lerps from grey to planet.Color by (phase/total) and the
+// palette densifies as phase grows. The return value is a 6-line string with
+// each non-empty cell wrapped in truecolor ANSI and a trailing reset.
+func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) string {
+	if total <= 0 {
+		total = 1
+	}
+	t := float64(phase) / float64(total)
+	rgb := LerpColor(greyStart, p.Color, t)
+	color := ansiColor(rgb)
+
+	var rows []string
+	for _, row := range shape {
+		var line strings.Builder
+		for _, shade := range row {
+			ch := ShadeToChar(shade, phaseStage(phase, total))
+			if ch == " " {
+				line.WriteByte(' ')
+				continue
+			}
+			line.WriteString(color)
+			line.WriteString(ch)
+			line.WriteString(ansiReset)
+		}
+		rows = append(rows, line.String())
+	}
+	return strings.Join(rows, "\n")
+}
+
+// phaseStage maps the provisioning phase index (1..total) to a 1..6 palette
+// stage. With 14 provisioning phases, each palette stage covers ~2.3 phases.
+// Phase 0 is treated as stage 1.
+func phaseStage(phase, total int) int {
+	if phase < 1 {
+		return 1
+	}
+	if total < 1 {
+		total = 1
+	}
+	stage := 1 + (phase-1)*6/total
+	if stage < 1 {
+		stage = 1
+	}
+	if stage > 6 {
+		stage = 6
+	}
+	return stage
+}

--- a/internal/overlay/render.go
+++ b/internal/overlay/render.go
@@ -1,14 +1,19 @@
 // Package overlay renders the bubbletea provisioning overlay — a planet
-// "coming into focus" as provisioning advances. The focus-pull effect uses
-// two axes: (1) the shape is blurred heavily at phase 1 and iteratively
-// sharpened toward the target image, and (2) the color lerps from a dim
-// grey toward the planet's canonical RGB.
+// "coming into focus" as provisioning advances.
 //
-// Each output cell uses the ▀/▄ half-block character with independent
-// foreground and background truecolors, so every terminal cell encodes
-// TWO vertically stacked sub-pixels — doubling effective vertical
-// resolution. Per-subpixel color is derived from its shade value via
-// truecolor scaling, so gradients are smooth (no density-palette banding).
+// Focus-pull uses three axes:
+//   - Pixelation: at phase 1 the shape is sampled at a coarse block size
+//     so the planet reads as a chunky mosaic of solid-color squares;
+//     block size drops linearly to 1 at phase=total.
+//   - Color saturation: base color lerps from dim grey toward the planet's
+//     canonical RGB as phase advances.
+//   - Surface texture: past 70% focus, a braille-dither overlay stipples
+//     subtle shadow/highlight variation across lit cells, ramping up with
+//     focus. Contrast is intentionally small — just enough to suggest
+//     surface detail without looking like random noise.
+//
+// Every cell paints explicit black bg so the planet always sits inside a
+// consistent black viewport regardless of terminal theme.
 package overlay
 
 import (
@@ -23,32 +28,41 @@ import (
 // interpolating toward the planet's canonical color as phases advance.
 var greyStart = [3]uint8{110, 110, 110}
 
-// haloThreshold suppresses dim blur tails below this shade value so the
-// halo stays bounded rather than flood-filling the frame at early phases.
+// haloThreshold suppresses dim tails below this shade so the silhouette
+// collapses cleanly to black rather than fringing.
 const haloThreshold = 0.08
 
-// maxBlurIters caps the iterative 3x3 box-blur passes applied to the
-// target shape at phase 1 (the most defocused frame). 0 iterations at
-// phase == total gives the sharp target image. Scales roughly with grid
-// size — doubled from 6 when the shape grid grew from 24² to 48².
-const maxBlurIters = 12
+// maxBlockSize is the pixelation block size used at phase 1 — big solid
+// squares that shrink toward 1 as focus approaches 1. 8 means at phase 1
+// the planet is effectively rendered at ShapeRows/8 × ShapeCols/8 resolution.
+const maxBlockSize = 8
 
-// viewportBg is the panel-interior background every planet cell paints,
-// so the blur tails blend into the enclosing black viewport regardless
-// of the user's terminal theme.
+// textureStart is the focus value at which braille dither kicks in.
+// Below this focus we render only half-block shapes; above, a growing
+// fraction of lit cells are painted with a braille character to suggest
+// surface texture.
+const textureStart = 0.70
+
+// textureDensity is the fraction of cells that receive braille treatment
+// when focus hits 1.0. Below, the fraction scales linearly from 0.
+const textureDensity = 0.28
+
+// textureContrast is the fg/bg shade differential used by braille cells.
+// Small (fg slightly brighter than bg), so the texture reads as surface
+// detail rather than discrete dots.
+const textureContrast = 0.12
+
+// viewportBg is the panel-interior background every cell paints.
 var viewportBg = [3]uint8{0, 0, 0}
 
-// upperHalf and lowerHalf are the Unicode half-block characters we use
-// to pack two vertical sub-pixels into one terminal cell. upperHalf
-// shows fg on top / bg on bottom; lowerHalf is its mirror.
+// upperHalf / lowerHalf / fullBlock pack two stacked sub-pixels per cell.
 const (
 	upperHalf = "▀"
 	lowerHalf = "▄"
 )
 
 // LerpColor linearly interpolates each channel of from→to by t∈[0,1].
-// Values outside [0,1] are clamped. Arithmetic uses float64 to avoid
-// uint8 underflow when a channel shrinks (e.g. 200 → 50).
+// Values outside [0,1] are clamped.
 func LerpColor(from, to [3]uint8, t float64) [3]uint8 {
 	if t < 0 {
 		t = 0
@@ -73,8 +87,7 @@ func LerpColor(from, to [3]uint8, t float64) [3]uint8 {
 	}
 }
 
-// scaleColor multiplies each channel of rgb by shade ∈ [0,1], producing a
-// darker version of rgb suitable for the unlit portion of a cell.
+// scaleColor multiplies each channel of rgb by shade ∈ [0,1].
 func scaleColor(rgb [3]uint8, shade float64) [3]uint8 {
 	if shade <= 0 {
 		return [3]uint8{0, 0, 0}
@@ -100,10 +113,35 @@ func bgAnsi(bg [3]uint8) string {
 	return fmt.Sprintf("\x1b[48;2;%d;%d;%dm", bg[0], bg[1], bg[2])
 }
 
-// RenderPlanet returns one frame of the focus-pull animation. Blur
-// iterations decrease with phase (target shape sharpens); color lerps from
-// grey toward planet.Color. Output height is planets.ShapeRows/2 terminal
-// rows because each output row represents two stacked sub-pixels.
+// hash2 is a cheap deterministic float in [0,1) keyed on (r, c). Used for
+// per-cell texture decisions so the stipple pattern stays stable across
+// frames instead of twinkling.
+func hash2(r, c int) float64 {
+	h := uint32(r)*73856093 ^ uint32(c)*19349663
+	h ^= h >> 13
+	h *= 0x5bd1e995
+	h ^= h >> 15
+	return float64(h%10000) / 10000.0
+}
+
+// pickBraille chooses a braille character (U+2800..U+28FF) whose dot
+// pattern is a stable function of (r, c). Dot count is biased by the
+// per-cell noise so textured regions vary visibly without clumping.
+func pickBraille(r, c int) string {
+	h := hash2(r, c)
+	// 2..6 dots keeps texture visible without turning cells into solid
+	// blocks (which would defeat the purpose).
+	dots := 2 + int(h*5)
+	mask := 0
+	// Use every other bit position so the resulting braille pattern
+	// spreads across both columns of the 2x4 dot grid.
+	for i := 0; i < dots; i++ {
+		mask |= 1 << ((i * 3) % 8)
+	}
+	return string(rune(0x2800 + mask))
+}
+
+// RenderPlanet returns one frame of the focus-pull animation.
 func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) string {
 	if total <= 0 {
 		total = 1
@@ -116,10 +154,20 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 		focus = 1
 	}
 
-	iters := int(math.Round(float64(maxBlurIters) * (1 - focus)))
-	frame := blurShape(shape, iters)
+	// Pixelation: chunky at phase 1, pixel-perfect at phase total.
+	blockSize := int(math.Round(float64(maxBlockSize) * (1 - focus)))
+	if blockSize < 1 {
+		blockSize = 1
+	}
+	frame := pixelateShape(shape, blockSize)
 
 	baseColor := LerpColor(greyStart, p.Color, focus)
+
+	// Texture ramp: 0 until textureStart, then linearly up to textureDensity.
+	var textureFrac float64
+	if focus > textureStart {
+		textureFrac = (focus - textureStart) / (1 - textureStart) * textureDensity
+	}
 
 	termRows := planets.ShapeRows / 2
 	var rows []string
@@ -137,10 +185,19 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 				line.WriteByte(' ')
 				line.WriteString(ansiReset)
 			case topOn && botOn:
-				topColor := scaleColor(baseColor, top)
-				botColor := scaleColor(baseColor, bot)
-				line.WriteString(fgBgAnsi(topColor, botColor))
-				line.WriteString(upperHalf)
+				// Braille texture overlay on fully-lit cells past textureStart.
+				if textureFrac > 0 && hash2(r, c) < textureFrac {
+					mid := (top + bot) * 0.5
+					bg := scaleColor(baseColor, mid)
+					fg := scaleColor(baseColor, math.Min(1, mid+textureContrast))
+					line.WriteString(fgBgAnsi(fg, bg))
+					line.WriteString(pickBraille(r, c))
+				} else {
+					topColor := scaleColor(baseColor, top)
+					botColor := scaleColor(baseColor, bot)
+					line.WriteString(fgBgAnsi(topColor, botColor))
+					line.WriteString(upperHalf)
+				}
 				line.WriteString(ansiReset)
 			case topOn:
 				topColor := scaleColor(baseColor, top)
@@ -159,34 +216,35 @@ func RenderPlanet(shape planets.Shape, p planets.Planet, phase, total int) strin
 	return strings.Join(rows, "\n")
 }
 
-// blurShape applies `iters` passes of a 3x3 box blur to s. Each pass smooths
-// edges and spreads shade outward; iterating many passes approximates a
-// Gaussian with sigma ≈ √iters. Out-of-bounds neighbors are treated as 0
-// so the halo fades to black at the frame edges.
-func blurShape(s planets.Shape, iters int) planets.Shape {
-	for i := 0; i < iters; i++ {
-		s = boxBlur3x3(s)
+// pixelateShape returns a new shape where every blockSize×blockSize region
+// of the input is flattened to the region's mean shade. blockSize <= 1
+// returns the input unchanged.
+func pixelateShape(s planets.Shape, blockSize int) planets.Shape {
+	if blockSize <= 1 {
+		return s
 	}
-	return s
-}
-
-func boxBlur3x3(s planets.Shape) planets.Shape {
 	var out planets.Shape
 	rows := planets.ShapeRows
 	cols := planets.ShapeCols
-	for r := 0; r < rows; r++ {
-		for c := 0; c < cols; c++ {
+	for blockR := 0; blockR < rows; blockR += blockSize {
+		for blockC := 0; blockC < cols; blockC += blockSize {
 			var sum float64
-			for dr := -1; dr <= 1; dr++ {
-				for dc := -1; dc <= 1; dc++ {
-					rr, cc := r+dr, c+dc
-					if rr < 0 || rr >= rows || cc < 0 || cc >= cols {
-						continue
-					}
-					sum += s[rr][cc]
+			var count int
+			for r := blockR; r < blockR+blockSize && r < rows; r++ {
+				for c := blockC; c < blockC+blockSize && c < cols; c++ {
+					sum += s[r][c]
+					count++
 				}
 			}
-			out[r][c] = sum / 9
+			mean := 0.0
+			if count > 0 {
+				mean = sum / float64(count)
+			}
+			for r := blockR; r < blockR+blockSize && r < rows; r++ {
+				for c := blockC; c < blockC+blockSize && c < cols; c++ {
+					out[r][c] = mean
+				}
+			}
 		}
 	}
 	return out

--- a/internal/overlay/render_test.go
+++ b/internal/overlay/render_test.go
@@ -33,39 +33,34 @@ func TestLerpColorReverseDirection(t *testing.T) {
 	}
 }
 
-func TestShadeToCharZero(t *testing.T) {
-	if got := ShadeToChar(0); got != " " {
-		t.Errorf("shade 0: got %q, want \" \"", got)
+func TestScaleColor(t *testing.T) {
+	rgb := [3]uint8{200, 100, 50}
+	if got := scaleColor(rgb, 0); got != ([3]uint8{0, 0, 0}) {
+		t.Errorf("shade 0: got %v, want black", got)
 	}
-}
-
-func TestShadeToCharBelowHaloThreshold(t *testing.T) {
-	// Dim blur tails below the halo threshold collapse to space so the
-	// halo fades to empty rather than fringing with ░.
-	if got := ShadeToChar(haloThreshold / 2); got != " " {
-		t.Errorf("sub-threshold shade: got %q, want \" \"", got)
+	if got := scaleColor(rgb, 1); got != rgb {
+		t.Errorf("shade 1: got %v, want %v", got, rgb)
 	}
-}
-
-func TestShadeToCharFullShadeReturnsDensest(t *testing.T) {
-	if got := ShadeToChar(1.0); got != "█" {
-		t.Errorf("shade 1.0: got %q, want \"█\"", got)
+	got := scaleColor(rgb, 0.5)
+	if got != ([3]uint8{100, 50, 25}) {
+		t.Errorf("shade 0.5: got %v, want [100 50 25]", got)
 	}
 }
 
 func TestRenderPlanetDimensions(t *testing.T) {
 	p := planets.MustGet("mercury")
 	shape := planets.GetShape("mercury")
-	out := RenderPlanet(shape, p, 1, 14)
+	out := RenderPlanet(shape, p, 14, 14)
 	lines := strings.Split(out, "\n")
-	if len(lines) != planets.ShapeRows {
-		t.Errorf("got %d lines, want %d", len(lines), planets.ShapeRows)
+	want := planets.ShapeRows / 2
+	if len(lines) != want {
+		t.Errorf("got %d lines, want %d (ShapeRows/2)", len(lines), want)
 	}
 }
 
 func TestRenderPlanetBlurryAtPhaseOne(t *testing.T) {
-	// At phase 1 the shape is maximally blurred, so the bright center cells
-	// of the sharp shape should render dimmer than they do at phase=total.
+	// At phase 1 the shape is maximally blurred, so early and late frames
+	// must differ visibly.
 	p := planets.MustGet("mercury")
 	shape := planets.GetShape("mercury")
 	early := RenderPlanet(shape, p, 1, 14)
@@ -80,9 +75,18 @@ func TestRenderPlanetContainsAnsiColor(t *testing.T) {
 	shape := planets.GetShape("mercury")
 	out := RenderPlanet(shape, p, 14, 14)
 	if !strings.Contains(out, "\x1b[38;2;") {
-		t.Error("expected truecolor ANSI escape in output")
+		t.Error("expected truecolor foreground ANSI escape in output")
 	}
 	if !strings.Contains(out, "\x1b[0m") {
 		t.Error("expected ANSI reset in output")
+	}
+}
+
+func TestRenderPlanetUsesHalfBlocks(t *testing.T) {
+	p := planets.MustGet("mercury")
+	shape := planets.GetShape("mercury")
+	out := RenderPlanet(shape, p, 14, 14)
+	if !strings.Contains(out, "▀") && !strings.Contains(out, "▄") {
+		t.Error("expected at least one half-block character (▀ or ▄) in output")
 	}
 }

--- a/internal/overlay/render_test.go
+++ b/internal/overlay/render_test.go
@@ -1,0 +1,91 @@
+package overlay
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elliottregan/cspace/internal/planets"
+)
+
+func TestLerpColorEndpoints(t *testing.T) {
+	from := [3]uint8{0, 0, 0}
+	to := [3]uint8{100, 200, 50}
+
+	if got := LerpColor(from, to, 0); got != from {
+		t.Errorf("t=0: got %v, want %v", got, from)
+	}
+	if got := LerpColor(from, to, 1); got != to {
+		t.Errorf("t=1: got %v, want %v", got, to)
+	}
+	got := LerpColor(from, to, 0.5)
+	if got != [3]uint8{50, 100, 25} {
+		t.Errorf("t=0.5: got %v, want [50 100 25]", got)
+	}
+}
+
+func TestLerpColorReverseDirection(t *testing.T) {
+	// Lerping from a lighter to a darker channel must not underflow uint8.
+	from := [3]uint8{200, 200, 200}
+	to := [3]uint8{50, 50, 50}
+	got := LerpColor(from, to, 0.5)
+	if got[0] != 125 || got[1] != 125 || got[2] != 125 {
+		t.Errorf("got %v, want [125 125 125]", got)
+	}
+}
+
+func TestShadeToCharZero(t *testing.T) {
+	for phase := 1; phase <= 6; phase++ {
+		if got := ShadeToChar(0, phase); got != " " {
+			t.Errorf("phase %d shade 0: got %q, want \" \"", phase, got)
+		}
+	}
+}
+
+func TestShadeToCharNonZero(t *testing.T) {
+	for phase := 1; phase <= 6; phase++ {
+		if got := ShadeToChar(1.0, phase); got == " " {
+			t.Errorf("phase %d shade 1.0: got space, want non-space", phase)
+		}
+	}
+}
+
+func TestShadeToCharPhase1Binary(t *testing.T) {
+	// Phase 1 palette has only "█" for non-zero shade.
+	for _, v := range []float64{0.1, 0.5, 0.9, 1.0} {
+		if got := ShadeToChar(v, 1); got != "█" {
+			t.Errorf("phase 1 shade %.1f: got %q, want \"█\"", v, got)
+		}
+	}
+}
+
+func TestRenderPlanetDimensions(t *testing.T) {
+	p := planets.MustGet("mercury")
+	shape := planets.GetShape("mercury")
+	out := RenderPlanet(shape, p, 1, 14)
+	lines := strings.Split(out, "\n")
+	if len(lines) != 6 {
+		t.Errorf("got %d lines, want 6", len(lines))
+	}
+}
+
+func TestRenderPlanetChangesAcrossPhases(t *testing.T) {
+	p := planets.MustGet("mercury")
+	shape := planets.GetShape("mercury")
+	early := RenderPlanet(shape, p, 1, 14)
+	late := RenderPlanet(shape, p, 14, 14)
+	if early == late {
+		t.Error("expected render to differ between phase 1 and phase 14")
+	}
+}
+
+func TestRenderPlanetContainsAnsiColor(t *testing.T) {
+	p := planets.MustGet("mercury")
+	shape := planets.GetShape("mercury")
+	out := RenderPlanet(shape, p, 14, 14)
+	if !strings.Contains(out, "\x1b[38;2;") {
+		t.Error("expected truecolor ANSI escape in output")
+	}
+	if !strings.Contains(out, "\x1b[0m") {
+		t.Error("expected ANSI reset in output")
+	}
+}

--- a/internal/overlay/render_test.go
+++ b/internal/overlay/render_test.go
@@ -34,27 +34,22 @@ func TestLerpColorReverseDirection(t *testing.T) {
 }
 
 func TestShadeToCharZero(t *testing.T) {
-	for phase := 1; phase <= 6; phase++ {
-		if got := ShadeToChar(0, phase); got != " " {
-			t.Errorf("phase %d shade 0: got %q, want \" \"", phase, got)
-		}
+	if got := ShadeToChar(0); got != " " {
+		t.Errorf("shade 0: got %q, want \" \"", got)
 	}
 }
 
-func TestShadeToCharNonZero(t *testing.T) {
-	for phase := 1; phase <= 6; phase++ {
-		if got := ShadeToChar(1.0, phase); got == " " {
-			t.Errorf("phase %d shade 1.0: got space, want non-space", phase)
-		}
+func TestShadeToCharBelowHaloThreshold(t *testing.T) {
+	// Dim blur tails below the halo threshold collapse to space so the
+	// halo fades to empty rather than fringing with ░.
+	if got := ShadeToChar(haloThreshold / 2); got != " " {
+		t.Errorf("sub-threshold shade: got %q, want \" \"", got)
 	}
 }
 
-func TestShadeToCharPhase1Binary(t *testing.T) {
-	// Phase 1 palette has only "█" for non-zero shade.
-	for _, v := range []float64{0.1, 0.5, 0.9, 1.0} {
-		if got := ShadeToChar(v, 1); got != "█" {
-			t.Errorf("phase 1 shade %.1f: got %q, want \"█\"", v, got)
-		}
+func TestShadeToCharFullShadeReturnsDensest(t *testing.T) {
+	if got := ShadeToChar(1.0); got != "█" {
+		t.Errorf("shade 1.0: got %q, want \"█\"", got)
 	}
 }
 
@@ -63,18 +58,20 @@ func TestRenderPlanetDimensions(t *testing.T) {
 	shape := planets.GetShape("mercury")
 	out := RenderPlanet(shape, p, 1, 14)
 	lines := strings.Split(out, "\n")
-	if len(lines) != 6 {
-		t.Errorf("got %d lines, want 6", len(lines))
+	if len(lines) != planets.ShapeRows {
+		t.Errorf("got %d lines, want %d", len(lines), planets.ShapeRows)
 	}
 }
 
-func TestRenderPlanetChangesAcrossPhases(t *testing.T) {
+func TestRenderPlanetBlurryAtPhaseOne(t *testing.T) {
+	// At phase 1 the shape is maximally blurred, so the bright center cells
+	// of the sharp shape should render dimmer than they do at phase=total.
 	p := planets.MustGet("mercury")
 	shape := planets.GetShape("mercury")
 	early := RenderPlanet(shape, p, 1, 14)
 	late := RenderPlanet(shape, p, 14, 14)
 	if early == late {
-		t.Error("expected render to differ between phase 1 and phase 14")
+		t.Error("expected render to differ between phase 1 (blurry) and phase 14 (sharp)")
 	}
 }
 

--- a/internal/planets/planets.go
+++ b/internal/planets/planets.go
@@ -1,0 +1,57 @@
+// Package planets loads the canonical planet visual config shared between
+// the provisioning overlay and the in-container statusline.
+package planets
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/elliottregan/cspace/internal/assets"
+)
+
+// Planet describes how a single planet renders: unicode symbol, canonical
+// 24-bit color, and a complementary accent color for band/detail shading.
+type Planet struct {
+	Symbol string   `json:"symbol"`
+	Color  [3]uint8 `json:"color"`
+	Accent [3]uint8 `json:"accent"`
+}
+
+type planetsFile struct {
+	Planets map[string]Planet `json:"planets"`
+}
+
+var all map[string]Planet
+
+func init() {
+	data, err := assets.EmbeddedFS.ReadFile("embedded/planets.json")
+	if err != nil {
+		panic(fmt.Sprintf("planets: reading embedded planets.json: %v", err))
+	}
+	var f planetsFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		panic(fmt.Sprintf("planets: unmarshal planets.json: %v", err))
+	}
+	all = f.Planets
+}
+
+// Get returns the Planet config for name. The second return value is false
+// when the name is not a known planet.
+func Get(name string) (Planet, bool) {
+	p, ok := all[name]
+	return p, ok
+}
+
+// MustGet returns Get(name) on hit, or a neutral grey fallback otherwise.
+// Callers use this when the instance name was user-provided and may not
+// correspond to a known planet (e.g. a custom instance name like "ci-bot").
+func MustGet(name string) Planet {
+	if p, ok := all[name]; ok {
+		return p
+	}
+	return Planet{
+		Symbol: "●",
+		Color:  [3]uint8{128, 128, 128},
+		Accent: [3]uint8{90, 90, 90},
+	}
+}

--- a/internal/planets/planets_test.go
+++ b/internal/planets/planets_test.go
@@ -41,12 +41,12 @@ func TestGetShapeDimensions(t *testing.T) {
 	names := []string{"mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"}
 	for _, name := range names {
 		s := GetShape(name)
-		if len(s) != 6 {
-			t.Errorf("%s: got %d rows, want 6", name, len(s))
+		if len(s) != ShapeRows {
+			t.Errorf("%s: got %d rows, want %d", name, len(s), ShapeRows)
 		}
 		for r, row := range s {
-			if len(row) != 12 {
-				t.Errorf("%s row %d: got %d cols, want 12", name, r, len(row))
+			if len(row) != ShapeCols {
+				t.Errorf("%s row %d: got %d cols, want %d", name, r, len(row), ShapeCols)
 			}
 		}
 	}
@@ -56,17 +56,20 @@ func TestGetShapeUnknown(t *testing.T) {
 	// Unknown names should fall back to the mercury shape so custom
 	// instance names still render something.
 	s := GetShape("ci-bot")
-	if len(s) != 6 {
-		t.Errorf("fallback shape: got %d rows, want 6", len(s))
+	if len(s) != ShapeRows {
+		t.Errorf("fallback shape: got %d rows, want %d", len(s), ShapeRows)
 	}
 }
 
 func TestShapeValuesInRange(t *testing.T) {
-	s := GetShape("mercury")
-	for r, row := range s {
-		for c, v := range row {
-			if v < 0 || v > 1 {
-				t.Errorf("mercury[%d][%d] = %v, must be in [0,1]", r, c, v)
+	names := []string{"mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"}
+	for _, name := range names {
+		s := GetShape(name)
+		for r, row := range s {
+			for c, v := range row {
+				if v < 0 || v > 1 {
+					t.Errorf("%s[%d][%d] = %v, must be in [0,1]", name, r, c, v)
+				}
 			}
 		}
 	}

--- a/internal/planets/planets_test.go
+++ b/internal/planets/planets_test.go
@@ -1,0 +1,38 @@
+package planets
+
+import "testing"
+
+func TestGetMercury(t *testing.T) {
+	p, ok := Get("mercury")
+	if !ok {
+		t.Fatal("expected mercury to be present")
+	}
+	if p.Symbol != "☿" {
+		t.Errorf("symbol: got %q, want ☿", p.Symbol)
+	}
+	if p.Color != [3]uint8{169, 169, 169} {
+		t.Errorf("color: got %v, want [169 169 169]", p.Color)
+	}
+}
+
+func TestGetUnknown(t *testing.T) {
+	if _, ok := Get("pluto"); ok {
+		t.Error("expected pluto to be absent")
+	}
+}
+
+func TestMustGetFallback(t *testing.T) {
+	p := MustGet("pluto")
+	if p.Symbol == "" {
+		t.Error("expected non-empty fallback symbol")
+	}
+}
+
+func TestAllPlanetsPresent(t *testing.T) {
+	want := []string{"mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"}
+	for _, name := range want {
+		if _, ok := Get(name); !ok {
+			t.Errorf("missing planet %q", name)
+		}
+	}
+}

--- a/internal/planets/planets_test.go
+++ b/internal/planets/planets_test.go
@@ -55,9 +55,8 @@ func TestGetShapeDimensions(t *testing.T) {
 func TestGetShapeUnknown(t *testing.T) {
 	// Unknown names should fall back to the mercury shape so custom
 	// instance names still render something.
-	s := GetShape("ci-bot")
-	if len(s) != ShapeRows {
-		t.Errorf("fallback shape: got %d rows, want %d", len(s), ShapeRows)
+	if got, want := GetShape("ci-bot"), GetShape("mercury"); got != want {
+		t.Error("expected unknown names to fall back to the mercury shape")
 	}
 }
 

--- a/internal/planets/planets_test.go
+++ b/internal/planets/planets_test.go
@@ -36,3 +36,38 @@ func TestAllPlanetsPresent(t *testing.T) {
 		}
 	}
 }
+
+func TestGetShapeDimensions(t *testing.T) {
+	names := []string{"mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"}
+	for _, name := range names {
+		s := GetShape(name)
+		if len(s) != 6 {
+			t.Errorf("%s: got %d rows, want 6", name, len(s))
+		}
+		for r, row := range s {
+			if len(row) != 12 {
+				t.Errorf("%s row %d: got %d cols, want 12", name, r, len(row))
+			}
+		}
+	}
+}
+
+func TestGetShapeUnknown(t *testing.T) {
+	// Unknown names should fall back to the mercury shape so custom
+	// instance names still render something.
+	s := GetShape("ci-bot")
+	if len(s) != 6 {
+		t.Errorf("fallback shape: got %d rows, want 6", len(s))
+	}
+}
+
+func TestShapeValuesInRange(t *testing.T) {
+	s := GetShape("mercury")
+	for r, row := range s {
+		for c, v := range row {
+			if v < 0 || v > 1 {
+				t.Errorf("mercury[%d][%d] = %v, must be in [0,1]", r, c, v)
+			}
+		}
+	}
+}

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -4,10 +4,7 @@ import "math"
 
 // Shape dimensions: 48 rows × 48 cols of SUB-pixels. Rendering pairs
 // consecutive rows into one terminal line using the ▀/▄ half-block
-// characters, so output is ShapeRows/2 = 24 terminal rows tall. With
-// subpixels counted as 1 visual unit and terminal chars as 1 unit wide
-// × 2 units tall, this gives a square unit space and a visually round
-// disk when rx == ry in sphereShape.
+// characters, so output is ShapeRows/2 = 24 terminal rows tall.
 const (
 	ShapeRows = 48
 	ShapeCols = 48
@@ -18,22 +15,25 @@ const (
 // character selected from a phase-specific palette.
 type Shape = [ShapeRows][ShapeCols]float64
 
-// lightDir points from the sphere surface toward the directional key light.
-// Slightly up-left-of-viewer so the bright spot sits in the upper-left
-// quadrant of the disk and the terminator shadow falls toward the lower
-// right — a classic 3D-sphere lighting setup.
+// Overlay is a secondary surface feature applied on top of the base
+// terrain during rendering: at each cell, the base color is blended
+// toward Color by the overlay's shade value. Used for clouds (white),
+// Jupiter's Great Red Spot (red), etc.
+type Overlay struct {
+	Shape Shape
+	Color [3]uint8
+}
+
+// lightDir: classic 3D-sphere key light slightly up-left-of-viewer.
 var lightDir = [3]float64{-0.40, -0.30, 0.85}
 
-// ambient is the base illumination on the shadowed hemisphere. Above 0 so
-// the silhouette stays visible past the terminator; low enough that the
-// directional shadow is clearly asymmetric.
+// ambient: base illumination on the shadow side so the silhouette stays
+// visible past the terminator.
 const ambient = 0.18
 
-// sphereShape produces a directionally lit elliptical disk centered at
-// (cx, cy) with semi-axes (rx, ry) in unit space. Each in-disk cell is
-// treated as a point on a 3D unit sphere: surface normal N = (dx, dy, z),
-// shade = ambient + (1 - ambient) · max(0, N · lightDir). This offsets the
-// bright spot from geometric center, producing a visible shadow.
+// sphereShape produces a directionally lit disk centered at (cx, cy)
+// with semi-axes (rx, ry). Shading uses a Lambertian model with the
+// light direction defined above.
 func sphereShape(cx, cy, rx, ry float64) Shape {
 	var s Shape
 	for r := 0; r < ShapeRows; r++ {
@@ -61,20 +61,6 @@ func sphereShape(cx, cy, rx, ry float64) Shape {
 	return s
 }
 
-// applyBands dims every other band of `period` rows by `dim`, producing
-// the horizontal stripes characteristic of gas giants.
-func applyBands(s Shape, period int, dim float64) Shape {
-	for r := 0; r < ShapeRows; r++ {
-		if (r/period)%2 == 0 {
-			continue
-		}
-		for c := 0; c < ShapeCols; c++ {
-			s[r][c] *= dim
-		}
-	}
-	return s
-}
-
 // applyPolarCap brightens the top `rows` rows of a shape by `boost`,
 // clamping to 1.0. Used for Mars's northern ice cap.
 func applyPolarCap(s Shape, rows int, boost float64) Shape {
@@ -92,101 +78,256 @@ func applyPolarCap(s Shape, rows int, boost float64) Shape {
 	return s
 }
 
-// applyRings overlays Saturn-like rings centered on the equator, one
-// subpixel row thick. Three bands plus a Cassini-style gap:
-//
-//	[body] | A-ring (bright) | gap (dim) | B-ring (medium) | taper
-//
-// The body's shadow passes in front of the rings naturally because
-// sphereShape has already filled the body rows at a higher shade than
-// the ring shades, so `if shade > s[row][c]` preserves the body.
-func applyRings(s Shape, bodyRx float64) Shape {
-	// Two thin equatorial subpixel rows; very thin elliptical disc.
-	midRow := ShapeRows / 2
-	rows := []int{midRow - 1, midRow}
-
-	// Ring bands: (innerX, outerX, shade). Measured from center; symmetric
-	// around x=0.5.
-	bands := []struct{ inner, outer, shade float64 }{
-		{bodyRx + 0.015, bodyRx + 0.065, 0.90}, // inner bright ring (A)
-		{bodyRx + 0.075, bodyRx + 0.090, 0.30}, // Cassini gap
-		{bodyRx + 0.100, 0.470, 0.75},          // outer ring (B)
+// applyJupiterBands applies latitude-based bands with soft top/bottom
+// edges and a small positional noise term so the bands curve with the
+// sphere (narrower at poles, wider at equator) and look turbulent rather
+// than drawn with a ruler.
+func applyJupiterBands(s Shape) Shape {
+	type band struct{ minDy, maxDy, dim float64 }
+	bands := []band{
+		{-0.95, -0.72, 0.62},
+		{-0.68, -0.48, 0.90},
+		{-0.44, -0.22, 0.58}, // NEB
+		{-0.18, 0.06, 0.94},  // EZ
+		{0.10, 0.32, 0.60},   // SEB
+		{0.36, 0.56, 0.88},
+		{0.60, 0.82, 0.64},
 	}
-
-	for i, row := range rows {
-		if row < 0 || row >= ShapeRows {
-			continue
-		}
-		// Upper and lower subpixel rows at the equator get slightly less
-		// intensity than the true center row so the ring reads as very
-		// thin rather than a solid slab.
-		rowScale := 1.0
-		if i == 0 {
-			rowScale = 0.55
-		}
+	const bodyR = 0.47
+	const edge = 0.045
+	for r := 0; r < ShapeRows; r++ {
 		for c := 0; c < ShapeCols; c++ {
-			x := (float64(c) + 0.5) / float64(ShapeCols)
-			d := math.Abs(x - 0.5)
+			if s[r][c] == 0 {
+				continue
+			}
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			dy := (y - 0.5) / bodyR
+			shade := 1.0
 			for _, b := range bands {
-				if d < b.inner || d > b.outer {
+				if dy < b.minDy || dy > b.maxDy {
 					continue
 				}
-				// Fade at extreme outer edge so rings don't hard-cut at
-				// the frame edge.
-				taper := 1.0
-				if d > 0.42 {
-					taper = (0.47 - d) / 0.05
-					if taper < 0 {
-						taper = 0
-					}
+				dim := b.dim
+				if dy-b.minDy < edge {
+					t := (dy - b.minDy) / edge
+					dim = 1 + (dim-1)*t
+				} else if b.maxDy-dy < edge {
+					t := (b.maxDy - dy) / edge
+					dim = 1 + (dim-1)*t
 				}
-				shade := b.shade * rowScale * taper
-				if shade > s[row][c] {
-					s[row][c] = shade
-				}
+				shade = dim
 				break
+			}
+			// Turbulence: small per-cell jitter.
+			noise := (shapeHash(r, c) - 0.5) * 0.06
+			shade += noise
+			if shade < 0.30 {
+				shade = 0.30
+			}
+			if shade > 1 {
+				shade = 1
+			}
+			s[r][c] *= shade
+		}
+	}
+	return s
+}
+
+// applyRings wraps Saturn-style rings around a sphere. The ring is a
+// thin tilted ellipse (ringRx × ringRy). Where the ring passes below
+// the sphere's equator it is drawn IN FRONT of the sphere; above the
+// equator the sphere occludes the ring. Three concentric bands with a
+// Cassini-style gap produce the striped disk look.
+func applyRings(s Shape, bodyRx float64) Shape {
+	const (
+		ringRx = 0.48
+		ringRy = 0.10
+	)
+	innerU := bodyRx/ringRx + 0.08
+	bands := []struct{ inner, outer, shade float64 }{
+		{innerU, innerU + 0.18, 0.88},        // inner bright ring (A)
+		{innerU + 0.20, innerU + 0.24, 0.22}, // Cassini gap
+		{innerU + 0.26, 0.98, 0.74},          // outer ring (B)
+	}
+	const edgeFade = 0.015
+	for r := 0; r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			dx := (x - 0.5) / ringRx
+			dy := (y - 0.5) / ringRy
+			u := math.Sqrt(dx*dx + dy*dy)
+
+			var ringShade float64
+			for _, b := range bands {
+				if u < b.inner || u > b.outer {
+					continue
+				}
+				shade := b.shade
+				if u-b.inner < edgeFade {
+					shade *= (u - b.inner) / edgeFade
+				}
+				if b.outer-u < edgeFade {
+					shade *= (b.outer - u) / edgeFade
+				}
+				ringShade = shade
+				break
+			}
+			if ringShade == 0 {
+				continue
+			}
+
+			// Check sphere occlusion. The front half of the ring (below
+			// the equator line in screen space) draws over the sphere;
+			// the back half is hidden where the sphere overlaps.
+			frontSide := y > 0.5
+			sDx := (x - 0.5) / bodyRx
+			sDy := (y - 0.5) / bodyRx
+			inSphere := sDx*sDx+sDy*sDy < 1
+			if inSphere && !frontSide {
+				continue
+			}
+			if ringShade > s[r][c] {
+				s[r][c] = ringShade
 			}
 		}
 	}
 	return s
 }
 
-// applyContinents darkens a scattered set of interior cells to suggest
-// landmasses. Patch centers are normalized so they stay inside the disk
-// across any grid size.
-func applyContinents(s Shape) Shape {
-	patches := [][2]float64{
-		{0.35, 0.35}, {0.40, 0.30}, {0.30, 0.45},
-		{0.62, 0.40}, {0.68, 0.55}, {0.55, 0.65},
-		{0.42, 0.62}, {0.72, 0.30}, {0.48, 0.75},
+// earthCloudShape generates soft wispy cloud patches scattered across
+// the disk — used as an Overlay to produce bright white puffs over the
+// blue base.
+func earthCloudShape() Shape {
+	patches := []struct{ cx, cy, rx, ry, intensity float64 }{
+		{0.28, 0.32, 0.10, 0.05, 0.85},
+		{0.52, 0.24, 0.11, 0.04, 0.72},
+		{0.68, 0.44, 0.11, 0.05, 0.80},
+		{0.40, 0.52, 0.09, 0.05, 0.60},
+		{0.24, 0.52, 0.08, 0.04, 0.62},
+		{0.60, 0.60, 0.12, 0.05, 0.72},
+		{0.38, 0.72, 0.10, 0.05, 0.65},
+		{0.72, 0.30, 0.08, 0.03, 0.50},
+		{0.48, 0.40, 0.07, 0.03, 0.55},
 	}
-	dRow := ShapeRows / 24
-	dCol := ShapeCols / 12
-	for _, p := range patches {
-		rc := int(p[1] * float64(ShapeRows))
-		cc := int(p[0] * float64(ShapeCols))
-		for dr := -dRow; dr <= dRow; dr++ {
-			for dc := -dCol; dc <= dCol; dc++ {
-				r, c := rc+dr, cc+dc
-				if r < 0 || r >= ShapeRows || c < 0 || c >= ShapeCols {
+	const bodyR = 0.45
+	var s Shape
+	for r := 0; r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			bdx := (x - 0.5) / bodyR
+			bdy := (y - 0.5) / bodyR
+			if bdx*bdx+bdy*bdy >= 1 {
+				continue
+			}
+			var intensity float64
+			for _, p := range patches {
+				dx := (x - p.cx) / p.rx
+				dy := (y - p.cy) / p.ry
+				d2 := dx*dx + dy*dy
+				if d2 >= 1 {
 					continue
 				}
-				if s[r][c] > 0 {
-					s[r][c] *= 0.60
+				v := p.intensity * math.Exp(-d2*2.5)
+				if v > intensity {
+					intensity = v
 				}
 			}
+			// Wispy positional noise.
+			noise := (shapeHash(r, c) - 0.5) * 0.18
+			intensity += noise
+			if intensity < 0 {
+				intensity = 0
+			}
+			if intensity > 1 {
+				intensity = 1
+			}
+			s[r][c] = intensity
 		}
 	}
 	return s
+}
+
+// venusCloudShape creates swirling cloud bands — used as an Overlay
+// with a warm cream color to produce Venus's thick haze.
+func venusCloudShape() Shape {
+	const bodyR = 0.47
+	var s Shape
+	for r := 0; r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			bdx := (x - 0.5) / bodyR
+			bdy := (y - 0.5) / bodyR
+			if bdx*bdx+bdy*bdy >= 1 {
+				continue
+			}
+			// Two overlapping sine fields give a swirling look.
+			v := 0.30 * (math.Sin(11*x+7*y+1.2) + math.Sin(17*x-6*y+3.3))
+			v = 0.5 + v*0.3
+			// Soft fade toward the silhouette edge.
+			rad := math.Sqrt(bdx*bdx + bdy*bdy)
+			if rad > 0.80 {
+				v *= (1.0 - rad) / 0.20
+			}
+			if v < 0 {
+				v = 0
+			}
+			if v > 0.85 {
+				v = 0.85
+			}
+			s[r][c] = v
+		}
+	}
+	return s
+}
+
+// jupiterRedSpotShape returns a small elliptical cloud for the Great
+// Red Spot — used as an Overlay with a muted red color on top of
+// Jupiter's banded base.
+func jupiterRedSpotShape() Shape {
+	const (
+		cx = 0.62
+		cy = 0.62
+		rx = 0.08
+		ry = 0.038
+	)
+	var s Shape
+	for r := 0; r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			dx := (x - cx) / rx
+			dy := (y - cy) / ry
+			d2 := dx*dx + dy*dy
+			if d2 >= 1 {
+				continue
+			}
+			s[r][c] = 0.88 * math.Exp(-d2*2.0)
+		}
+	}
+	return s
+}
+
+// shapeHash is a cheap deterministic float in [0,1) keyed on (r, c).
+// Reused by both shapes.go and overlay/render.go so the noise patterns
+// stay stable across frames.
+func shapeHash(r, c int) float64 {
+	h := uint32(r)*73856093 ^ uint32(c)*19349663
+	h ^= h >> 13
+	h *= 0x5bd1e995
+	h ^= h >> 15
+	return float64(h%10000) / 10000.0
 }
 
 var (
 	mercurySimpleSphere = sphereShape(0.5, 0.5, 0.46, 0.46)
 	venusUniformHaze    = sphereShape(0.5, 0.5, 0.47, 0.47)
-	earthContinents     = applyContinents(sphereShape(0.5, 0.5, 0.45, 0.45))
+	earthBaseSphere     = sphereShape(0.5, 0.5, 0.45, 0.45)
 	marsPolarCap        = applyPolarCap(sphereShape(0.5, 0.5, 0.43, 0.43), 10, 1.25)
-	jupiterBands        = applyBands(sphereShape(0.5, 0.5, 0.47, 0.47), 6, 0.70)
-	saturnRings         = applyRings(sphereShape(0.5, 0.5, 0.32, 0.32), 0.32)
+	jupiterBands        = applyJupiterBands(sphereShape(0.5, 0.5, 0.47, 0.47))
+	saturnRings         = applyRings(sphereShape(0.5, 0.5, 0.26, 0.26), 0.26)
 	uranusSmallSphere   = sphereShape(0.5, 0.5, 0.40, 0.40)
 	neptuneDenseCore    = sphereShape(0.5, 0.5, 0.40, 0.40)
 )
@@ -194,7 +335,7 @@ var (
 var shapes = map[string]Shape{
 	"mercury": mercurySimpleSphere,
 	"venus":   venusUniformHaze,
-	"earth":   earthContinents,
+	"earth":   earthBaseSphere,
 	"mars":    marsPolarCap,
 	"jupiter": jupiterBands,
 	"saturn":  saturnRings,
@@ -202,11 +343,27 @@ var shapes = map[string]Shape{
 	"neptune": neptuneDenseCore,
 }
 
-// GetShape returns the shade grid for the named planet. Unknown names
-// fall back to the mercury sphere so custom instance names still render.
+// GetShape returns the base shade grid for the named planet. Unknown
+// names fall back to the mercury sphere so custom instance names still
+// render.
 func GetShape(name string) Shape {
 	if s, ok := shapes[name]; ok {
 		return s
 	}
 	return mercurySimpleSphere
+}
+
+// planetOverlays holds per-planet surface features that color-blend
+// onto the base terrain during rendering. Earth gets white clouds,
+// Venus gets warm haze, Jupiter gets a red spot.
+var planetOverlays = map[string][]Overlay{
+	"earth":   {{Shape: earthCloudShape(), Color: [3]uint8{250, 250, 250}}},
+	"venus":   {{Shape: venusCloudShape(), Color: [3]uint8{255, 240, 200}}},
+	"jupiter": {{Shape: jupiterRedSpotShape(), Color: [3]uint8{175, 55, 35}}},
+}
+
+// GetOverlays returns the per-planet color overlays, or nil if the
+// planet has none.
+func GetOverlays(name string) []Overlay {
+	return planetOverlays[name]
 }

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -1,0 +1,106 @@
+package planets
+
+// Shape is a 6-row × 12-col grid of shade values in [0.0, 1.0] describing
+// how a planet renders. Each cell is one terminal character. 0.0 = empty,
+// 1.0 = maximum intensity.
+type Shape = [6][12]float64
+
+// mercurySimpleSphere — featureless silvery sphere, linear falloff.
+var mercurySimpleSphere = Shape{
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
+	{0.0, 0.3, 0.7, 0.9, 1.0, 1.0, 1.0, 0.9, 0.7, 0.5, 0.2, 0.0},
+	{0.0, 0.3, 0.7, 0.9, 1.0, 1.0, 1.0, 0.9, 0.7, 0.5, 0.2, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+}
+
+// venusUniformHaze — thick bright atmosphere, nearly uniform disk.
+var venusUniformHaze = Shape{
+	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.5, 0.8, 0.9, 0.9, 0.9, 0.9, 0.8, 0.5, 0.0, 0.0},
+	{0.0, 0.4, 0.8, 0.9, 0.9, 1.0, 1.0, 0.9, 0.9, 0.7, 0.3, 0.0},
+	{0.0, 0.4, 0.8, 0.9, 0.9, 1.0, 1.0, 0.9, 0.9, 0.7, 0.3, 0.0},
+	{0.0, 0.0, 0.5, 0.8, 0.9, 0.9, 0.9, 0.9, 0.8, 0.5, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+}
+
+// earthContinents — irregular shading suggests land/sea contrast.
+var earthContinents = Shape{
+	{0.0, 0.0, 0.0, 0.3, 0.6, 0.7, 0.7, 0.6, 0.3, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.5, 0.8, 0.7, 0.9, 0.9, 0.8, 0.6, 0.3, 0.0, 0.0},
+	{0.0, 0.3, 0.6, 0.7, 0.9, 1.0, 0.8, 0.9, 0.7, 0.4, 0.1, 0.0},
+	{0.0, 0.2, 0.7, 0.9, 0.8, 1.0, 1.0, 0.7, 0.8, 0.5, 0.2, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.9, 0.8, 0.9, 0.8, 0.6, 0.3, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+}
+
+// marsPolarCap — top row slightly brighter than bottom, hint of northern ice cap.
+var marsPolarCap = Shape{
+	{0.0, 0.0, 0.0, 0.3, 0.6, 0.8, 0.8, 0.6, 0.3, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
+	{0.0, 0.3, 0.6, 0.8, 0.9, 1.0, 1.0, 0.9, 0.7, 0.4, 0.1, 0.0},
+	{0.0, 0.2, 0.5, 0.8, 0.9, 1.0, 1.0, 0.9, 0.7, 0.4, 0.1, 0.0},
+	{0.0, 0.0, 0.3, 0.6, 0.7, 0.8, 0.8, 0.7, 0.5, 0.3, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.2, 0.4, 0.5, 0.5, 0.4, 0.2, 0.0, 0.0, 0.0},
+}
+
+// jupiterBands — alternating rows with different core intensity read as horizontal bands.
+var jupiterBands = Shape{
+	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+	{0.0, 0.2, 0.5, 0.8, 1.0, 1.0, 1.0, 0.9, 0.6, 0.2, 0.0, 0.0},
+	{0.0, 0.2, 0.6, 0.8, 0.9, 1.0, 1.0, 0.8, 0.7, 0.4, 0.1, 0.0},
+	{0.0, 0.1, 0.5, 0.8, 1.0, 1.0, 1.0, 0.9, 0.6, 0.3, 0.0, 0.0},
+	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+}
+
+// saturnRings — sphere in middle 4 rows, ring extends to cols 0-1 and 10-11 on the equator.
+var saturnRings = Shape{
+	{0.0, 0.0, 0.0, 0.0, 0.4, 0.6, 0.6, 0.4, 0.0, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.2, 0.6, 0.9, 1.0, 1.0, 0.9, 0.6, 0.2, 0.0, 0.0},
+	{0.3, 0.4, 0.5, 0.7, 0.9, 1.0, 1.0, 0.9, 0.7, 0.5, 0.4, 0.3},
+	{0.3, 0.4, 0.5, 0.7, 0.9, 1.0, 1.0, 0.9, 0.7, 0.5, 0.4, 0.3},
+	{0.0, 0.0, 0.2, 0.6, 0.9, 1.0, 1.0, 0.9, 0.6, 0.2, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.0, 0.4, 0.6, 0.6, 0.4, 0.0, 0.0, 0.0, 0.0},
+}
+
+// uranusSmallSphere — smaller, uniform disk (Uranus reads as a featureless blue-green ball).
+var uranusSmallSphere = Shape{
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.3, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.3, 0.0, 0.0},
+	{0.0, 0.2, 0.6, 0.8, 0.9, 1.0, 1.0, 0.9, 0.8, 0.6, 0.2, 0.0},
+	{0.0, 0.2, 0.6, 0.8, 0.9, 1.0, 1.0, 0.9, 0.8, 0.6, 0.2, 0.0},
+	{0.0, 0.0, 0.3, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.3, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+}
+
+// neptuneDenseCore — smaller, darker-edged disk with bright concentrated core.
+var neptuneDenseCore = Shape{
+	{0.0, 0.0, 0.0, 0.0, 0.3, 0.5, 0.5, 0.3, 0.0, 0.0, 0.0, 0.0},
+	{0.0, 0.0, 0.2, 0.5, 0.7, 0.8, 0.8, 0.7, 0.5, 0.2, 0.0, 0.0},
+	{0.0, 0.1, 0.5, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.5, 0.1, 0.0},
+	{0.0, 0.1, 0.5, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.5, 0.1, 0.0},
+	{0.0, 0.0, 0.2, 0.5, 0.7, 0.8, 0.8, 0.7, 0.5, 0.2, 0.0, 0.0},
+	{0.0, 0.0, 0.0, 0.0, 0.3, 0.5, 0.5, 0.3, 0.0, 0.0, 0.0, 0.0},
+}
+
+var shapes = map[string]Shape{
+	"mercury": mercurySimpleSphere,
+	"venus":   venusUniformHaze,
+	"earth":   earthContinents,
+	"mars":    marsPolarCap,
+	"jupiter": jupiterBands,
+	"saturn":  saturnRings,
+	"uranus":  uranusSmallSphere,
+	"neptune": neptuneDenseCore,
+}
+
+// GetShape returns the shade grid for the named planet. Unknown names fall
+// back to the mercury sphere so custom instance names still render.
+func GetShape(name string) Shape {
+	if s, ok := shapes[name]; ok {
+		return s
+	}
+	return mercurySimpleSphere
+}

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -195,21 +195,36 @@ func applyRings(s Shape, bodyRx float64) Shape {
 	return s
 }
 
-// earthCloudShape generates soft wispy cloud patches scattered across
-// the disk — used as an Overlay to produce bright white puffs over the
-// blue base.
+// earthCloudShape generates large, overlapping, wispy cloud formations
+// that read as weather systems rather than discrete spots. The result
+// is additive — overlapping formations accumulate into bigger cloud
+// masses — and modulated by multi-scale sine noise for turbulent
+// fringes and finer positional noise for stippled edges.
 func earthCloudShape() Shape {
-	patches := []struct{ cx, cy, rx, ry, intensity float64 }{
-		{0.28, 0.32, 0.10, 0.05, 0.85},
-		{0.52, 0.24, 0.11, 0.04, 0.72},
-		{0.68, 0.44, 0.11, 0.05, 0.80},
-		{0.40, 0.52, 0.09, 0.05, 0.60},
-		{0.24, 0.52, 0.08, 0.04, 0.62},
-		{0.60, 0.60, 0.12, 0.05, 0.72},
-		{0.38, 0.72, 0.10, 0.05, 0.65},
-		{0.72, 0.30, 0.08, 0.03, 0.50},
-		{0.48, 0.40, 0.07, 0.03, 0.55},
+	// Wide, elongated formations. Horizontal > vertical so they read as
+	// atmospheric bands and fronts rather than round puffs. Placed to
+	// overlap in clusters.
+	formations := []struct{ cx, cy, rx, ry, intensity float64 }{
+		// Tropical/equatorial band (overlapping cluster crossing the disk)
+		{0.22, 0.40, 0.16, 0.06, 0.72},
+		{0.36, 0.36, 0.15, 0.05, 0.82},
+		{0.48, 0.42, 0.18, 0.06, 0.88},
+		{0.60, 0.38, 0.17, 0.05, 0.80},
+		{0.72, 0.44, 0.13, 0.07, 0.70},
+		// Northern mid-latitudes — storm track
+		{0.28, 0.22, 0.13, 0.05, 0.70},
+		{0.42, 0.18, 0.11, 0.04, 0.60},
+		{0.58, 0.24, 0.16, 0.05, 0.72},
+		// Southern hemisphere front
+		{0.24, 0.64, 0.15, 0.06, 0.72},
+		{0.40, 0.72, 0.19, 0.05, 0.82},
+		{0.58, 0.68, 0.16, 0.06, 0.76},
+		{0.72, 0.62, 0.12, 0.05, 0.62},
+		// Polar wisps — thin broad streaks near the silhouette
+		{0.50, 0.12, 0.20, 0.04, 0.55},
+		{0.50, 0.86, 0.20, 0.04, 0.55},
 	}
+
 	const bodyR = 0.45
 	var s Shape
 	for r := 0; r < ShapeRows; r++ {
@@ -221,22 +236,37 @@ func earthCloudShape() Shape {
 			if bdx*bdx+bdy*bdy >= 1 {
 				continue
 			}
+
+			// Additive accumulation of formation contributions. Gentle
+			// Gaussian falloff reaches past d²=1 so edges taper softly;
+			// per-formation weight keeps overlaps from clipping too fast.
 			var intensity float64
-			for _, p := range patches {
+			for _, p := range formations {
 				dx := (x - p.cx) / p.rx
 				dy := (y - p.cy) / p.ry
 				d2 := dx*dx + dy*dy
-				if d2 >= 1 {
+				if d2 >= 1.8 {
 					continue
 				}
-				v := p.intensity * math.Exp(-d2*2.5)
-				if v > intensity {
-					intensity = v
-				}
+				intensity += 0.55 * p.intensity * math.Exp(-d2*1.1)
 			}
-			// Wispy positional noise.
-			noise := (shapeHash(r, c) - 0.5) * 0.18
-			intensity += noise
+
+			// Multi-scale sine noise gives turbulent wispy edges. Three
+			// octaves with decreasing amplitude / increasing frequency.
+			wisp := 0.14 * math.Sin(8*x+4*y+0.7)
+			wisp += 0.08 * math.Sin(16*x-6*y+2.3)
+			wisp += 0.05 * math.Sin(24*x+11*y+4.1)
+
+			// Apply wispy modulation stronger where clouds already
+			// exist so it shapes the fringes rather than creating
+			// random puffs in clear sky.
+			if intensity > 0.04 {
+				intensity += wisp * math.Min(1.0, intensity*1.8)
+			}
+
+			// Fine per-cell noise for stippled edge detail.
+			intensity += (shapeHash(r, c) - 0.5) * 0.10
+
 			if intensity < 0 {
 				intensity = 0
 			}

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -1,89 +1,130 @@
 package planets
 
-// Shape is a 6-row × 12-col grid of shade values in [0.0, 1.0] describing
-// how a planet renders. Each cell is one terminal character. 0.0 = empty,
-// 1.0 = maximum intensity.
-type Shape = [6][12]float64
+import "math"
 
-// mercurySimpleSphere — featureless silvery sphere, linear falloff.
-var mercurySimpleSphere = Shape{
-	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
-	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
-	{0.0, 0.3, 0.7, 0.9, 1.0, 1.0, 1.0, 0.9, 0.7, 0.5, 0.2, 0.0},
-	{0.0, 0.3, 0.7, 0.9, 1.0, 1.0, 1.0, 0.9, 0.7, 0.5, 0.2, 0.0},
-	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
-	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+// Shape dimensions: 10 rows × 24 cols. The 2.4:1 column:row ratio
+// compensates for typical terminal char aspect (~0.5 w/h), yielding
+// a visually round disk.
+const (
+	ShapeRows = 10
+	ShapeCols = 24
+)
+
+// Shape is a row × col grid of shade values in [0.0, 1.0]. 0.0 = empty,
+// 1.0 = maximum intensity. Consumers render each cell as one terminal
+// character selected from a phase-specific palette.
+type Shape = [ShapeRows][ShapeCols]float64
+
+// sphereShape produces a Lambertian-shaded elliptical disk centered at
+// (cx, cy) with semi-axes (rx, ry) in unit space. Shading uses sqrt(1 - d²)
+// to mimic diffuse illumination of a 3D sphere: 1.0 where the surface
+// normal faces the viewer (center), falling smoothly to 0 at the terminator.
+func sphereShape(cx, cy, rx, ry float64) Shape {
+	var s Shape
+	for r := 0; r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			dx := (x - cx) / rx
+			dy := (y - cy) / ry
+			d2 := dx*dx + dy*dy
+			if d2 >= 1 {
+				continue
+			}
+			s[r][c] = math.Sqrt(1 - d2)
+		}
+	}
+	return s
 }
 
-// venusUniformHaze — thick bright atmosphere, nearly uniform disk.
-var venusUniformHaze = Shape{
-	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
-	{0.0, 0.0, 0.5, 0.8, 0.9, 0.9, 0.9, 0.9, 0.8, 0.5, 0.0, 0.0},
-	{0.0, 0.4, 0.8, 0.9, 0.9, 1.0, 1.0, 0.9, 0.9, 0.7, 0.3, 0.0},
-	{0.0, 0.4, 0.8, 0.9, 0.9, 1.0, 1.0, 0.9, 0.9, 0.7, 0.3, 0.0},
-	{0.0, 0.0, 0.5, 0.8, 0.9, 0.9, 0.9, 0.9, 0.8, 0.5, 0.0, 0.0},
-	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+// applyBands dims every other band of `period` rows by `dim`, producing
+// the horizontal stripes characteristic of gas giants.
+func applyBands(s Shape, period int, dim float64) Shape {
+	for r := 0; r < ShapeRows; r++ {
+		if (r/period)%2 == 0 {
+			continue
+		}
+		for c := 0; c < ShapeCols; c++ {
+			s[r][c] *= dim
+		}
+	}
+	return s
 }
 
-// earthContinents — irregular shading suggests land/sea contrast.
-var earthContinents = Shape{
-	{0.0, 0.0, 0.0, 0.3, 0.6, 0.7, 0.7, 0.6, 0.3, 0.0, 0.0, 0.0},
-	{0.0, 0.0, 0.5, 0.8, 0.7, 0.9, 0.9, 0.8, 0.6, 0.3, 0.0, 0.0},
-	{0.0, 0.3, 0.6, 0.7, 0.9, 1.0, 0.8, 0.9, 0.7, 0.4, 0.1, 0.0},
-	{0.0, 0.2, 0.7, 0.9, 0.8, 1.0, 1.0, 0.7, 0.8, 0.5, 0.2, 0.0},
-	{0.0, 0.0, 0.4, 0.7, 0.9, 0.8, 0.9, 0.8, 0.6, 0.3, 0.0, 0.0},
-	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
+// applyPolarCap brightens the top `rows` rows of a shape by `boost`,
+// clamping to 1.0. Used for Mars's northern ice cap.
+func applyPolarCap(s Shape, rows int, boost float64) Shape {
+	for r := 0; r < rows && r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			if s[r][c] > 0 {
+				v := s[r][c] * boost
+				if v > 1 {
+					v = 1
+				}
+				s[r][c] = v
+			}
+		}
+	}
+	return s
 }
 
-// marsPolarCap — top row slightly brighter than bottom, hint of northern ice cap.
-var marsPolarCap = Shape{
-	{0.0, 0.0, 0.0, 0.3, 0.6, 0.8, 0.8, 0.6, 0.3, 0.0, 0.0, 0.0},
-	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
-	{0.0, 0.3, 0.6, 0.8, 0.9, 1.0, 1.0, 0.9, 0.7, 0.4, 0.1, 0.0},
-	{0.0, 0.2, 0.5, 0.8, 0.9, 1.0, 1.0, 0.9, 0.7, 0.4, 0.1, 0.0},
-	{0.0, 0.0, 0.3, 0.6, 0.7, 0.8, 0.8, 0.7, 0.5, 0.3, 0.0, 0.0},
-	{0.0, 0.0, 0.0, 0.2, 0.4, 0.5, 0.5, 0.4, 0.2, 0.0, 0.0, 0.0},
+// applyRings overlays a thin ring at the equator row, extending outward
+// past the planet body to the frame edges. The ring fades from brighter
+// near the body's terminator toward the outer edge of the frame.
+func applyRings(s Shape, bodyRx float64) Shape {
+	mid := ShapeRows / 2
+	rows := []int{mid - 1, mid}
+	for _, r := range rows {
+		if r < 0 || r >= ShapeRows {
+			continue
+		}
+		for c := 0; c < ShapeCols; c++ {
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			d := math.Abs(x - 0.5)
+			// Ring extends from just outside the body (d > bodyRx) to
+			// near the frame edge (d < 0.48).
+			if d <= bodyRx || d >= 0.48 {
+				continue
+			}
+			// Brighter near body, fading to 0.4 at outer edge.
+			t := (d - bodyRx) / (0.48 - bodyRx)
+			shade := 0.8 - 0.4*t
+			if shade > s[r][c] {
+				s[r][c] = shade
+			}
+		}
+	}
+	return s
 }
 
-// jupiterBands — alternating rows with different core intensity read as horizontal bands.
-var jupiterBands = Shape{
-	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
-	{0.0, 0.2, 0.5, 0.8, 1.0, 1.0, 1.0, 0.9, 0.6, 0.2, 0.0, 0.0},
-	{0.0, 0.2, 0.6, 0.8, 0.9, 1.0, 1.0, 0.8, 0.7, 0.4, 0.1, 0.0},
-	{0.0, 0.1, 0.5, 0.8, 1.0, 1.0, 1.0, 0.9, 0.6, 0.3, 0.0, 0.0},
-	{0.0, 0.0, 0.4, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.4, 0.0, 0.0},
-	{0.0, 0.0, 0.0, 0.4, 0.6, 0.7, 0.7, 0.6, 0.4, 0.0, 0.0, 0.0},
+// applyContinents darkens a handful of interior cells to suggest land
+// masses against the ocean fill.
+func applyContinents(s Shape) Shape {
+	patches := [][2]int{
+		{3, 8}, {3, 9}, {4, 7}, {4, 10}, {4, 11},
+		{5, 14}, {5, 15}, {6, 15},
+		{3, 17}, {4, 18},
+		{6, 11}, {7, 10},
+	}
+	for _, p := range patches {
+		r, c := p[0], p[1]
+		if r >= 0 && r < ShapeRows && c >= 0 && c < ShapeCols && s[r][c] > 0 {
+			s[r][c] *= 0.55
+		}
+	}
+	return s
 }
 
-// saturnRings — sphere in middle 4 rows, ring extends to cols 0-1 and 10-11 on the equator.
-var saturnRings = Shape{
-	{0.0, 0.0, 0.0, 0.0, 0.4, 0.6, 0.6, 0.4, 0.0, 0.0, 0.0, 0.0},
-	{0.0, 0.0, 0.2, 0.6, 0.9, 1.0, 1.0, 0.9, 0.6, 0.2, 0.0, 0.0},
-	{0.3, 0.4, 0.5, 0.7, 0.9, 1.0, 1.0, 0.9, 0.7, 0.5, 0.4, 0.3},
-	{0.3, 0.4, 0.5, 0.7, 0.9, 1.0, 1.0, 0.9, 0.7, 0.5, 0.4, 0.3},
-	{0.0, 0.0, 0.2, 0.6, 0.9, 1.0, 1.0, 0.9, 0.6, 0.2, 0.0, 0.0},
-	{0.0, 0.0, 0.0, 0.0, 0.4, 0.6, 0.6, 0.4, 0.0, 0.0, 0.0, 0.0},
-}
-
-// uranusSmallSphere — smaller, uniform disk (Uranus reads as a featureless blue-green ball).
-var uranusSmallSphere = Shape{
-	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
-	{0.0, 0.0, 0.3, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.3, 0.0, 0.0},
-	{0.0, 0.2, 0.6, 0.8, 0.9, 1.0, 1.0, 0.9, 0.8, 0.6, 0.2, 0.0},
-	{0.0, 0.2, 0.6, 0.8, 0.9, 1.0, 1.0, 0.9, 0.8, 0.6, 0.2, 0.0},
-	{0.0, 0.0, 0.3, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.3, 0.0, 0.0},
-	{0.0, 0.0, 0.0, 0.2, 0.5, 0.6, 0.6, 0.5, 0.2, 0.0, 0.0, 0.0},
-}
-
-// neptuneDenseCore — smaller, darker-edged disk with bright concentrated core.
-var neptuneDenseCore = Shape{
-	{0.0, 0.0, 0.0, 0.0, 0.3, 0.5, 0.5, 0.3, 0.0, 0.0, 0.0, 0.0},
-	{0.0, 0.0, 0.2, 0.5, 0.7, 0.8, 0.8, 0.7, 0.5, 0.2, 0.0, 0.0},
-	{0.0, 0.1, 0.5, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.5, 0.1, 0.0},
-	{0.0, 0.1, 0.5, 0.7, 0.8, 0.9, 0.9, 0.8, 0.7, 0.5, 0.1, 0.0},
-	{0.0, 0.0, 0.2, 0.5, 0.7, 0.8, 0.8, 0.7, 0.5, 0.2, 0.0, 0.0},
-	{0.0, 0.0, 0.0, 0.0, 0.3, 0.5, 0.5, 0.3, 0.0, 0.0, 0.0, 0.0},
-}
+var (
+	mercurySimpleSphere = sphereShape(0.5, 0.5, 0.46, 0.46)
+	venusUniformHaze    = sphereShape(0.5, 0.5, 0.47, 0.47)
+	earthContinents     = applyContinents(sphereShape(0.5, 0.5, 0.45, 0.45))
+	marsPolarCap        = applyPolarCap(sphereShape(0.5, 0.5, 0.43, 0.43), 2, 1.25)
+	jupiterBands        = applyBands(sphereShape(0.5, 0.5, 0.47, 0.47), 1, 0.72)
+	saturnRings         = applyRings(sphereShape(0.5, 0.5, 0.32, 0.32), 0.32)
+	uranusSmallSphere   = sphereShape(0.5, 0.5, 0.40, 0.40)
+	neptuneDenseCore    = sphereShape(0.5, 0.5, 0.40, 0.40)
+)
 
 var shapes = map[string]Shape{
 	"mercury": mercurySimpleSphere,
@@ -96,8 +137,8 @@ var shapes = map[string]Shape{
 	"neptune": neptuneDenseCore,
 }
 
-// GetShape returns the shade grid for the named planet. Unknown names fall
-// back to the mercury sphere so custom instance names still render.
+// GetShape returns the shade grid for the named planet. Unknown names
+// fall back to the mercury sphere so custom instance names still render.
 func GetShape(name string) Shape {
 	if s, ok := shapes[name]; ok {
 		return s

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -318,8 +318,8 @@ func mercuryRaysShape() Shape {
 		rayCount      int     // N-fold symmetric ray pattern
 		phaseOffset   float64 // rotation of the ray pattern
 	}{
-		{0.58, 0.62, 0.32, 0.60, 14, 0.7},
-		{0.34, 0.38, 0.22, 0.45, 11, 1.9},
+		{0.50, 0.58, 0.32, 0.60, 14, 0.7},  // central, just below equator
+		{0.66, 0.22, 0.22, 0.45, 11, 1.9},  // near north pole, ~1 o'clock
 	}
 
 	var s Shape

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -136,19 +136,16 @@ func applyJupiterBands(s Shape) Shape {
 // applyRings wraps Saturn-style rings around a sphere. The ring is a
 // thin tilted ellipse (ringRx × ringRy). Where the ring passes below
 // the sphere's equator it is drawn IN FRONT of the sphere; above the
-// equator the sphere occludes the ring. Three concentric bands with a
-// Cassini-style gap produce the striped disk look.
+// equator the sphere occludes the ring. Five concentric bands with
+// a Cassini division and a thin C/B gap give the striped disk its
+// natural layered look.
 func applyRings(s Shape, bodyRx float64) Shape {
 	const (
 		ringRx = 0.48
 		ringRy = 0.10
 	)
 	innerU := bodyRx/ringRx + 0.08
-	bands := []struct{ inner, outer, shade float64 }{
-		{innerU, innerU + 0.18, 0.88},        // inner bright ring (A)
-		{innerU + 0.20, innerU + 0.24, 0.22}, // Cassini gap
-		{innerU + 0.26, 0.98, 0.74},          // outer ring (B)
-	}
+	bands := saturnRingBands(innerU)
 	const edgeFade = 0.015
 	for r := 0; r < ShapeRows; r++ {
 		for c := 0; c < ShapeCols; c++ {
@@ -428,21 +425,38 @@ func neptuneStormShape() Shape {
 	}, 0.40)
 }
 
+// saturnRingBands returns the five ring bands (C, C/B gap, B, Cassini,
+// A, outer haze) in order of increasing u. Shared between the base
+// shape builder and the overlay mask so band edges stay in sync.
+func saturnRingBands(innerU float64) []struct{ inner, outer, shade float64 } {
+	return []struct{ inner, outer, shade float64 }{
+		{innerU, innerU + 0.09, 0.50},         // C ring — innermost, faint
+		{innerU + 0.10, innerU + 0.11, 0.18},  // thin C/B gap
+		{innerU + 0.12, innerU + 0.24, 0.88},  // B ring — brightest
+		{innerU + 0.25, innerU + 0.28, 0.18},  // Cassini division
+		{innerU + 0.29, innerU + 0.36, 0.78},  // A ring
+		{innerU + 0.37, 0.97, 0.42},           // outer haze / F region
+	}
+}
+
 // saturnRingOverlayMask returns a cell-level mask of where Saturn's
 // bright ring bands are visible (front half over sphere, both halves
-// outside sphere body). Used by an overlay to tint ring cells toward
-// a pale ring color instead of the planet's gold. The Cassini gap is
-// deliberately excluded so the gap keeps the planet-body color and
-// the band structure stays readable.
+// outside sphere body). Gaps (C/B gap, Cassini division) are excluded
+// so they keep the planet-body color and the band structure stays
+// legible.
 func saturnRingOverlayMask(bodyRx float64) Shape {
 	const (
 		ringRx = 0.48
 		ringRy = 0.10
 	)
 	innerU := bodyRx/ringRx + 0.08
+	// Bright bands only (skip the two gaps and the very outer faint).
+	all := saturnRingBands(innerU)
 	brightBands := []struct{ inner, outer float64 }{
-		{innerU, innerU + 0.18},      // A ring
-		{innerU + 0.26, 0.98},        // B ring
+		{all[0].inner, all[0].outer}, // C ring
+		{all[2].inner, all[2].outer}, // B ring
+		{all[4].inner, all[4].outer}, // A ring
+		{all[5].inner, all[5].outer}, // outer haze
 	}
 	var s Shape
 	for r := 0; r < ShapeRows; r++ {
@@ -492,7 +506,7 @@ func saturnShadowMask(bodyRx float64) Shape {
 		ringRy         = 0.10
 		shadowOffset   = 0.008 // shadow sits just below ring's back edge
 		bandHalfHeight = 0.018
-		maxIntensity   = 0.28
+		maxIntensity   = 0.45
 	)
 	for r := 0; r < ShapeRows; r++ {
 		for c := 0; c < ShapeCols; c++ {
@@ -533,6 +547,84 @@ func neptuneDarkSpotShape() Shape {
 	return buildFormationShape([]formationCenter{
 		{0.32, 0.40, 0.09, 0.045, 0.85},
 	}, 0.40)
+}
+
+// applySaturnBands dims the sphere shade by latitude to add the subtle
+// horizontal banding real Saturn shows — much softer than Jupiter's.
+// Multiplies the base shade by a modest factor within each band and
+// smooths band edges so no visible seams appear.
+func applySaturnBands(s Shape) Shape {
+	type band struct{ minDy, maxDy, dim float64 }
+	bands := []band{
+		{-0.90, -0.55, 1.04}, // slightly brighter northern mid-lat
+		{-0.20, 0.12, 0.93},  // slightly dimmer equatorial band
+		{0.30, 0.65, 1.03},   // slightly brighter southern mid-lat
+		{0.78, 0.95, 0.92},   // slightly dimmer far south
+	}
+	const bodyR = 0.26
+	const edge = 0.05
+	for r := 0; r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			if s[r][c] == 0 {
+				continue
+			}
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			dy := (y - 0.5) / bodyR
+			shade := 1.0
+			for _, b := range bands {
+				if dy < b.minDy || dy > b.maxDy {
+					continue
+				}
+				dim := b.dim
+				if dy-b.minDy < edge {
+					t := (dy - b.minDy) / edge
+					dim = 1 + (dim-1)*t
+				} else if b.maxDy-dy < edge {
+					t := (b.maxDy - dy) / edge
+					dim = 1 + (dim-1)*t
+				}
+				shade = dim
+				break
+			}
+			v := s[r][c] * shade
+			if v > 1 {
+				v = 1
+			}
+			s[r][c] = v
+		}
+	}
+	return s
+}
+
+// saturnEquatorTint returns a subtle mask that concentrates at the
+// equator, used to paint a warmer pink/salmon tint across the middle
+// of the disk — the signature hue shift real Saturn shows at mid-
+// latitudes.
+func saturnEquatorTint(bodyRx float64) Shape {
+	var s Shape
+	const (
+		centerY     = 0.50
+		bandHalfHt  = 0.055
+		maxBlend    = 0.35
+	)
+	for r := 0; r < ShapeRows; r++ {
+		y := (float64(r) + 0.5) / float64(ShapeRows)
+		dist := math.Abs(y - centerY)
+		if dist > bandHalfHt {
+			continue
+		}
+		t := 1 - dist/bandHalfHt
+		for c := 0; c < ShapeCols; c++ {
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			sDx := (x - 0.5) / bodyRx
+			sDy := (y - 0.5) / bodyRx
+			if sDx*sDx+sDy*sDy >= 1 {
+				continue
+			}
+			s[r][c] = t * maxBlend
+		}
+	}
+	return s
 }
 
 // venusCloudShape creates swirling cloud bands — used as an Overlay
@@ -613,7 +705,7 @@ var (
 	earthBaseSphere     = sphereShape(0.5, 0.5, 0.45, 0.45)
 	marsPolarCap        = applyPolarCap(sphereShape(0.5, 0.5, 0.43, 0.43), 10, 1.25)
 	jupiterBands        = applyJupiterBands(sphereShape(0.5, 0.5, 0.47, 0.47))
-	saturnRings         = applyRings(sphereShape(0.5, 0.5, 0.26, 0.26), 0.26)
+	saturnRings         = applyRings(applySaturnBands(sphereShape(0.5, 0.5, 0.26, 0.26)), 0.26)
 	uranusSmallSphere   = sphereShape(0.5, 0.5, 0.40, 0.40)
 	neptuneDenseCore    = sphereShape(0.5, 0.5, 0.40, 0.40)
 )
@@ -656,6 +748,7 @@ var planetOverlays = map[string][]Overlay{
 		{Shape: jupiterRedSpotShape(), Color: [3]uint8{170, 95, 50}},
 	},
 	"saturn": {
+		{Shape: saturnEquatorTint(0.26), Color: [3]uint8{218, 172, 140}},
 		{Shape: saturnShadowMask(0.26), Color: [3]uint8{12, 8, 4}},
 		{Shape: saturnRingOverlayMask(0.26), Color: [3]uint8{218, 192, 155}},
 	},

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -2,15 +2,15 @@ package planets
 
 import "math"
 
-// Shape dimensions: 24 rows × 24 cols of SUB-pixels. Rendering pairs
+// Shape dimensions: 48 rows × 48 cols of SUB-pixels. Rendering pairs
 // consecutive rows into one terminal line using the ▀/▄ half-block
-// characters, so output is ShapeRows/2 terminal rows tall. With
+// characters, so output is ShapeRows/2 = 24 terminal rows tall. With
 // subpixels counted as 1 visual unit and terminal chars as 1 unit wide
 // × 2 units tall, this gives a square unit space and a visually round
 // disk when rx == ry in sphereShape.
 const (
-	ShapeRows = 24
-	ShapeCols = 24
+	ShapeRows = 48
+	ShapeCols = 48
 )
 
 // Shape is a row × col grid of shade values in [0.0, 1.0]. 0.0 = empty,
@@ -122,20 +122,21 @@ func applyRings(s Shape, bodyRx float64) Shape {
 }
 
 // applyContinents darkens a scattered set of interior cells to suggest
-// landmasses. Coordinates scale proportionally to the grid so the patches
-// stay inside the earth disk.
+// landmasses. Patch centers are normalized so they stay inside the disk
+// across any grid size.
 func applyContinents(s Shape) Shape {
-	// Normalized patch centers (x, y) in [0,1] unit space.
 	patches := [][2]float64{
 		{0.35, 0.35}, {0.40, 0.30}, {0.30, 0.45},
 		{0.62, 0.40}, {0.68, 0.55}, {0.55, 0.65},
 		{0.42, 0.62}, {0.72, 0.30}, {0.48, 0.75},
 	}
+	dRow := ShapeRows / 24
+	dCol := ShapeCols / 12
 	for _, p := range patches {
 		rc := int(p[1] * float64(ShapeRows))
 		cc := int(p[0] * float64(ShapeCols))
-		for dr := -1; dr <= 1; dr++ {
-			for dc := -2; dc <= 2; dc++ {
+		for dr := -dRow; dr <= dRow; dr++ {
+			for dc := -dCol; dc <= dCol; dc++ {
 				r, c := rc+dr, cc+dc
 				if r < 0 || r >= ShapeRows || c < 0 || c >= ShapeCols {
 					continue
@@ -153,8 +154,8 @@ var (
 	mercurySimpleSphere = sphereShape(0.5, 0.5, 0.46, 0.46)
 	venusUniformHaze    = sphereShape(0.5, 0.5, 0.47, 0.47)
 	earthContinents     = applyContinents(sphereShape(0.5, 0.5, 0.45, 0.45))
-	marsPolarCap        = applyPolarCap(sphereShape(0.5, 0.5, 0.43, 0.43), 5, 1.25)
-	jupiterBands        = applyBands(sphereShape(0.5, 0.5, 0.47, 0.47), 3, 0.70)
+	marsPolarCap        = applyPolarCap(sphereShape(0.5, 0.5, 0.43, 0.43), 10, 1.25)
+	jupiterBands        = applyBands(sphereShape(0.5, 0.5, 0.47, 0.47), 6, 0.70)
 	saturnRings         = applyRings(sphereShape(0.5, 0.5, 0.32, 0.32), 0.32)
 	uranusSmallSphere   = sphereShape(0.5, 0.5, 0.40, 0.40)
 	neptuneDenseCore    = sphereShape(0.5, 0.5, 0.40, 0.40)

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -92,29 +92,59 @@ func applyPolarCap(s Shape, rows int, boost float64) Shape {
 	return s
 }
 
-// applyRings overlays a thin ring at the equator row, extending outward
-// past the planet body to the frame edges. The ring fades from brighter
-// near the body's terminator toward the outer edge of the frame.
+// applyRings overlays Saturn-like rings centered on the equator, one
+// subpixel row thick. Three bands plus a Cassini-style gap:
+//
+//	[body] | A-ring (bright) | gap (dim) | B-ring (medium) | taper
+//
+// The body's shadow passes in front of the rings naturally because
+// sphereShape has already filled the body rows at a higher shade than
+// the ring shades, so `if shade > s[row][c]` preserves the body.
 func applyRings(s Shape, bodyRx float64) Shape {
-	mid := ShapeRows / 2
-	rows := []int{mid - 1, mid}
-	for _, r := range rows {
-		if r < 0 || r >= ShapeRows {
+	// Two thin equatorial subpixel rows; very thin elliptical disc.
+	midRow := ShapeRows / 2
+	rows := []int{midRow - 1, midRow}
+
+	// Ring bands: (innerX, outerX, shade). Measured from center; symmetric
+	// around x=0.5.
+	bands := []struct{ inner, outer, shade float64 }{
+		{bodyRx + 0.015, bodyRx + 0.065, 0.90}, // inner bright ring (A)
+		{bodyRx + 0.075, bodyRx + 0.090, 0.30}, // Cassini gap
+		{bodyRx + 0.100, 0.470, 0.75},          // outer ring (B)
+	}
+
+	for i, row := range rows {
+		if row < 0 || row >= ShapeRows {
 			continue
+		}
+		// Upper and lower subpixel rows at the equator get slightly less
+		// intensity than the true center row so the ring reads as very
+		// thin rather than a solid slab.
+		rowScale := 1.0
+		if i == 0 {
+			rowScale = 0.55
 		}
 		for c := 0; c < ShapeCols; c++ {
 			x := (float64(c) + 0.5) / float64(ShapeCols)
 			d := math.Abs(x - 0.5)
-			// Ring extends from just outside the body (d > bodyRx) to
-			// near the frame edge (d < 0.48).
-			if d <= bodyRx || d >= 0.48 {
-				continue
-			}
-			// Brighter near body, fading to 0.4 at outer edge.
-			t := (d - bodyRx) / (0.48 - bodyRx)
-			shade := 0.8 - 0.4*t
-			if shade > s[r][c] {
-				s[r][c] = shade
+			for _, b := range bands {
+				if d < b.inner || d > b.outer {
+					continue
+				}
+				// Fade at extreme outer edge so rings don't hard-cut at
+				// the frame edge.
+				taper := 1.0
+				if d > 0.42 {
+					taper = (0.47 - d) / 0.05
+					if taper < 0 {
+						taper = 0
+					}
+				}
+				shade := b.shade * rowScale * taper
+				if shade > s[row][c] {
+					s[row][c] = shade
+				}
+				break
 			}
 		}
 	}

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -78,20 +78,24 @@ func applyPolarCap(s Shape, rows int, boost float64) Shape {
 	return s
 }
 
-// applyJupiterBands applies latitude-based bands with soft top/bottom
-// edges and a small positional noise term so the bands curve with the
-// sphere (narrower at poles, wider at equator) and look turbulent rather
-// than drawn with a ruler.
+// applyJupiterBands applies latitude-based bands that darken the belts
+// (NEB, SEB) and keep the zones near full brightness. A bright cream
+// overlay (jupiterZonesShape) then lifts the zones toward Jupiter's
+// signature pale ivory; the contrast between the dim belts and the
+// lifted zones gives the planet its characteristic striped look.
+//
+// Band edges are softened and modulated with multi-octave noise so the
+// transitions look turbulent (swirls, eddies) rather than ruler-straight.
 func applyJupiterBands(s Shape) Shape {
 	type band struct{ minDy, maxDy, dim float64 }
 	bands := []band{
-		{-0.95, -0.72, 0.62},
-		{-0.68, -0.48, 0.90},
-		{-0.44, -0.22, 0.58}, // NEB
-		{-0.18, 0.06, 0.94},  // EZ
-		{0.10, 0.32, 0.60},   // SEB
-		{0.36, 0.56, 0.88},
-		{0.60, 0.82, 0.64},
+		{-0.92, -0.72, 0.78}, // N polar — flat/muted
+		{-0.68, -0.48, 0.95}, // NTZ — zone (slightly dim, overlay brightens)
+		{-0.44, -0.22, 0.50}, // NEB — dark belt
+		{-0.18, 0.06, 0.96},  // EZ — zone
+		{0.10, 0.32, 0.50},   // SEB — dark belt (Great Red Spot lives here)
+		{0.36, 0.56, 0.95},   // STropZ — zone
+		{0.60, 0.82, 0.78},   // S polar — flat/muted
 	}
 	const bodyR = 0.47
 	const edge = 0.045
@@ -101,9 +105,19 @@ func applyJupiterBands(s Shape) Shape {
 				continue
 			}
 			y := (float64(r) + 0.5) / float64(ShapeRows)
+			x := (float64(c) + 0.5) / float64(ShapeCols)
 			dy := (y - 0.5) / bodyR
 			shade := 1.0
+			// Track distance to nearest band edge so we can crank up
+			// turbulence at belt/zone interfaces.
+			nearestEdge := math.Inf(1)
 			for _, b := range bands {
+				if d := math.Abs(dy - b.minDy); d < nearestEdge {
+					nearestEdge = d
+				}
+				if d := math.Abs(dy - b.maxDy); d < nearestEdge {
+					nearestEdge = d
+				}
 				if dy < b.minDy || dy > b.maxDy {
 					continue
 				}
@@ -118,8 +132,19 @@ func applyJupiterBands(s Shape) Shape {
 				shade = dim
 				break
 			}
-			// Turbulence: small per-cell jitter.
-			noise := (shapeHash(r, c) - 0.5) * 0.06
+
+			// Base per-cell jitter.
+			noise := (shapeHash(r, c) - 0.5) * 0.08
+			// Second-octave jitter for finer texture.
+			noise += (shapeHash(r*3+1, c*5+7) - 0.5) * 0.05
+			// Horizontal wispy sine — gives the sense of wind-shear within belts.
+			noise += 0.04 * math.Sin(14*x+2*y)
+
+			// Boost turbulence at band edges (up to ~2.4×).
+			if nearestEdge < 0.06 {
+				noise *= 1 + (1-nearestEdge/0.06)*1.4
+			}
+
 			shade += noise
 			if shade < 0.30 {
 				shade = 0.30
@@ -128,6 +153,65 @@ func applyJupiterBands(s Shape) Shape {
 				shade = 1
 			}
 			s[r][c] *= shade
+		}
+	}
+	return s
+}
+
+// jupiterZonesShape — bright cream overlay mask targeting Jupiter's
+// zones (NTZ, EZ, STropZ). Gaussian falloff from each zone's center
+// latitude plus multi-scale sine noise gives the zones soft turbulent
+// edges instead of flat stripes.
+func jupiterZonesShape() Shape {
+	var s Shape
+	const bodyR = 0.47
+	// Zone centers in dy latitude space (bdy coordinates), with a
+	// half-height and peak intensity.
+	zones := []struct{ cyDy, halfHt, intensity float64 }{
+		{-0.58, 0.11, 0.60}, // NTZ
+		{-0.06, 0.13, 0.82}, // EZ (brightest, widest)
+		{0.46, 0.11, 0.68},  // STropZ
+	}
+	for r := 0; r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			bdx := (x - 0.5) / bodyR
+			bdy := (y - 0.5) / bodyR
+			if bdx*bdx+bdy*bdy >= 1 {
+				continue
+			}
+			var v float64
+			for _, z := range zones {
+				d := math.Abs(bdy - z.cyDy)
+				if d > z.halfHt {
+					continue
+				}
+				t := 1 - d/z.halfHt
+				// Quadratic taper — sharper peak, softer edges than linear.
+				zoneV := z.intensity * t * t
+				if zoneV > v {
+					v = zoneV
+				}
+			}
+			// Horizontal wispy sine turbulence at zone latitudes.
+			wisp := 0.10 * math.Sin(9*x+4*y+0.6)
+			wisp += 0.06 * math.Sin(16*x-5*y+2.2)
+			if v > 0.05 {
+				v += wisp * math.Min(1, v*1.5)
+			}
+			// Fade near disk edge so zones don't bleed off the silhouette.
+			rad := math.Sqrt(bdx*bdx + bdy*bdy)
+			if rad > 0.85 {
+				v *= (1 - rad) / 0.15
+			}
+			if v < 0 {
+				v = 0
+			}
+			if v > 1 {
+				v = 1
+			}
+			s[r][c] = v
 		}
 	}
 	return s
@@ -745,7 +829,8 @@ var planetOverlays = map[string][]Overlay{
 	"earth": {{Shape: earthCloudShape(), Color: [3]uint8{250, 250, 250}}},
 	"mars":  {{Shape: marsSurfaceShape(), Color: [3]uint8{95, 30, 10}}},
 	"jupiter": {
-		{Shape: jupiterRedSpotShape(), Color: [3]uint8{170, 95, 50}},
+		{Shape: jupiterZonesShape(), Color: [3]uint8{245, 225, 190}},
+		{Shape: jupiterRedSpotShape(), Color: [3]uint8{200, 135, 100}},
 	},
 	"saturn": {
 		{Shape: saturnEquatorTint(0.26), Color: [3]uint8{218, 172, 140}},

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -318,8 +318,8 @@ func mercuryRaysShape() Shape {
 		rayCount      int     // N-fold symmetric ray pattern
 		phaseOffset   float64 // rotation of the ray pattern
 	}{
-		{0.58, 0.62, 0.32, 0.85, 14, 0.7},
-		{0.34, 0.38, 0.22, 0.55, 11, 1.9},
+		{0.58, 0.62, 0.32, 0.60, 14, 0.7},
+		{0.34, 0.38, 0.22, 0.45, 11, 1.9},
 	}
 
 	var s Shape
@@ -647,7 +647,7 @@ func GetShape(name string) Shape {
 var planetOverlays = map[string][]Overlay{
 	"mercury": {
 		{Shape: mercuryCratersShape(), Color: [3]uint8{95, 95, 95}},
-		{Shape: mercuryRaysShape(), Color: [3]uint8{225, 225, 222}},
+		{Shape: mercuryRaysShape(), Color: [3]uint8{205, 205, 202}},
 	},
 	"venus": {{Shape: venusCloudShape(), Color: [3]uint8{255, 240, 200}}},
 	"earth": {{Shape: earthCloudShape(), Color: [3]uint8{250, 250, 250}}},

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -272,45 +272,56 @@ func earthCloudShape() Shape {
 	}, 0.45)
 }
 
-// mercuryCratersShape — many small crater basins hash-scattered across
-// the disk so they don't form visible lattice patterns. Rendered with
-// a bright cream overlay to read as highlights/ejecta from impacts
-// against the grey body (real Mercury craters appear brighter than
-// the surrounding regolith).
+// mercuryCratersShape — dense scattering of small crater-rim shadows
+// across the disk. Rendered with a darker overlay so they read as the
+// pockmark texture that dominates real Mercury's appearance.
 func mercuryCratersShape() Shape {
 	const bodyR = 0.46
 	var formations []formationCenter
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 90; i++ {
 		h1 := shapeHash(i*13+1, i*7+19)
 		h2 := shapeHash(i*11+5, i*17+3)
 		h3 := shapeHash(i*19+7, i*23+11)
 		h4 := shapeHash(i*29+13, i*31+17)
 
-		cx := 0.1 + h1*0.8
-		cy := 0.1 + h2*0.8
-		// Rejection-sample to keep craters well inside the disk.
+		cx := 0.08 + h1*0.84
+		cy := 0.08 + h2*0.84
 		dx := (cx - 0.5) / bodyR
 		dy := (cy - 0.5) / bodyR
-		if dx*dx+dy*dy > 0.78 {
+		if dx*dx+dy*dy > 0.82 {
 			continue
 		}
 		formations = append(formations, formationCenter{
 			cx:        cx,
 			cy:        cy,
-			rx:        0.016 + h3*0.034,
-			ry:        0.012 + h4*0.028,
-			intensity: 0.35 + h3*0.30,
+			rx:        0.010 + h3*0.022, // smaller pockmarks
+			ry:        0.008 + h4*0.018,
+			intensity: 0.30 + h3*0.40,
 		})
 	}
 	return buildFormationShape(formations, bodyR)
 }
 
-// mercuryVeinsShape — thin curving "veins" (fault scarps, ejecta rays)
-// traced by the zero-crossings of sine-product fields. Two overlapping
-// wave fields give a web of curves across the disk without visible
-// repetition.
-func mercuryVeinsShape() Shape {
+// mercuryRaysShape — bright impact crater centers with radial ray
+// systems extending outward. This is the dominant visual feature of
+// real Mercury (e.g. Hokusai, Kuiper craters): a small bright crater
+// floor surrounded by long straight ejecta rays that span a significant
+// fraction of the disk.
+func mercuryRaysShape() Shape {
 	const bodyR = 0.46
+
+	// Bright rayed craters. Placed asymmetrically so they feel natural.
+	centers := []struct {
+		cx, cy        float64 // crater position in unit space
+		radius        float64 // outer reach of the rays
+		strength      float64 // peak brightness
+		rayCount      int     // N-fold symmetric ray pattern
+		phaseOffset   float64 // rotation of the ray pattern
+	}{
+		{0.58, 0.62, 0.32, 0.85, 14, 0.7},
+		{0.34, 0.38, 0.22, 0.55, 11, 1.9},
+	}
+
 	var s Shape
 	for r := 0; r < ShapeRows; r++ {
 		for c := 0; c < ShapeCols; c++ {
@@ -321,21 +332,52 @@ func mercuryVeinsShape() Shape {
 			if bdx*bdx+bdy*bdy >= 1 {
 				continue
 			}
-			// Zero-crossing of a product of sines traces a curved line.
-			// Two independent fields give two overlapping sets of veins.
-			v1 := math.Sin(15*x+10*y+1.2) * math.Sin(12*x-17*y+2.3)
-			if th := math.Abs(v1); th < 0.11 {
-				s[r][c] = (1 - th/0.11) * 0.55
-			}
-			v2 := math.Sin(21*x-13*y+3.1) * math.Sin(9*x+15*y+0.7)
-			if th := math.Abs(v2); th < 0.07 {
-				add := (1 - th/0.07) * 0.40
-				if add > s[r][c] {
-					s[r][c] = add
+
+			for _, k := range centers {
+				dx := x - k.cx
+				dy := y - k.cy
+				dist := math.Sqrt(dx*dx + dy*dy)
+
+				// Bright crater disc at the center.
+				const craterR = 0.018
+				if dist < craterR {
+					t := 1 - dist/craterR
+					v := k.strength * (0.4 + 0.6*t)
+					if v > s[r][c] {
+						s[r][c] = v
+					}
+					continue
+				}
+
+				if dist > k.radius {
+					continue
+				}
+
+				// Rays: N-fold-symmetric cosine wave in angle, thresholded
+				// so only the ray peaks show.
+				angle := math.Atan2(dy, dx)
+				ray := math.Cos(float64(k.rayCount)*angle + k.phaseOffset)
+				if ray < 0.55 {
+					continue
+				}
+				// Normalize ray amplitude.
+				rayAmp := (ray - 0.55) / 0.45
+
+				// Fade outward and taper at tips.
+				outer := (dist - craterR) / (k.radius - craterR)
+				if outer > 1 {
+					outer = 1
+				}
+				distFade := 1 - outer
+				widthFade := math.Pow(distFade, 0.6)
+
+				v := rayAmp * widthFade * distFade * k.strength
+				if v > s[r][c] {
+					s[r][c] = v
 				}
 			}
-			// Fade veins near the disk edge so they don't clutter the
-			// silhouette.
+
+			// Fade near disk edge so rays don't bleed off the silhouette.
 			rad := math.Sqrt(bdx*bdx + bdy*bdy)
 			if rad > 0.85 {
 				s[r][c] *= (1 - rad) / 0.15
@@ -604,8 +646,8 @@ func GetShape(name string) Shape {
 // first, so later overlays can tint on top of darkened/shadowed cells.
 var planetOverlays = map[string][]Overlay{
 	"mercury": {
-		{Shape: mercuryCratersShape(), Color: [3]uint8{220, 212, 198}},
-		{Shape: mercuryVeinsShape(), Color: [3]uint8{205, 198, 186}},
+		{Shape: mercuryCratersShape(), Color: [3]uint8{95, 95, 95}},
+		{Shape: mercuryRaysShape(), Color: [3]uint8{225, 225, 222}},
 	},
 	"venus": {{Shape: venusCloudShape(), Color: [3]uint8{255, 240, 200}}},
 	"earth": {{Shape: earthCloudShape(), Color: [3]uint8{250, 250, 250}}},

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -393,14 +393,14 @@ func mercuryRaysShape() Shape {
 
 	// Bright rayed craters. Placed asymmetrically so they feel natural.
 	centers := []struct {
-		cx, cy        float64 // crater position in unit space
-		radius        float64 // outer reach of the rays
-		strength      float64 // peak brightness
-		rayCount      int     // N-fold symmetric ray pattern
-		phaseOffset   float64 // rotation of the ray pattern
+		cx, cy      float64 // crater position in unit space
+		radius      float64 // outer reach of the rays
+		strength    float64 // peak brightness
+		rayCount    int     // N-fold symmetric ray pattern
+		phaseOffset float64 // rotation of the ray pattern
 	}{
-		{0.50, 0.58, 0.32, 0.60, 14, 0.7},  // central, just below equator
-		{0.66, 0.22, 0.22, 0.45, 11, 1.9},  // near north pole, ~1 o'clock
+		{0.50, 0.58, 0.32, 0.60, 14, 0.7}, // central, just below equator
+		{0.66, 0.22, 0.22, 0.45, 11, 1.9}, // near north pole, ~1 o'clock
 	}
 
 	var s Shape
@@ -514,12 +514,12 @@ func neptuneStormShape() Shape {
 // shape builder and the overlay mask so band edges stay in sync.
 func saturnRingBands(innerU float64) []struct{ inner, outer, shade float64 } {
 	return []struct{ inner, outer, shade float64 }{
-		{innerU, innerU + 0.09, 0.50},         // C ring — innermost, faint
-		{innerU + 0.10, innerU + 0.11, 0.18},  // thin C/B gap
-		{innerU + 0.12, innerU + 0.24, 0.88},  // B ring — brightest
-		{innerU + 0.25, innerU + 0.28, 0.18},  // Cassini division
-		{innerU + 0.29, innerU + 0.36, 0.78},  // A ring
-		{innerU + 0.37, 0.97, 0.42},           // outer haze / F region
+		{innerU, innerU + 0.09, 0.50},        // C ring — innermost, faint
+		{innerU + 0.10, innerU + 0.11, 0.18}, // thin C/B gap
+		{innerU + 0.12, innerU + 0.24, 0.88}, // B ring — brightest
+		{innerU + 0.25, innerU + 0.28, 0.18}, // Cassini division
+		{innerU + 0.29, innerU + 0.36, 0.78}, // A ring
+		{innerU + 0.37, 0.97, 0.42},          // outer haze / F region
 	}
 }
 
@@ -687,9 +687,9 @@ func applySaturnBands(s Shape) Shape {
 func saturnEquatorTint(bodyRx float64) Shape {
 	var s Shape
 	const (
-		centerY     = 0.50
-		bandHalfHt  = 0.055
-		maxBlend    = 0.35
+		centerY    = 0.50
+		bandHalfHt = 0.055
+		maxBlend   = 0.35
 	)
 	for r := 0; r < ShapeRows; r++ {
 		y := (float64(r) + 0.5) / float64(ShapeRows)

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -15,10 +15,22 @@ const (
 // character selected from a phase-specific palette.
 type Shape = [ShapeRows][ShapeCols]float64
 
-// sphereShape produces a Lambertian-shaded elliptical disk centered at
-// (cx, cy) with semi-axes (rx, ry) in unit space. Shading uses sqrt(1 - d²)
-// to mimic diffuse illumination of a 3D sphere: 1.0 where the surface
-// normal faces the viewer (center), falling smoothly to 0 at the terminator.
+// lightDir points from the sphere surface toward the directional key light.
+// Slightly up-left-of-viewer so the bright spot sits in the upper-left
+// quadrant of the disk and the terminator shadow falls toward the lower
+// right — a classic 3D-sphere lighting setup.
+var lightDir = [3]float64{-0.40, -0.30, 0.85}
+
+// ambient is the base illumination on the shadowed hemisphere. Above 0 so
+// the silhouette stays visible past the terminator; low enough that the
+// directional shadow is clearly asymmetric.
+const ambient = 0.18
+
+// sphereShape produces a directionally lit elliptical disk centered at
+// (cx, cy) with semi-axes (rx, ry) in unit space. Each in-disk cell is
+// treated as a point on a 3D unit sphere: surface normal N = (dx, dy, z),
+// shade = ambient + (1 - ambient) · max(0, N · lightDir). This offsets the
+// bright spot from geometric center, producing a visible shadow.
 func sphereShape(cx, cy, rx, ry float64) Shape {
 	var s Shape
 	for r := 0; r < ShapeRows; r++ {
@@ -31,7 +43,16 @@ func sphereShape(cx, cy, rx, ry float64) Shape {
 			if d2 >= 1 {
 				continue
 			}
-			s[r][c] = math.Sqrt(1 - d2)
+			z := math.Sqrt(1 - d2)
+			dot := dx*lightDir[0] + dy*lightDir[1] + z*lightDir[2]
+			if dot < 0 {
+				dot = 0
+			}
+			shade := ambient + (1-ambient)*dot
+			if shade > 1 {
+				shade = 1
+			}
+			s[r][c] = shade
 		}
 	}
 	return s

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -469,8 +469,8 @@ func mercuryRaysShape() Shape {
 }
 
 // marsSurfaceShape — large dusty basins and storm streaks. Rendered
-// with a dark rust color so regions look like deep Martian terrain
-// (Hellas Planitia, Valles Marineris) against the lighter orange body.
+// with a dark rust color so regions look like deep basaltic terrain
+// against the lighter orange body.
 func marsSurfaceShape() Shape {
 	return buildFormationShape([]formationCenter{
 		{0.28, 0.38, 0.13, 0.06, 0.70},

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -272,28 +272,77 @@ func earthCloudShape() Shape {
 	}, 0.45)
 }
 
-// mercurySurfaceShape — many small dark crater basins scattered across
-// the surface. Rendered with a near-black overlay to read as shadowed
-// impact craters against the grey body.
-func mercurySurfaceShape() Shape {
-	return buildFormationShape([]formationCenter{
-		{0.22, 0.28, 0.05, 0.03, 0.70},
-		{0.35, 0.40, 0.06, 0.04, 0.68},
-		{0.18, 0.58, 0.04, 0.03, 0.55},
-		{0.45, 0.30, 0.07, 0.04, 0.78},
-		{0.64, 0.35, 0.05, 0.03, 0.60},
-		{0.73, 0.52, 0.06, 0.04, 0.72},
-		{0.30, 0.72, 0.05, 0.03, 0.55},
-		{0.56, 0.66, 0.06, 0.04, 0.72},
-		{0.70, 0.72, 0.04, 0.03, 0.52},
-		{0.40, 0.55, 0.05, 0.03, 0.62},
-		{0.58, 0.20, 0.04, 0.03, 0.50},
-		{0.28, 0.46, 0.03, 0.02, 0.48},
-		{0.50, 0.80, 0.05, 0.03, 0.58},
-		{0.78, 0.30, 0.04, 0.03, 0.50},
-		{0.18, 0.38, 0.04, 0.03, 0.55},
-		{0.48, 0.48, 0.05, 0.03, 0.62},
-	}, 0.46)
+// mercuryCratersShape — many small crater basins hash-scattered across
+// the disk so they don't form visible lattice patterns. Rendered with
+// a bright cream overlay to read as highlights/ejecta from impacts
+// against the grey body (real Mercury craters appear brighter than
+// the surrounding regolith).
+func mercuryCratersShape() Shape {
+	const bodyR = 0.46
+	var formations []formationCenter
+	for i := 0; i < 50; i++ {
+		h1 := shapeHash(i*13+1, i*7+19)
+		h2 := shapeHash(i*11+5, i*17+3)
+		h3 := shapeHash(i*19+7, i*23+11)
+		h4 := shapeHash(i*29+13, i*31+17)
+
+		cx := 0.1 + h1*0.8
+		cy := 0.1 + h2*0.8
+		// Rejection-sample to keep craters well inside the disk.
+		dx := (cx - 0.5) / bodyR
+		dy := (cy - 0.5) / bodyR
+		if dx*dx+dy*dy > 0.78 {
+			continue
+		}
+		formations = append(formations, formationCenter{
+			cx:        cx,
+			cy:        cy,
+			rx:        0.016 + h3*0.034,
+			ry:        0.012 + h4*0.028,
+			intensity: 0.35 + h3*0.30,
+		})
+	}
+	return buildFormationShape(formations, bodyR)
+}
+
+// mercuryVeinsShape — thin curving "veins" (fault scarps, ejecta rays)
+// traced by the zero-crossings of sine-product fields. Two overlapping
+// wave fields give a web of curves across the disk without visible
+// repetition.
+func mercuryVeinsShape() Shape {
+	const bodyR = 0.46
+	var s Shape
+	for r := 0; r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			bdx := (x - 0.5) / bodyR
+			bdy := (y - 0.5) / bodyR
+			if bdx*bdx+bdy*bdy >= 1 {
+				continue
+			}
+			// Zero-crossing of a product of sines traces a curved line.
+			// Two independent fields give two overlapping sets of veins.
+			v1 := math.Sin(15*x+10*y+1.2) * math.Sin(12*x-17*y+2.3)
+			if th := math.Abs(v1); th < 0.11 {
+				s[r][c] = (1 - th/0.11) * 0.55
+			}
+			v2 := math.Sin(21*x-13*y+3.1) * math.Sin(9*x+15*y+0.7)
+			if th := math.Abs(v2); th < 0.07 {
+				add := (1 - th/0.07) * 0.40
+				if add > s[r][c] {
+					s[r][c] = add
+				}
+			}
+			// Fade veins near the disk edge so they don't clutter the
+			// silhouette.
+			rad := math.Sqrt(bdx*bdx + bdy*bdy)
+			if rad > 0.85 {
+				s[r][c] *= (1 - rad) / 0.15
+			}
+		}
+	}
+	return s
 }
 
 // marsSurfaceShape — large dusty basins and storm streaks. Rendered
@@ -325,16 +374,14 @@ func uranusHazeShape() Shape {
 	}, 0.40)
 }
 
-// neptuneStormShape — compact dark storms (à la Great Dark Spot) in
-// the upper cloud deck, overlaid with a brighter blue so they read as
-// distinct weather systems.
+// neptuneStormShape — compact bright storm systems (separate from the
+// darker Great Dark Spot overlay).
 func neptuneStormShape() Shape {
 	return buildFormationShape([]formationCenter{
-		{0.32, 0.40, 0.11, 0.05, 0.75}, // Great Dark Spot analog
 		{0.64, 0.54, 0.10, 0.04, 0.62},
-		{0.52, 0.30, 0.08, 0.04, 0.55},
+		{0.52, 0.28, 0.08, 0.04, 0.55},
 		{0.36, 0.66, 0.09, 0.04, 0.62},
-		{0.62, 0.28, 0.07, 0.03, 0.48},
+		{0.68, 0.30, 0.07, 0.03, 0.48},
 		{0.50, 0.52, 0.06, 0.03, 0.45},
 	}, 0.40)
 }
@@ -391,33 +438,59 @@ func saturnRingOverlayMask(bodyRx float64) Shape {
 	return s
 }
 
-// saturnShadowMask returns a thin horizontal band of shadow across the
-// planet's surface where the rings block sunlight. Rendered with a
-// near-black overlay so cells on the sphere dim.
+// saturnShadowMask returns a thin CURVED shadow that traces the ring's
+// back-edge projected onto the sphere. Keeping the curve parallel to
+// the ring ellipse makes the shadow feel connected to the ring rather
+// than a horizontal painted-on stripe. Intensity is intentionally low
+// so the shadow reads as a subtle graze.
 func saturnShadowMask(bodyRx float64) Shape {
 	var s Shape
 	const (
-		shadowCenterY   = 0.485 // slightly above equator — ring is tilted
-		shadowHalfHt    = 0.020
+		ringRx         = 0.48
+		ringRy         = 0.10
+		shadowOffset   = 0.008 // shadow sits just below ring's back edge
+		bandHalfHeight = 0.018
+		maxIntensity   = 0.28
 	)
 	for r := 0; r < ShapeRows; r++ {
-		y := (float64(r) + 0.5) / float64(ShapeRows)
-		dist := math.Abs(y - shadowCenterY)
-		if dist > shadowHalfHt {
-			continue
-		}
-		taper := 1 - dist/shadowHalfHt // 1 at band center, 0 at edge
 		for c := 0; c < ShapeCols; c++ {
+			y := (float64(r) + 0.5) / float64(ShapeRows)
 			x := (float64(c) + 0.5) / float64(ShapeCols)
+
+			// Only darken cells on the sphere body.
 			sDx := (x - 0.5) / bodyRx
 			sDy := (y - 0.5) / bodyRx
 			if sDx*sDx+sDy*sDy >= 1 {
 				continue
 			}
-			s[r][c] = taper * 0.55
+
+			// Ring's back-edge curve at this x: the upper arc of the
+			// tilted ring ellipse.
+			normX := (x - 0.5) / ringRx
+			if normX*normX >= 1 {
+				continue
+			}
+			ringUpperY := 0.5 - ringRy*math.Sqrt(1-normX*normX)
+			shadowY := ringUpperY + shadowOffset
+
+			dist := math.Abs(y - shadowY)
+			if dist > bandHalfHeight {
+				continue
+			}
+			t := 1 - dist/bandHalfHeight
+			s[r][c] = t * maxIntensity
 		}
 	}
 	return s
+}
+
+// neptuneDarkSpotShape — a single compact darker formation representing
+// Neptune's Great Dark Spot. Rendered as a darker-blue overlay on top
+// of the lighter storm formations.
+func neptuneDarkSpotShape() Shape {
+	return buildFormationShape([]formationCenter{
+		{0.32, 0.40, 0.09, 0.045, 0.85},
+	}, 0.40)
 }
 
 // venusCloudShape creates swirling cloud bands — used as an Overlay
@@ -530,17 +603,25 @@ func GetShape(name string) Shape {
 // the overlay color. Order matters — earlier overlays are applied
 // first, so later overlays can tint on top of darkened/shadowed cells.
 var planetOverlays = map[string][]Overlay{
-	"mercury": {{Shape: mercurySurfaceShape(), Color: [3]uint8{40, 40, 40}}},
-	"venus":   {{Shape: venusCloudShape(), Color: [3]uint8{255, 240, 200}}},
-	"earth":   {{Shape: earthCloudShape(), Color: [3]uint8{250, 250, 250}}},
-	"mars":    {{Shape: marsSurfaceShape(), Color: [3]uint8{95, 30, 10}}},
-	"jupiter": {{Shape: jupiterRedSpotShape(), Color: [3]uint8{170, 95, 50}}},
-	"saturn": {
-		{Shape: saturnShadowMask(0.26), Color: [3]uint8{10, 10, 10}},
-		{Shape: saturnRingOverlayMask(0.26), Color: [3]uint8{235, 218, 195}},
+	"mercury": {
+		{Shape: mercuryCratersShape(), Color: [3]uint8{220, 212, 198}},
+		{Shape: mercuryVeinsShape(), Color: [3]uint8{205, 198, 186}},
 	},
-	"uranus":  {{Shape: uranusHazeShape(), Color: [3]uint8{195, 245, 245}}},
-	"neptune": {{Shape: neptuneStormShape(), Color: [3]uint8{110, 145, 230}}},
+	"venus": {{Shape: venusCloudShape(), Color: [3]uint8{255, 240, 200}}},
+	"earth": {{Shape: earthCloudShape(), Color: [3]uint8{250, 250, 250}}},
+	"mars":  {{Shape: marsSurfaceShape(), Color: [3]uint8{95, 30, 10}}},
+	"jupiter": {
+		{Shape: jupiterRedSpotShape(), Color: [3]uint8{170, 95, 50}},
+	},
+	"saturn": {
+		{Shape: saturnShadowMask(0.26), Color: [3]uint8{12, 8, 4}},
+		{Shape: saturnRingOverlayMask(0.26), Color: [3]uint8{218, 192, 155}},
+	},
+	"uranus": {{Shape: uranusHazeShape(), Color: [3]uint8{195, 245, 245}}},
+	"neptune": {
+		{Shape: neptuneDarkSpotShape(), Color: [3]uint8{20, 35, 90}},
+		{Shape: neptuneStormShape(), Color: [3]uint8{110, 145, 230}},
+	},
 }
 
 // GetOverlays returns the per-planet color overlays, or nil if the

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -195,37 +195,19 @@ func applyRings(s Shape, bodyRx float64) Shape {
 	return s
 }
 
-// earthCloudShape generates large, overlapping, wispy cloud formations
-// that read as weather systems rather than discrete spots. The result
-// is additive — overlapping formations accumulate into bigger cloud
-// masses — and modulated by multi-scale sine noise for turbulent
-// fringes and finer positional noise for stippled edges.
-func earthCloudShape() Shape {
-	// Wide, elongated formations. Horizontal > vertical so they read as
-	// atmospheric bands and fronts rather than round puffs. Placed to
-	// overlap in clusters.
-	formations := []struct{ cx, cy, rx, ry, intensity float64 }{
-		// Tropical/equatorial band (overlapping cluster crossing the disk)
-		{0.22, 0.40, 0.16, 0.06, 0.72},
-		{0.36, 0.36, 0.15, 0.05, 0.82},
-		{0.48, 0.42, 0.18, 0.06, 0.88},
-		{0.60, 0.38, 0.17, 0.05, 0.80},
-		{0.72, 0.44, 0.13, 0.07, 0.70},
-		// Northern mid-latitudes — storm track
-		{0.28, 0.22, 0.13, 0.05, 0.70},
-		{0.42, 0.18, 0.11, 0.04, 0.60},
-		{0.58, 0.24, 0.16, 0.05, 0.72},
-		// Southern hemisphere front
-		{0.24, 0.64, 0.15, 0.06, 0.72},
-		{0.40, 0.72, 0.19, 0.05, 0.82},
-		{0.58, 0.68, 0.16, 0.06, 0.76},
-		{0.72, 0.62, 0.12, 0.05, 0.62},
-		// Polar wisps — thin broad streaks near the silhouette
-		{0.50, 0.12, 0.20, 0.04, 0.55},
-		{0.50, 0.86, 0.20, 0.04, 0.55},
-	}
+// formationCenter defines one soft patch contributing to a wispy surface
+// feature. Many overlapping centers produce clouds/craters/storm
+// patterns depending on the color they're rendered in.
+type formationCenter struct {
+	cx, cy, rx, ry, intensity float64
+}
 
-	const bodyR = 0.45
+// buildFormationShape applies the cloud/formation noise algorithm
+// (additive gaussian patches + 3-octave sine wisps + per-cell speckle)
+// to a list of formation centers, constrained to a disk of radius
+// bodyR centered at (0.5, 0.5). Reusable across planets to produce
+// coherent surface textures.
+func buildFormationShape(formations []formationCenter, bodyR float64) Shape {
 	var s Shape
 	for r := 0; r < ShapeRows; r++ {
 		for c := 0; c < ShapeCols; c++ {
@@ -237,9 +219,6 @@ func earthCloudShape() Shape {
 				continue
 			}
 
-			// Additive accumulation of formation contributions. Gentle
-			// Gaussian falloff reaches past d²=1 so edges taper softly;
-			// per-formation weight keeps overlaps from clipping too fast.
 			var intensity float64
 			for _, p := range formations {
 				dx := (x - p.cx) / p.rx
@@ -251,20 +230,13 @@ func earthCloudShape() Shape {
 				intensity += 0.55 * p.intensity * math.Exp(-d2*1.1)
 			}
 
-			// Multi-scale sine noise gives turbulent wispy edges. Three
-			// octaves with decreasing amplitude / increasing frequency.
 			wisp := 0.14 * math.Sin(8*x+4*y+0.7)
 			wisp += 0.08 * math.Sin(16*x-6*y+2.3)
 			wisp += 0.05 * math.Sin(24*x+11*y+4.1)
-
-			// Apply wispy modulation stronger where clouds already
-			// exist so it shapes the fringes rather than creating
-			// random puffs in clear sky.
 			if intensity > 0.04 {
 				intensity += wisp * math.Min(1.0, intensity*1.8)
 			}
 
-			// Fine per-cell noise for stippled edge detail.
 			intensity += (shapeHash(r, c) - 0.5) * 0.10
 
 			if intensity < 0 {
@@ -274,6 +246,175 @@ func earthCloudShape() Shape {
 				intensity = 1
 			}
 			s[r][c] = intensity
+		}
+	}
+	return s
+}
+
+// earthCloudShape — big wispy weather systems across tropical, mid-
+// latitude and polar bands.
+func earthCloudShape() Shape {
+	return buildFormationShape([]formationCenter{
+		{0.22, 0.40, 0.16, 0.06, 0.72},
+		{0.36, 0.36, 0.15, 0.05, 0.82},
+		{0.48, 0.42, 0.18, 0.06, 0.88},
+		{0.60, 0.38, 0.17, 0.05, 0.80},
+		{0.72, 0.44, 0.13, 0.07, 0.70},
+		{0.28, 0.22, 0.13, 0.05, 0.70},
+		{0.42, 0.18, 0.11, 0.04, 0.60},
+		{0.58, 0.24, 0.16, 0.05, 0.72},
+		{0.24, 0.64, 0.15, 0.06, 0.72},
+		{0.40, 0.72, 0.19, 0.05, 0.82},
+		{0.58, 0.68, 0.16, 0.06, 0.76},
+		{0.72, 0.62, 0.12, 0.05, 0.62},
+		{0.50, 0.12, 0.20, 0.04, 0.55},
+		{0.50, 0.86, 0.20, 0.04, 0.55},
+	}, 0.45)
+}
+
+// mercurySurfaceShape — many small dark crater basins scattered across
+// the surface. Rendered with a near-black overlay to read as shadowed
+// impact craters against the grey body.
+func mercurySurfaceShape() Shape {
+	return buildFormationShape([]formationCenter{
+		{0.22, 0.28, 0.05, 0.03, 0.70},
+		{0.35, 0.40, 0.06, 0.04, 0.68},
+		{0.18, 0.58, 0.04, 0.03, 0.55},
+		{0.45, 0.30, 0.07, 0.04, 0.78},
+		{0.64, 0.35, 0.05, 0.03, 0.60},
+		{0.73, 0.52, 0.06, 0.04, 0.72},
+		{0.30, 0.72, 0.05, 0.03, 0.55},
+		{0.56, 0.66, 0.06, 0.04, 0.72},
+		{0.70, 0.72, 0.04, 0.03, 0.52},
+		{0.40, 0.55, 0.05, 0.03, 0.62},
+		{0.58, 0.20, 0.04, 0.03, 0.50},
+		{0.28, 0.46, 0.03, 0.02, 0.48},
+		{0.50, 0.80, 0.05, 0.03, 0.58},
+		{0.78, 0.30, 0.04, 0.03, 0.50},
+		{0.18, 0.38, 0.04, 0.03, 0.55},
+		{0.48, 0.48, 0.05, 0.03, 0.62},
+	}, 0.46)
+}
+
+// marsSurfaceShape — large dusty basins and storm streaks. Rendered
+// with a dark rust color so regions look like deep Martian terrain
+// (Hellas Planitia, Valles Marineris) against the lighter orange body.
+func marsSurfaceShape() Shape {
+	return buildFormationShape([]formationCenter{
+		{0.28, 0.38, 0.13, 0.06, 0.70},
+		{0.54, 0.46, 0.16, 0.05, 0.75}, // Valles-like east-west stripe
+		{0.72, 0.32, 0.09, 0.05, 0.60},
+		{0.20, 0.62, 0.10, 0.06, 0.62},
+		{0.45, 0.68, 0.12, 0.06, 0.68},
+		{0.66, 0.66, 0.08, 0.05, 0.55},
+		{0.34, 0.52, 0.07, 0.04, 0.50},
+		{0.58, 0.22, 0.08, 0.04, 0.55},
+	}, 0.43)
+}
+
+// uranusHazeShape — soft wide haze formations for the otherwise
+// featureless methane atmosphere. Rendered with a brighter cyan so it
+// reads as high-altitude haze.
+func uranusHazeShape() Shape {
+	return buildFormationShape([]formationCenter{
+		{0.28, 0.38, 0.24, 0.08, 0.62},
+		{0.58, 0.52, 0.22, 0.09, 0.68},
+		{0.44, 0.66, 0.20, 0.07, 0.55},
+		{0.52, 0.28, 0.19, 0.06, 0.52},
+		{0.72, 0.36, 0.14, 0.06, 0.48},
+	}, 0.40)
+}
+
+// neptuneStormShape — compact dark storms (à la Great Dark Spot) in
+// the upper cloud deck, overlaid with a brighter blue so they read as
+// distinct weather systems.
+func neptuneStormShape() Shape {
+	return buildFormationShape([]formationCenter{
+		{0.32, 0.40, 0.11, 0.05, 0.75}, // Great Dark Spot analog
+		{0.64, 0.54, 0.10, 0.04, 0.62},
+		{0.52, 0.30, 0.08, 0.04, 0.55},
+		{0.36, 0.66, 0.09, 0.04, 0.62},
+		{0.62, 0.28, 0.07, 0.03, 0.48},
+		{0.50, 0.52, 0.06, 0.03, 0.45},
+	}, 0.40)
+}
+
+// saturnRingOverlayMask returns a cell-level mask of where Saturn's
+// bright ring bands are visible (front half over sphere, both halves
+// outside sphere body). Used by an overlay to tint ring cells toward
+// a pale ring color instead of the planet's gold. The Cassini gap is
+// deliberately excluded so the gap keeps the planet-body color and
+// the band structure stays readable.
+func saturnRingOverlayMask(bodyRx float64) Shape {
+	const (
+		ringRx = 0.48
+		ringRy = 0.10
+	)
+	innerU := bodyRx/ringRx + 0.08
+	brightBands := []struct{ inner, outer float64 }{
+		{innerU, innerU + 0.18},      // A ring
+		{innerU + 0.26, 0.98},        // B ring
+	}
+	var s Shape
+	for r := 0; r < ShapeRows; r++ {
+		for c := 0; c < ShapeCols; c++ {
+			y := (float64(r) + 0.5) / float64(ShapeRows)
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			dx := (x - 0.5) / ringRx
+			dy := (y - 0.5) / ringRy
+			u := math.Sqrt(dx*dx + dy*dy)
+
+			onBand := false
+			for _, b := range brightBands {
+				if u >= b.inner && u <= b.outer {
+					onBand = true
+					break
+				}
+			}
+			if !onBand {
+				continue
+			}
+
+			// Respect sphere occlusion: ring above the sphere's equator
+			// passes behind the body, so we hide it inside the sphere.
+			frontSide := y > 0.5
+			sDx := (x - 0.5) / bodyRx
+			sDy := (y - 0.5) / bodyRx
+			inSphere := sDx*sDx+sDy*sDy < 1
+			if inSphere && !frontSide {
+				continue
+			}
+
+			s[r][c] = 0.82
+		}
+	}
+	return s
+}
+
+// saturnShadowMask returns a thin horizontal band of shadow across the
+// planet's surface where the rings block sunlight. Rendered with a
+// near-black overlay so cells on the sphere dim.
+func saturnShadowMask(bodyRx float64) Shape {
+	var s Shape
+	const (
+		shadowCenterY   = 0.485 // slightly above equator — ring is tilted
+		shadowHalfHt    = 0.020
+	)
+	for r := 0; r < ShapeRows; r++ {
+		y := (float64(r) + 0.5) / float64(ShapeRows)
+		dist := math.Abs(y - shadowCenterY)
+		if dist > shadowHalfHt {
+			continue
+		}
+		taper := 1 - dist/shadowHalfHt // 1 at band center, 0 at edge
+		for c := 0; c < ShapeCols; c++ {
+			x := (float64(c) + 0.5) / float64(ShapeCols)
+			sDx := (x - 0.5) / bodyRx
+			sDy := (y - 0.5) / bodyRx
+			if sDx*sDx+sDy*sDy >= 1 {
+				continue
+			}
+			s[r][c] = taper * 0.55
 		}
 	}
 	return s
@@ -384,12 +525,22 @@ func GetShape(name string) Shape {
 }
 
 // planetOverlays holds per-planet surface features that color-blend
-// onto the base terrain during rendering. Earth gets white clouds,
-// Venus gets warm haze, Jupiter gets a red spot.
+// onto the base terrain during rendering. Each overlay's shade at a
+// given cell controls how much the cell's rendered color leans toward
+// the overlay color. Order matters — earlier overlays are applied
+// first, so later overlays can tint on top of darkened/shadowed cells.
 var planetOverlays = map[string][]Overlay{
-	"earth":   {{Shape: earthCloudShape(), Color: [3]uint8{250, 250, 250}}},
+	"mercury": {{Shape: mercurySurfaceShape(), Color: [3]uint8{40, 40, 40}}},
 	"venus":   {{Shape: venusCloudShape(), Color: [3]uint8{255, 240, 200}}},
-	"jupiter": {{Shape: jupiterRedSpotShape(), Color: [3]uint8{175, 55, 35}}},
+	"earth":   {{Shape: earthCloudShape(), Color: [3]uint8{250, 250, 250}}},
+	"mars":    {{Shape: marsSurfaceShape(), Color: [3]uint8{95, 30, 10}}},
+	"jupiter": {{Shape: jupiterRedSpotShape(), Color: [3]uint8{170, 95, 50}}},
+	"saturn": {
+		{Shape: saturnShadowMask(0.26), Color: [3]uint8{10, 10, 10}},
+		{Shape: saturnRingOverlayMask(0.26), Color: [3]uint8{235, 218, 195}},
+	},
+	"uranus":  {{Shape: uranusHazeShape(), Color: [3]uint8{195, 245, 245}}},
+	"neptune": {{Shape: neptuneStormShape(), Color: [3]uint8{110, 145, 230}}},
 }
 
 // GetOverlays returns the per-planet color overlays, or nil if the

--- a/internal/planets/shapes.go
+++ b/internal/planets/shapes.go
@@ -2,11 +2,14 @@ package planets
 
 import "math"
 
-// Shape dimensions: 10 rows × 24 cols. The 2.4:1 column:row ratio
-// compensates for typical terminal char aspect (~0.5 w/h), yielding
-// a visually round disk.
+// Shape dimensions: 24 rows × 24 cols of SUB-pixels. Rendering pairs
+// consecutive rows into one terminal line using the ▀/▄ half-block
+// characters, so output is ShapeRows/2 terminal rows tall. With
+// subpixels counted as 1 visual unit and terminal chars as 1 unit wide
+// × 2 units tall, this gives a square unit space and a visually round
+// disk when rx == ry in sphereShape.
 const (
-	ShapeRows = 10
+	ShapeRows = 24
 	ShapeCols = 24
 )
 
@@ -118,19 +121,29 @@ func applyRings(s Shape, bodyRx float64) Shape {
 	return s
 }
 
-// applyContinents darkens a handful of interior cells to suggest land
-// masses against the ocean fill.
+// applyContinents darkens a scattered set of interior cells to suggest
+// landmasses. Coordinates scale proportionally to the grid so the patches
+// stay inside the earth disk.
 func applyContinents(s Shape) Shape {
-	patches := [][2]int{
-		{3, 8}, {3, 9}, {4, 7}, {4, 10}, {4, 11},
-		{5, 14}, {5, 15}, {6, 15},
-		{3, 17}, {4, 18},
-		{6, 11}, {7, 10},
+	// Normalized patch centers (x, y) in [0,1] unit space.
+	patches := [][2]float64{
+		{0.35, 0.35}, {0.40, 0.30}, {0.30, 0.45},
+		{0.62, 0.40}, {0.68, 0.55}, {0.55, 0.65},
+		{0.42, 0.62}, {0.72, 0.30}, {0.48, 0.75},
 	}
 	for _, p := range patches {
-		r, c := p[0], p[1]
-		if r >= 0 && r < ShapeRows && c >= 0 && c < ShapeCols && s[r][c] > 0 {
-			s[r][c] *= 0.55
+		rc := int(p[1] * float64(ShapeRows))
+		cc := int(p[0] * float64(ShapeCols))
+		for dr := -1; dr <= 1; dr++ {
+			for dc := -2; dc <= 2; dc++ {
+				r, c := rc+dr, cc+dc
+				if r < 0 || r >= ShapeRows || c < 0 || c >= ShapeCols {
+					continue
+				}
+				if s[r][c] > 0 {
+					s[r][c] *= 0.60
+				}
+			}
 		}
 	}
 	return s
@@ -140,8 +153,8 @@ var (
 	mercurySimpleSphere = sphereShape(0.5, 0.5, 0.46, 0.46)
 	venusUniformHaze    = sphereShape(0.5, 0.5, 0.47, 0.47)
 	earthContinents     = applyContinents(sphereShape(0.5, 0.5, 0.45, 0.45))
-	marsPolarCap        = applyPolarCap(sphereShape(0.5, 0.5, 0.43, 0.43), 2, 1.25)
-	jupiterBands        = applyBands(sphereShape(0.5, 0.5, 0.47, 0.47), 1, 0.72)
+	marsPolarCap        = applyPolarCap(sphereShape(0.5, 0.5, 0.43, 0.43), 5, 1.25)
+	jupiterBands        = applyBands(sphereShape(0.5, 0.5, 0.47, 0.47), 3, 0.70)
 	saturnRings         = applyRings(sphereShape(0.5, 0.5, 0.32, 0.32), 0.32)
 	uranusSmallSphere   = sphereShape(0.5, 0.5, 0.40, 0.40)
 	neptuneDenseCore    = sphereShape(0.5, 0.5, 0.40, 0.40)

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -4,6 +4,7 @@ package provision
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,9 +22,33 @@ var nameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // Params holds everything needed to provision an instance.
 type Params struct {
-	Name   string         // Instance name (validated: alphanumeric + hyphens/underscores)
-	Branch string         // Git branch to checkout (empty = host's current branch)
-	Cfg    *config.Config // Merged configuration
+	Name     string         // Instance name (validated: alphanumeric + hyphens/underscores)
+	Branch   string         // Git branch to checkout (empty = host's current branch)
+	Cfg      *config.Config // Merged configuration
+	Reporter Reporter       // Progress reporter; nil → logReporter{}
+	Stdout   io.Writer      // Subprocess stdout; nil → os.Stdout
+	Stderr   io.Writer      // Subprocess stderr; nil → os.Stderr
+}
+
+func (p Params) reporter() Reporter {
+	if p.Reporter != nil {
+		return p.Reporter
+	}
+	return logReporter{}
+}
+
+func (p Params) stdout() io.Writer {
+	if p.Stdout != nil {
+		return p.Stdout
+	}
+	return os.Stdout
+}
+
+func (p Params) stderr() io.Writer {
+	if p.Stderr != nil {
+		return p.Stderr
+	}
+	return os.Stderr
 }
 
 // Result holds the outcome of a provisioning run.
@@ -35,184 +60,196 @@ type Result struct {
 // Run provisions a cspace devcontainer instance. Idempotent — safe to
 // re-run on a partially configured instance.
 //
-// Steps:
-//  1. Validate instance name
-//  2. If already running, skip container creation
-//  3. Remove orphaned containers, detect branch, create git bundle
-//  4. Create shared Docker volumes
-//  5. Create project network
-//  6. Start global reverse proxy, connect to project network
-//  7. docker compose up -d
-//  8. Wait for container readiness
-//     8b. Inject /etc/hosts for cspace.local resolution inside containers
-//  9. Fix volume ownership
-//  10. Copy bundle into container, init workspace
-//  11. Configure git identity
-//  12. Copy .env files
-//  13. Setup GH_TOKEN + gh auth
-//  14. Idempotent: marketplace, plugins, post-setup hook
-func Run(p Params) (Result, error) {
+// Progress is reported through p.Reporter (defaults to logReporter{}), which
+// receives one Phase call per entry in the Phases slice plus a final Done or
+// Error call. When the container is already running, phases 2–13 are skipped
+// and phase 1 is reported as "Reusing running container"; phase 14 (the
+// idempotent tail: marketplace, plugins, post-setup) always runs.
+//
+// Phases (see the Phases slice for labels):
+//  1. Validating name
+//  2. Removing orphans
+//  3. Bundling repo
+//  4. Creating volumes
+//  5. Creating network
+//  6. Starting reverse proxy
+//  7. Setting up directories (teleport, memory, sessions, context)
+//  8. Starting containers (docker compose up -d)
+//  9. Waiting for container
+//  10. Configuring hosts (inject cspace.local → Traefik)
+//  11. Setting permissions (chown /workspace, /home/dev/.claude, /teleport)
+//  12. Initializing workspace (bundle unpack + init-workspace.sh)
+//  13. Configuring git & env (git identity, .env files, GH_TOKEN)
+//  14. Installing plugins (marketplace + plugins + post-setup)
+func Run(p Params) (result Result, err error) {
+	reporter := p.reporter()
+	currentPhase := ""
+	reportPhase := func(num int, label string) {
+		currentPhase = label
+		reporter.Phase(label, num, len(Phases))
+	}
+	reportWarn := func(msg string) { reporter.Warn(msg) }
+	defer func() {
+		if err != nil {
+			reporter.Error(currentPhase, err)
+			return
+		}
+		reporter.Done()
+	}()
+
 	name := p.Name
 	cfg := p.Cfg
 
-	// 1. Validate instance name
-	if err := validateName(name); err != nil {
+	// Pre-phase validation (no reporter event — failure here is a user
+	// input bug, not a provisioning phase).
+	if err = validateName(name); err != nil {
 		return Result{}, err
 	}
 
 	composeName := cfg.ComposeName(name)
 	created := false
 
-	// 2. Check if already running
 	if instance.IsRunning(composeName) {
-		fmt.Printf("Instance '%s' already running — checking configuration...\n", name)
+		reportPhase(1, "Reusing running container")
 	} else {
 		created = true
-		fmt.Printf("Creating new instance '%s'...\n", name)
 
-		// 3. Remove orphaned containers from a previous instance with the
-		// same name. Handles partial teardowns where docker compose down
-		// didn't fully clean up. Refuses to remove running containers to
-		// prevent accidentally destroying a live instance. Runs before the
-		// expensive git bundle so we fail fast.
-		containerName := cfg.ComposeName(name)
+		// Phase 1: validate (spec label) — note: actual validation
+		// already ran above.
+		reportPhase(1, Phases[0])
+
+		// Phase 2: remove orphaned containers from a previous instance with
+		// the same name. Handles partial teardowns where docker compose
+		// down didn't fully clean up. Refuses to remove running containers
+		// to prevent accidentally destroying a live instance. Runs before
+		// the expensive git bundle so we fail fast.
+		reportPhase(2, Phases[1])
 		for _, suffix := range []string{"", ".browser"} {
-			if err := docker.RemoveOrphanContainer(containerName + suffix); err != nil {
+			if err = docker.RemoveOrphanContainer(composeName + suffix); err != nil {
 				return Result{}, fmt.Errorf("refusing to provision '%s': %w", name, err)
 			}
 		}
 
-		// 4. Detect branch and remote URL
+		// Phase 3: detect branch, remote URL, and create git bundle.
 		branch := p.Branch
 		if branch == "" {
 			branch = gitCurrentBranch(cfg.ProjectRoot)
 		}
 		remoteURL := gitRemoteURL(cfg.ProjectRoot)
-
-		// Create git bundle
 		bundlePath := filepath.Join(os.TempDir(), fmt.Sprintf("cspace-%s.bundle", name))
-		fmt.Printf("Bundling repo (branch: %s)...\n", branch)
-		if err := gitBundleCreate(cfg.ProjectRoot, bundlePath); err != nil {
+		reportPhase(3, Phases[2])
+		if err = gitBundleCreate(cfg.ProjectRoot, bundlePath, p.stdout(), p.stderr()); err != nil {
 			return Result{}, fmt.Errorf("creating git bundle: %w", err)
 		}
 		defer func() { _ = os.Remove(bundlePath) }()
 
-		// 4. Create shared volumes
-		if err := ensureVolumes(cfg); err != nil {
+		// Phase 4: create shared volumes.
+		reportPhase(4, Phases[3])
+		if err = ensureVolumesReported(cfg, reportWarn); err != nil {
 			return Result{}, fmt.Errorf("creating volumes: %w", err)
 		}
 
-		// 5. Ensure the shared project network exists before starting the
-		// Compose stack. The cspace service declares this as an external
-		// network in docker-compose.core.yml, so it must exist before compose up.
-		if err := docker.NetworkCreate(cfg.ProjectNetwork(), cfg.InstanceLabel()); err != nil {
+		// Phase 5: ensure the shared project network exists before
+		// starting the Compose stack. The cspace service declares this as
+		// an external network in docker-compose.core.yml, so it must exist
+		// before compose up.
+		reportPhase(5, Phases[4])
+		if err = docker.NetworkCreate(cfg.ProjectNetwork(), cfg.InstanceLabel()); err != nil {
 			return Result{}, fmt.Errorf("creating project network: %w", err)
 		}
 
-		// 6. Start the global reverse proxy and connect it to the project network.
-		if err := docker.EnsureProxy(cfg.AssetsDir); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: proxy: %v\n", err)
+		// Phase 6: start the global reverse proxy and connect it to the
+		// project network so Traefik can route traffic to instance
+		// containers.
+		reportPhase(6, Phases[5])
+		if perr := docker.EnsureProxy(cfg.AssetsDir); perr != nil {
+			reportWarn(fmt.Sprintf("proxy: %v", perr))
+		}
+		if perr := docker.NetworkConnect(cfg.ProjectNetwork(), docker.ProxyContainerName); perr != nil {
+			reportWarn(fmt.Sprintf("connecting proxy to project network: %v", perr))
 		}
 
-		// Connect the proxy to this project's network so Traefik can
-		// route traffic to instance containers.
-		if err := docker.NetworkConnect(cfg.ProjectNetwork(), docker.ProxyContainerName); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: connecting proxy to project network: %v\n", err)
-		}
-
-		// Ensure the teleport transfer directory exists and is exported
-		// to the compose environment for the bind mount.
+		// Phase 7: set up host-side directories that compose will bind
+		// mount (teleport, memory, sessions, context). Docker auto-creates
+		// missing bind-mount paths as root-owned — we create them first so
+		// they're writable by the invoking user.
+		reportPhase(7, Phases[6])
 		tpDir := teleportHostDir()
-		if err := ensureTeleportDir(tpDir); err != nil {
+		if err = ensureTeleportDir(tpDir); err != nil {
 			return Result{}, err
 		}
-		if err := os.Setenv("CSPACE_TELEPORT_DIR", tpDir); err != nil {
+		if err = os.Setenv("CSPACE_TELEPORT_DIR", tpDir); err != nil {
 			return Result{}, fmt.Errorf("exporting CSPACE_TELEPORT_DIR: %w", err)
 		}
-
-		// Ensure .cspace/memory/ exists on the host with the invoking
-		// user's ownership before compose bind-mounts it — otherwise
-		// Docker auto-creates it root-owned and agents can't write.
-		if err := ensureMemoryDir(cfg.ProjectRoot); err != nil {
+		if err = ensureMemoryDir(cfg.ProjectRoot); err != nil {
+			return Result{}, err
+		}
+		if err = ensureSessionsDir(cfg.SessionsDir()); err != nil {
+			return Result{}, err
+		}
+		if err = ensureContextDir(cfg.ProjectRoot); err != nil {
 			return Result{}, err
 		}
 
-		// Ensure the shared sessions dir exists for the same reason.
-		// All containers for this project bind-mount this to their
-		// /home/dev/.claude/projects/-workspace, so sessions survive
-		// container rebuild and teleport can skip the JSONL copy.
-		if err := ensureSessionsDir(cfg.SessionsDir()); err != nil {
-			return Result{}, err
-		}
-
-		// Ensure .cspace/context/ exists on the host for the cspace-context
-		// bind mount. Every container for this project shares one view
-		// of decisions/discoveries/findings via this directory.
-		if err := ensureContextDir(cfg.ProjectRoot); err != nil {
-			return Result{}, err
-		}
-
-		// 7. Start instance containers
-		if err := compose.Run(name, cfg, "up", "-d"); err != nil {
+		// Phase 8: start instance containers.
+		reportPhase(8, Phases[7])
+		if err = compose.Run(name, cfg, "up", "-d"); err != nil {
 			return Result{}, fmt.Errorf("starting container: %w", err)
 		}
 
-		// 8. Wait for readiness
-		fmt.Println("Waiting for container...")
-		if err := WaitForReady(composeName, 120*time.Second); err != nil {
+		// Phase 9: wait for container readiness.
+		reportPhase(9, Phases[8])
+		if err = WaitForReady(composeName, 120*time.Second); err != nil {
 			return Result{}, err
 		}
 
-		// 8b. Inject /etc/hosts entries so cspace.local hostnames resolve
-		// to Traefik's Docker IP inside all containers.
-		if err := docker.InjectHosts(composeName, cfg.ProjectNetwork()); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: hosts injection: %v\n", err)
+		// Phase 10: inject /etc/hosts entries so cspace.local hostnames
+		// resolve to Traefik's Docker IP inside all containers.
+		reportPhase(10, Phases[9])
+		if herr := docker.InjectHosts(composeName, cfg.ProjectNetwork()); herr != nil {
+			reportWarn(fmt.Sprintf("hosts injection: %v", herr))
 		}
 
-		// 9. Fix volume ownership. /teleport is a host bind mount that Docker
-		// auto-creates as root when the host path doesn't already exist (common
-		// in nested DinD setups), so explicitly fix it alongside the named
-		// volumes to ensure the dev user can write bundles there.
-		if _, err := instance.DcExecRoot(composeName, "chown", "-R", "dev:dev", "/workspace", "/home/dev/.claude", "/teleport"); err != nil {
+		// Phase 11: fix volume ownership. /teleport is a host bind mount
+		// that Docker auto-creates as root when the host path doesn't
+		// already exist (common in nested DinD setups), so explicitly fix
+		// it alongside the named volumes to ensure the dev user can write
+		// bundles there.
+		reportPhase(11, Phases[10])
+		if _, err = instance.DcExecRoot(composeName, "chown", "-R", "dev:dev", "/workspace", "/home/dev/.claude", "/teleport"); err != nil {
 			return Result{}, fmt.Errorf("fixing ownership: %w", err)
 		}
 
-		// 10. Copy bundle and init workspace
-		if err := initWorkspace(composeName, bundlePath, branch, remoteURL); err != nil {
+		// Phase 12: copy bundle and init workspace.
+		reportPhase(12, Phases[11])
+		if err = initWorkspace(composeName, bundlePath, branch, remoteURL); err != nil {
 			return Result{}, fmt.Errorf("initializing workspace: %w", err)
 		}
 
-		// 11. Configure git identity from host
+		// Phase 13: configure git identity, copy .env files, setup
+		// GH_TOKEN + gh auth.
+		reportPhase(13, Phases[12])
 		configureGit(composeName, cfg.ProjectRoot)
-
-		// 12. Copy .env files
 		copyEnvFile(composeName, cfg.ProjectRoot, ".env")
 		copyEnvFile(composeName, cfg.ProjectRoot, ".env.local")
-
-		// 13. Setup GH_TOKEN + gh auth (warn on failure, don't block provisioning)
-		if err := setupGHAuth(composeName, cfg.ProjectRoot); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+		if gerr := setupGHAuth(composeName, cfg.ProjectRoot); gerr != nil {
+			reportWarn(gerr.Error())
 		}
 	}
 
-	// --- Idempotent stages (run even if container was already running) ---
-
-	// 14a. Ensure plugin marketplace
-	if err := ensureMarketplace(composeName); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: marketplace setup: %v\n", err)
+	// Phase 14: idempotent tail (marketplace + plugins + post-setup). Runs
+	// for both new and reused containers.
+	reportPhase(14, Phases[13])
+	if merr := ensureMarketplace(composeName); merr != nil {
+		reportWarn(fmt.Sprintf("marketplace setup: %v", merr))
+	}
+	if ierr := installPlugins(composeName, cfg); ierr != nil {
+		reportWarn(fmt.Sprintf("plugin installation: %v", ierr))
+	}
+	if perr := runPostSetup(composeName, cfg); perr != nil {
+		reportWarn(fmt.Sprintf("post-setup: %v", perr))
 	}
 
-	// 14b. Install recommended plugins
-	if err := installPlugins(composeName, cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: plugin installation: %v\n", err)
-	}
-
-	// 14c. Run post-setup hook
-	if err := runPostSetup(composeName, cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: post-setup: %v\n", err)
-	}
-
-	fmt.Println("Setup complete.")
 	return Result{Created: created, Name: name}, nil
 }
 
@@ -358,10 +395,10 @@ func teleportHostDir() string {
 }
 
 // gitBundleCreate creates a git bundle of the entire repo.
-func gitBundleCreate(projectRoot, bundlePath string) error {
+func gitBundleCreate(projectRoot, bundlePath string, stdout, stderr io.Writer) error {
 	cmd := exec.Command("git", "-C", projectRoot, "bundle", "create", bundlePath, "--all")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	return cmd.Run()
 }
 
@@ -379,6 +416,18 @@ func ensureVolumes(cfg *config.Config) error {
 		if err := docker.VolumeCreate(vol); err != nil {
 			// Log but don't fail — volume may already exist
 			fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+		}
+	}
+	return nil
+}
+
+// ensureVolumesReported is the Reporter-aware variant of ensureVolumes used
+// by provision.Run so warnings flow through the provided reporter instead of
+// directly to stderr. teleport.go still uses ensureVolumes for its own path.
+func ensureVolumesReported(cfg *config.Config, warn func(string)) error {
+	for _, vol := range []string{cfg.LogsVolume()} {
+		if err := docker.VolumeCreate(vol); err != nil {
+			warn(err.Error())
 		}
 	}
 	return nil

--- a/internal/provision/reporter.go
+++ b/internal/provision/reporter.go
@@ -62,7 +62,8 @@ func (logReporter) Done() {
 }
 
 func (logReporter) Error(phase string, err error) {
-	if phase != "" {
-		fmt.Fprintf(os.Stderr, "error in phase %q: %v\n", phase, err)
-	}
+	// No-op. In the default (non-overlay) path, errors are surfaced by the
+	// caller — cobra prints the error returned from Run. Reporter.Error
+	// exists primarily so overlay implementations can render a panel with
+	// the failing phase.
 }

--- a/internal/provision/reporter.go
+++ b/internal/provision/reporter.go
@@ -1,0 +1,68 @@
+package provision
+
+import (
+	"fmt"
+	"os"
+)
+
+// Reporter receives provisioning progress notifications. Implementations
+// choose how to surface them — fmt.Printf (logReporter) or a bubbletea
+// channel (overlay.ChannelReporter).
+//
+// All methods are called from provision.Run's own goroutine; implementations
+// that forward to channels should use buffered channels so they never block
+// provisioning.
+type Reporter interface {
+	// Phase announces entry into a named phase (1-indexed).
+	Phase(name string, num, total int)
+	// Warn surfaces a non-fatal issue.
+	Warn(msg string)
+	// Done is called once, on successful completion.
+	Done()
+	// Error is called once, on fatal failure. phase is the last phase
+	// that started before the failure ("" = unknown).
+	Error(phase string, err error)
+}
+
+// Phases lists the human-readable label for each of the 14 provisioning
+// phases, in order. Exposed so callers (e.g. the overlay) can show the
+// total count ahead of provisioning starting.
+var Phases = []string{
+	"Validating name",
+	"Removing orphans",
+	"Bundling repo",
+	"Creating volumes",
+	"Creating network",
+	"Starting reverse proxy",
+	"Setting up directories",
+	"Starting containers",
+	"Waiting for container",
+	"Configuring hosts",
+	"Setting permissions",
+	"Initializing workspace",
+	"Configuring git & env",
+	"Installing plugins",
+}
+
+// logReporter is the default reporter used when Params.Reporter is nil.
+// It mimics pre-overlay behavior: plain fmt.Printf lines on stdout,
+// warnings on stderr.
+type logReporter struct{}
+
+func (logReporter) Phase(name string, num, total int) {
+	fmt.Printf("[%d/%d] %s...\n", num, total, name)
+}
+
+func (logReporter) Warn(msg string) {
+	fmt.Fprintf(os.Stderr, "warning: %s\n", msg)
+}
+
+func (logReporter) Done() {
+	fmt.Println("Setup complete.")
+}
+
+func (logReporter) Error(phase string, err error) {
+	if phase != "" {
+		fmt.Fprintf(os.Stderr, "error in phase %q: %v\n", phase, err)
+	}
+}

--- a/internal/provision/reporter_test.go
+++ b/internal/provision/reporter_test.go
@@ -1,0 +1,45 @@
+package provision
+
+import "testing"
+
+type captured struct {
+	kind  string // "phase", "warn", "done", "error"
+	name  string
+	num   int
+	total int
+	err   error
+}
+
+type recordingReporter struct{ events []captured }
+
+func (r *recordingReporter) Phase(name string, num, total int) {
+	r.events = append(r.events, captured{kind: "phase", name: name, num: num, total: total})
+}
+func (r *recordingReporter) Warn(msg string) {
+	r.events = append(r.events, captured{kind: "warn", name: msg})
+}
+func (r *recordingReporter) Done() {
+	r.events = append(r.events, captured{kind: "done"})
+}
+func (r *recordingReporter) Error(phase string, err error) {
+	r.events = append(r.events, captured{kind: "error", name: phase, err: err})
+}
+
+func TestReporterInterfaceImplementations(t *testing.T) {
+	// Compile-time assertion: both reporter types implement Reporter.
+	var _ Reporter = (*recordingReporter)(nil)
+	var _ Reporter = logReporter{}
+}
+
+func TestPhasesReference(t *testing.T) {
+	// Sanity check: the Phases slice exposes 14 labeled steps.
+	if len(Phases) != 14 {
+		t.Errorf("Phases: got %d entries, want 14", len(Phases))
+	}
+	if Phases[0] != "Validating name" {
+		t.Errorf("Phases[0]: got %q", Phases[0])
+	}
+	if Phases[13] != "Installing plugins" {
+		t.Errorf("Phases[13]: got %q", Phases[13])
+	}
+}

--- a/lib/planets.json
+++ b/lib/planets.json
@@ -1,0 +1,12 @@
+{
+  "planets": {
+    "mercury": { "symbol": "☿", "color": [169, 169, 169], "accent": [120, 120, 120] },
+    "venus":   { "symbol": "♀", "color": [237, 214, 153], "accent": [200, 170, 110] },
+    "earth":   { "symbol": "♁", "color": [78, 159, 222],  "accent": [60, 130, 90]   },
+    "mars":    { "symbol": "♂", "color": [193, 68, 14],   "accent": [220, 180, 160] },
+    "jupiter": { "symbol": "♃", "color": [200, 133, 44],  "accent": [150, 90, 40]   },
+    "saturn":  { "symbol": "♄", "color": [212, 180, 131], "accent": [170, 140, 100] },
+    "uranus":  { "symbol": "♅", "color": [127, 223, 223], "accent": [90, 170, 170]  },
+    "neptune": { "symbol": "♆", "color": [63, 84, 186],   "accent": [40, 60, 140]   }
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the raw Docker/compose stream during `cspace up` provisioning with a bubbletea alt-screen overlay that animates the instance's planet coming into focus through the 14 provisioning phases. On success the alt-screen exits cleanly and Claude takes over; on failure a bordered error panel shows the failing phase and a `--verbose` hint.

Closes #41.

## What it looks like

- **Black viewport** with double-line cold-silver frame
- **48×48 sub-pixel planet art** on the left using truecolor half-block (`▀`) rendering: each terminal cell encodes two stacked sub-pixels with independent 24-bit colors, giving smooth gradients and edge anti-aliasing without quantization bands
- **2001-style HUD** on the right: `◐◓◑◒` moon-phase spinner, `PH N/14` index, `T+ MM:SS` elapsed, solid-filled progress bar (`█`/`░`), and a sci-fi status word (`CROSSLINK`, `IGNITION`, `HANDSHAKE`, …) with the actual phase name dimmed below
- **Focus-pull** = pixelation (8×8 blocks → 1×1) + color saturation (grey → planet canonical) + braille dither over the last 15% of focus for subtle surface texture
- **Per-planet features**:
  - **Mercury** — dense hash-scattered dark pockmarks + radial ray systems from two bright impact craters
  - **Venus** — swirling cream haze from overlapping sine fields
  - **Earth** — large overlapping cloud formations (14 systems) with multi-scale wispy noise
  - **Mars** — rust basins and a Valles-Marineris-like stripe + polar cap
  - **Jupiter** — darkened NEB/SEB belts, cream-lifted NTZ/EZ/STropZ zones, turbulent band edges, salmon Great Red Spot in the SEB
  - **Saturn** — subtle latitude banding, pink equator tint, 5-band rings (C/B/Cassini/A/outer) with pale tan color and a curved shadow across the body
  - **Uranus** — soft high-altitude cyan haze
  - **Neptune** — dark Great Dark Spot + brighter storm systems

## Fallbacks

The overlay bypasses automatically when:
- `--verbose` is passed
- stdin or stdout isn't a TTY (pipes, CI)
- terminal is smaller than 96×32

In any of those cases the default `logReporter` prints plain `[N/14] Phase…` lines and the command behaves exactly as before.

## Architecture

- `internal/planets/` — `Planet`, `Shape` (48×48 float grid), `Overlay` (shape + color pairs), per-planet shape generators and `buildFormationShape` cloud/formation noise algorithm
- `internal/overlay/` — pure render primitives (`LerpColor`, `RenderPlanetWith`, `pixelateShape`), bubbletea `Model` + `ChannelReporter` + `ProvisionEvent`
- `internal/provision/` — `Reporter` interface + `Phases` slice. `Run` reports 14 phases via `reporter.Phase/Warn/Done/Error`. Default `logReporter` preserves pre-change output.
- `internal/cli/up.go` — new `--verbose` flag, size-gated overlay selection, goroutine-backed dispatch with race-free `done` channel and events-drain on overlay failure

## Dev tooling

- `cmd/overlay-demo/` + `make overlay-demo` — runs the overlay against synthesized phase events so you can iterate on the animation without spinning up a container
- `cmd/overlay-web/` + `make overlay-web` — serves a browser preview at `http://localhost:3000/` showing all 14 phases for a selected planet, with live sliders for `BLOCK`, `HALO`, and the three texture knobs. Converts the ANSI output to inline-styled HTML spans.

## Test plan

- [x] `make fmt-check`, `make vet`, `make test` all pass
- [x] `go test -race` clean on the goroutine-coordinating packages (cli, overlay, provision)
- [x] Unit tests cover: planet lookup/fallback, shape dimensions + value ranges, color lerp endpoints + no uint8 underflow, render dimensions + ANSI escapes + half-block presence, View output for loading and error states, Reporter interface compliance, `Phases` slice integrity
- [ ] Manual: `cspace up --no-claude` shows the overlay with planet art coming into focus for each planet (mercury…neptune)
- [ ] Manual: `cspace up --no-claude --verbose` falls back to plain log output
- [ ] Manual: `cspace up --no-claude | cat` falls back to plain log output (stdout not a TTY)
- [ ] Manual: terminal smaller than 96×32 falls back to plain log output
- [ ] Manual: a provisioning failure renders the error panel with the failing phase name, `cspace up <name> --verbose` hint, and exits non-zero after keypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)