### PR TITLE
Add advisor agents: pluggable long-running specialists (decision-maker + typed MCP messaging)

### DIFF
--- a/.cspace/context/direction.md
+++ b/.cspace/context/direction.md
@@ -1,0 +1,3 @@
+# Direction
+
+cspace exists to make it easy to spin up isolated, reproducible Claude Code devcontainers that can autonomously resolve GitHub issues under human supervision. Near-term focus: multi-agent orchestration with typed messaging and advisor-grade architectural oversight.

--- a/.cspace/context/principles.md
+++ b/.cspace/context/principles.md
@@ -1,0 +1,6 @@
+# Principles
+
+- **Package for cohesion, not just for containment.** A new package is justified when (a) the code has a single clear responsibility beyond a one-liner, (b) tests want their own package boundary, or (c) multiple callers in unrelated places will depend on it.
+- **Helpers with one caller belong next to that caller.** Don't speculatively create a package for code that's only used in one place.
+- **Public API surface should stay minimal.** Prefer unexported helpers until a second caller materializes.
+- **File layout follows actual consumers.** If the only caller is in `internal/cli/`, a helper lives in `internal/cli/`. Promote to its own package the moment a second consumer appears.

--- a/.cspace/context/roadmap.md
+++ b/.cspace/context/roadmap.md
@@ -1,0 +1,3 @@
+# Roadmap
+
+Now: advisor agents (this PR) — pluggable long-running specialists. Next: tighten inter-agent messaging UX, seed real project principles, and measure advisor consultation ROI on real issue batches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,17 @@ The `.cspace/context/` directory holds layered planning context accessible via t
 
 Agents call `read_context` at the start of non-trivial work. `.cspace/context/` is bind-mounted from the host into every cspace container for the project, so writes (decisions, discoveries, findings) by one agent are visible to siblings in real time without git push/pull. The cspace-context MCP server reads/writes directly against this bind mount; `writeEntry` uses `O_EXCL` create for race-safe concurrent creates across containers. See `docs/superpowers/specs/2026-04-13-context-mcp-server-design.md` for the original contract (findings are a later extension).
 
+## Advisors
+
+Advisors are long-running specialist agents consulted alongside the coordinator. Each runs in its own cspace container as `role=advisor` — persistent, session-continuous across `cspace coordinate` invocations. They are declared in `.cspace.json` under `advisors` (see defaults for the decision-maker).
+
+- **Role prompts** live at `lib/advisors/<name>.md` (shipped) or `.cspace/advisors/<name>.md` (per-project override).
+- **Opinions** come from `.cspace/context/principles.md` (human-owned per the context-server spec). Populate it with the project's architectural preferences; the decision-maker reads it on each consultation.
+- **Lifecycle:** `cspace coordinate` auto-launches configured advisors. `cspace advisor list|down|restart` manages them explicitly. Advisors persist across coordinator sessions so their SDK sessions accumulate project context.
+- **Communication:** coordinators and workers consult via the `ask_advisor` MCP tool on the agent-messenger server. Replies arrive as new user turns, not tool results.
+
+See `docs/superpowers/specs/2026-04-18-advisor-agents-design.md` for the full design.
+
 ## Development
 
 The CLI is built with Go using the Cobra framework. The agent supervisor is Node.js ESM.

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ sync-embedded:
 	@cp -r lib/scripts internal/assets/embedded/
 	@cp -r lib/hooks internal/assets/embedded/
 	@cp -r lib/agents internal/assets/embedded/
+	@cp -r lib/advisors internal/assets/embedded/
 	@cp -r lib/agent-supervisor internal/assets/embedded/
 	@rm -rf internal/assets/embedded/agent-supervisor/node_modules
 	@cp -r lib/skills internal/assets/embedded/

--- a/docs/superpowers/plans/2026-04-18-advisor-agents.md
+++ b/docs/superpowers/plans/2026-04-18-advisor-agents.md
@@ -1,0 +1,2822 @@
+# Advisor Agents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a pluggable long-running advisor-agent class, with the decision-maker (Opus, max effort) as the first instance, and move inter-agent messaging from bash `cspace send` to typed role-scoped MCP tools.
+
+**Architecture:** Each advisor runs in its own cspace container as a `role=advisor` supervisor (persistent, session-continuous). Advisors are declared in `.cspace.json` under `advisors`. The existing in-process `agent-messenger` MCP server gains role-scoped send/ask/reply tools; the `status` socket command gains `git_branch` and `queue_depth`. `cspace coordinate` auto-launches configured advisors alongside the coordinator.
+
+**Tech Stack:** Go (CLI, config, supervisor launch), Node.js ESM (agent-supervisor, MCP tools via Claude Agent SDK + Zod), markdown (playbooks).
+
+**Spec:** See `docs/superpowers/specs/2026-04-18-advisor-agents-design.md` for full design rationale.
+
+---
+
+## File Structure
+
+**New files:**
+- `lib/advisors/decision-maker.md` — shipped system prompt for the decision-maker advisor
+- `internal/advisor/advisor.go` — Go package: advisor launch, liveness probe, teardown
+- `internal/advisor/advisor_test.go` — tests for advisor package
+- `internal/cli/advisor.go` — `cspace advisor list|down|restart` subcommands
+
+**Modified files:**
+- `lib/defaults.json` — add `advisors` block with decision-maker default
+- `internal/config/config.go` — `Advisors map[string]AdvisorConfig` on `Config`, `AdvisorConfig` struct
+- `internal/config/config_test.go` — test parsing of advisors block
+- `internal/config/resolve.go` — `ResolveAdvisor(name)` helper
+- `internal/config/resolve_test.go` — test resolve advisor
+- `internal/supervisor/dispatch.go` — add `RoleAdvisor = "advisor"` constant
+- `internal/supervisor/launch.go` — thread advisor role through `LaunchParams` (model/effort overrides)
+- `internal/supervisor/launch_test.go` — test advisor launch args
+- `lib/agent-supervisor/args.mjs` — accept `--role advisor`
+- `lib/agent-supervisor/supervisor.mjs` — role=advisor multi-turn semantics, extended `status` response, `shutdown_self` socket command
+- `lib/agent-supervisor/supervisor.test.mjs` — tests for status extension and shutdown_self
+- `lib/agent-supervisor/sdk-mcp-tools.mjs` — new role-scoped send/ask/reply tools
+- `lib/agent-supervisor/sdk-mcp-tools.test.mjs` — new test file for messaging tools (create)
+- `internal/cli/coordinate.go` — launch advisors on startup, Sonnet default, render roster into prompt
+- `internal/cli/root.go` — register `cspace advisor` command
+- `lib/agents/coordinator.md` — Phase 0.5 (advisors), worker `--persistent` launch, triggers
+- `lib/agents/implementer.md` — handshake at Setup, `ask_advisor` mid-task, `shutdown_self` at Ship
+- `CLAUDE.md` — "Advisors" section
+
+---
+
+## Conventions for this plan
+
+- Go tests use `go test ./...` or scoped forms like `go test ./internal/config/...`.
+- Node tests use `cd lib/agent-supervisor && node --test <file>`. The supervisor package already uses `node --test` with no extra test runner.
+- After each task, run `make vet` and `make test` from the repo root as a sanity check. Tasks reference `make sync-embedded` when assets change — `make build` does this automatically but tests that read embedded assets need it explicitly.
+- Commit messages follow the repo style: short imperative, no trailing period. E.g. `Add AdvisorConfig struct and Advisors map to Config`.
+
+---
+
+### Task 1: Add `AdvisorConfig` struct and `Advisors` map to `Config`
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Test: `internal/config/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/config/config_test.go`:
+
+```go
+func TestConfigAdvisorsBlock(t *testing.T) {
+	cfg, err := loadConfigFromJSON(t, `{
+		"advisors": {
+			"decision-maker": {
+				"model": "claude-opus-4-7",
+				"effort": "max",
+				"baseBranch": "main"
+			},
+			"custom": {
+				"systemPromptFile": ".cspace/advisors/custom.md"
+			}
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if len(cfg.Advisors) != 2 {
+		t.Fatalf("want 2 advisors, got %d", len(cfg.Advisors))
+	}
+	dm, ok := cfg.Advisors["decision-maker"]
+	if !ok {
+		t.Fatalf("missing decision-maker entry")
+	}
+	if dm.Model != "claude-opus-4-7" {
+		t.Errorf("Model = %q, want claude-opus-4-7", dm.Model)
+	}
+	if dm.Effort != "max" {
+		t.Errorf("Effort = %q, want max", dm.Effort)
+	}
+	if dm.BaseBranch != "main" {
+		t.Errorf("BaseBranch = %q, want main", dm.BaseBranch)
+	}
+	custom := cfg.Advisors["custom"]
+	if custom.SystemPromptFile != ".cspace/advisors/custom.md" {
+		t.Errorf("SystemPromptFile = %q", custom.SystemPromptFile)
+	}
+}
+
+func TestConfigAdvisorsEmptyByDefault(t *testing.T) {
+	cfg, err := loadConfigFromJSON(t, `{}`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Advisors == nil {
+		t.Fatal("Advisors should be non-nil (possibly empty map from defaults.json)")
+	}
+}
+```
+
+If `loadConfigFromJSON` does not yet exist, add this helper at the top of the test file (check if a similar helper already exists first):
+
+```go
+func loadConfigFromJSON(t *testing.T, overlay string) (*Config, error) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".cspace.json"), []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return Load(dir, "")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/config/ -run TestConfigAdvisors -v
+```
+
+Expected: FAIL with `cfg.Advisors undefined`.
+
+- [ ] **Step 3: Add the struct and field**
+
+In `internal/config/config.go`, add above the existing `ProjectConfig` struct definition (or wherever related types live):
+
+```go
+// AdvisorConfig configures a single long-running advisor agent.
+// See docs/superpowers/specs/2026-04-18-advisor-agents-design.md.
+type AdvisorConfig struct {
+	Model            string `json:"model,omitempty"`
+	Effort           string `json:"effort,omitempty"`
+	SystemPromptFile string `json:"systemPromptFile,omitempty"`
+	BaseBranch       string `json:"baseBranch,omitempty"`
+}
+```
+
+In the `Config` struct (currently ending around line 48), add the field immediately after `Plugins`:
+
+```go
+Advisors map[string]AdvisorConfig `json:"advisors,omitempty"`
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/config/ -run TestConfigAdvisors -v
+```
+
+Expected: PASS (both subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "Add AdvisorConfig struct and Advisors map to Config"
+```
+
+---
+
+### Task 2: Add `ResolveAdvisor` helper
+
+**Files:**
+- Modify: `internal/config/resolve.go`
+- Test: `internal/config/resolve_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/config/resolve_test.go`:
+
+```go
+func TestResolveAdvisor(t *testing.T) {
+	project := t.TempDir()
+	assets := t.TempDir()
+
+	// Fallback: assets/advisors/decision-maker.md exists.
+	if err := os.MkdirAll(filepath.Join(assets, "advisors"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fallback := filepath.Join(assets, "advisors", "decision-maker.md")
+	if err := os.WriteFile(fallback, []byte("fallback"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ResolveAdvisor(project, assets, "decision-maker")
+	if got != fallback {
+		t.Errorf("fallback: got %s, want %s", got, fallback)
+	}
+
+	// Override: .cspace/advisors/decision-maker.md wins.
+	if err := os.MkdirAll(filepath.Join(project, ".cspace", "advisors"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	override := filepath.Join(project, ".cspace", "advisors", "decision-maker.md")
+	if err := os.WriteFile(override, []byte("override"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got = ResolveAdvisor(project, assets, "decision-maker")
+	if got != override {
+		t.Errorf("override: got %s, want %s", got, override)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/config/ -run TestResolveAdvisor -v
+```
+
+Expected: FAIL with `undefined: ResolveAdvisor`.
+
+- [ ] **Step 3: Add the resolver**
+
+In `internal/config/resolve.go`, add after `ResolveAgent`:
+
+```go
+// ResolveAdvisor resolves an advisor system-prompt file, checking the project
+// override directory first, then falling back to the extracted embedded assets.
+//
+// Resolution order:
+//  1. $PROJECT_ROOT/.cspace/advisors/<name>.md
+//  2. $ASSETS_DIR/advisors/<name>.md
+//
+// Used when AdvisorConfig.SystemPromptFile is empty (the default). Callers
+// that want to respect an explicit SystemPromptFile should check that first.
+func ResolveAdvisor(projectRoot, assetsDir, name string) string {
+	path, _ := resolveFile(projectRoot, assetsDir, "advisors", "advisors", name+".md")
+	return path
+}
+```
+
+And add a `Config` method below the existing `ResolveAgent` method wrapper:
+
+```go
+// ResolveAdvisor resolves an advisor system-prompt file using this config's paths.
+// If the named advisor's config has an explicit SystemPromptFile, that path is
+// returned directly (joined against project root if relative); otherwise the
+// default override/fallback resolution applies.
+func (c *Config) ResolveAdvisor(name string) string {
+	if a, ok := c.Advisors[name]; ok && a.SystemPromptFile != "" {
+		if filepath.IsAbs(a.SystemPromptFile) {
+			return a.SystemPromptFile
+		}
+		return filepath.Join(c.ProjectRoot, a.SystemPromptFile)
+	}
+	return ResolveAdvisor(c.ProjectRoot, c.AssetsDir, name)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/config/ -run TestResolveAdvisor -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/resolve.go internal/config/resolve_test.go
+git commit -m "Add ResolveAdvisor for advisor system-prompt path resolution"
+```
+
+---
+
+### Task 3: Ship default decision-maker system prompt and defaults.json entry
+
+**Files:**
+- Create: `lib/advisors/decision-maker.md`
+- Modify: `lib/defaults.json`
+
+No TDD here — this is shipped content, not executable behavior. Task 1's test already covers defaults merging.
+
+- [ ] **Step 1: Create the shipped system prompt**
+
+Create `lib/advisors/decision-maker.md` with exactly this content:
+
+```markdown
+You are a decision-making consultant to the cspace coordinator and
+implementer agents. You do not write code. You read, reason, and reply.
+
+## Your job
+Weigh architectural trade-offs against the project's stated principles
+and direction. When consulted, produce a recommendation with explicit
+reasoning.
+
+## On each consultation
+1. Call read_context(["direction","principles","roadmap"]) for fresh
+   values (humans edit these; your session cache may be stale).
+2. Call list_findings(status=["open","acknowledged"]) and read any that
+   bear on the question.
+3. Call list_entries(kind="decisions") and read any prior decisions that
+   touch the same area.
+4. Read code as needed — grep, read, follow references.
+
+## Response shape
+- Recommendation (one sentence).
+- Key reasoning (3-8 bullets, each tied to a principle, constraint, or
+  prior decision).
+- Alternatives considered and why they lose.
+- Follow-ups for the caller if any.
+
+## Record your conclusions
+For non-trivial calls, call log_decision(...) so the reasoning survives
+beyond your session. The coordinator/implementer reading it later should
+be able to act without re-consulting you.
+
+## On handshakes
+If the message is a handshake_advisor (an implementer saying "starting
+work on X"), do a shallow research pass: read the issue, grep the hinted
+files, skim related decisions/findings. Do not reply to the implementer.
+Your SDK session now has that context and will be warm for later questions.
+
+The note_to_coordinator tool is available if during research you discover
+something the coordinator needs to know right away (a conflict with a
+prior decision, a finding that invalidates the issue's premise). Use it
+sparingly — the default on handshakes is silence.
+
+## Anti-patterns
+- Do not edit code, open PRs, run verify commands, or take side effects
+  beyond context-server writes.
+- Do not answer questions that aren't architectural — redirect to the
+  coordinator.
+- Do not speculate past what principles.md and direction.md actually say.
+  If they're silent on a question, say so explicitly.
+```
+
+- [ ] **Step 2: Add advisors block to defaults.json**
+
+In `lib/defaults.json`, after the `plugins` block and before `services`, insert:
+
+```json
+  "advisors": {
+    "decision-maker": {
+      "model": "claude-opus-4-7",
+      "effort": "max",
+      "baseBranch": "main"
+    }
+  },
+```
+
+Verify it's still valid JSON:
+
+```bash
+python3 -m json.tool < lib/defaults.json > /dev/null && echo "valid JSON"
+```
+
+Expected: `valid JSON`.
+
+- [ ] **Step 3: Sync embedded assets**
+
+```bash
+make sync-embedded
+```
+
+Expected: no errors; embedded copy of `lib/` refreshed.
+
+- [ ] **Step 4: Verify defaults are loaded**
+
+```bash
+go test ./internal/config/... -v
+```
+
+Expected: all tests pass. Existing parse tests see the new `advisors` block without issue.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/advisors/decision-maker.md lib/defaults.json internal/assets/embedded
+git commit -m "Ship default decision-maker system prompt and defaults.json advisors block"
+```
+
+---
+
+### Task 4: Extend supervisor `status` with `git_branch` and `queue_depth`
+
+**Files:**
+- Modify: `lib/agent-supervisor/supervisor.mjs`
+- Test: `lib/agent-supervisor/supervisor.test.mjs`
+
+The current `status` reply is `{ role, instance, sessionId, turns, lastActivityMs }`. We add `git_branch` (cached 2s) and `queue_depth`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `lib/agent-supervisor/supervisor.test.mjs` (if the file exists) or create it with:
+
+```javascript
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { computeStatusExtras } from './supervisor.mjs'
+
+test('computeStatusExtras returns queue_depth and git_branch', async () => {
+  const extras = await computeStatusExtras({
+    queueLength: 3,
+    cwd: process.cwd(),
+  })
+  assert.equal(extras.queue_depth, 3)
+  assert.equal(typeof extras.git_branch, 'string')
+})
+
+test('computeStatusExtras caches git_branch within TTL', async () => {
+  const state = { lastBranch: null, lastBranchTs: 0 }
+  const first = await computeStatusExtras({
+    queueLength: 0,
+    cwd: process.cwd(),
+    cache: state,
+    now: () => 1000,
+  })
+  assert.ok(state.lastBranchTs === 1000)
+  const second = await computeStatusExtras({
+    queueLength: 0,
+    cwd: '/does/not/exist',
+    cache: state,
+    now: () => 1500, // within 2s TTL
+  })
+  assert.equal(second.git_branch, first.git_branch, 'should reuse cached branch')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd lib/agent-supervisor && node --test supervisor.test.mjs
+```
+
+Expected: FAIL with `computeStatusExtras is not a function`.
+
+- [ ] **Step 3: Implement `computeStatusExtras`**
+
+In `lib/agent-supervisor/supervisor.mjs`, add above the `startSocket` function:
+
+```javascript
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const GIT_BRANCH_TTL_MS = 2000
+
+/**
+ * Build the extra fields to merge into the supervisor's status reply.
+ * `cache` is a mutable object ({lastBranch, lastBranchTs}) used to cache
+ * the git branch result across rapid-fire calls. `now` is injectable for tests.
+ */
+export async function computeStatusExtras({ queueLength, cwd, cache, now }) {
+  cache = cache || computeStatusExtras.defaultCache
+  now = now || Date.now
+
+  const extras = { queue_depth: queueLength }
+
+  const t = now()
+  if (cache.lastBranch !== null && t - cache.lastBranchTs < GIT_BRANCH_TTL_MS) {
+    extras.git_branch = cache.lastBranch
+  } else {
+    let branch = 'unknown'
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD'], {
+        timeout: 1000,
+      })
+      branch = stdout.trim() || 'unknown'
+    } catch {
+      branch = 'unknown'
+    }
+    cache.lastBranch = branch
+    cache.lastBranchTs = t
+    extras.git_branch = branch
+  }
+
+  return extras
+}
+computeStatusExtras.defaultCache = { lastBranch: null, lastBranchTs: 0 }
+```
+
+- [ ] **Step 4: Wire extras into the status socket reply**
+
+In `supervisor.mjs`, find the `status` case inside `handleRequest`:
+
+```javascript
+case 'status':
+  return { ok: true, status: getStatus() }
+```
+
+Replace with:
+
+```javascript
+case 'status': {
+  const base = getStatus()
+  const extras = await computeStatusExtras({
+    queueLength: promptQueue._queue.length,
+    cwd: cwd,
+  })
+  return { ok: true, status: { ...base, ...extras } }
+}
+```
+
+Note: this requires `cwd` and `promptQueue` to be in scope where `handleRequest` is defined. `startSocket` already takes `promptQueue` as a parameter. Update `startSocket`'s signature to also accept `cwd`, and thread it from the `main()` call site.
+
+Update the `startSocket({ sockPath, promptQueue, getQuery, getStatus, onShutdown })` signature to:
+
+```javascript
+function startSocket({ sockPath, promptQueue, cwd, getQuery, getStatus, onShutdown }) {
+```
+
+And update the `main()` call site (search for `const sockServer = startSocket({`) to pass `cwd`:
+
+```javascript
+const sockServer = startSocket({
+  sockPath,
+  promptQueue,
+  cwd,
+  getQuery: () => queryHandle,
+  ...
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd lib/agent-supervisor && node --test supervisor.test.mjs
+```
+
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/agent-supervisor/supervisor.mjs lib/agent-supervisor/supervisor.test.mjs
+git commit -m "Extend supervisor status socket with queue_depth and cached git_branch"
+```
+
+---
+
+### Task 5: Add `shutdown_self` socket command
+
+**Files:**
+- Modify: `lib/agent-supervisor/supervisor.mjs`
+- Test: `lib/agent-supervisor/supervisor.test.mjs`
+
+The existing `shutdown` socket command already works. We're adding a named alias tailored for agent self-shutdown so the MCP tool layer can expose it with a clean name. For now, alias `shutdown_self` to the same path as `shutdown`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `lib/agent-supervisor/supervisor.test.mjs`:
+
+```javascript
+import { handleSupervisorRequest } from './supervisor.mjs'
+
+test('shutdown_self closes the prompt queue', async () => {
+  let shutdownCalled = false
+  const state = {
+    promptQueue: { push: () => {}, close: () => {}, _queue: [] },
+    cwd: process.cwd(),
+    onShutdown: () => { shutdownCalled = true },
+    getQuery: () => null,
+    getStatus: () => ({ role: 'agent', instance: 'test', sessionId: '', turns: 0, lastActivityMs: 0 }),
+  }
+  const reply = await handleSupervisorRequest({ cmd: 'shutdown_self' }, state)
+  assert.equal(reply.ok, true)
+  assert.equal(shutdownCalled, true)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd lib/agent-supervisor && node --test supervisor.test.mjs
+```
+
+Expected: FAIL with `handleSupervisorRequest is not a function`.
+
+- [ ] **Step 3: Extract `handleSupervisorRequest` as an exported pure-ish function**
+
+In `supervisor.mjs`, extract the `handleRequest` logic inside `startSocket` into a top-level exported function. Replace the inline definition with a call to the exported one.
+
+Add near the top of the file (after helpers):
+
+```javascript
+/**
+ * Handle a single supervisor socket request. Exported for tests.
+ * `state` = { promptQueue, cwd, getQuery, getStatus, onShutdown }
+ */
+export async function handleSupervisorRequest(req, state) {
+  switch (req.cmd) {
+    case 'send_user_message': {
+      if (typeof req.text !== 'string' || !req.text) {
+        return { ok: false, error: 'text required' }
+      }
+      state.promptQueue.push(makeUserMessage(req.text))
+      return { ok: true }
+    }
+    case 'interrupt': {
+      const q = state.getQuery()
+      if (!q) return { ok: false, error: 'query not yet started' }
+      try {
+        await q.interrupt()
+        return { ok: true }
+      } catch (e) {
+        return { ok: false, error: e.message }
+      }
+    }
+    case 'status': {
+      const base = state.getStatus()
+      const extras = await computeStatusExtras({
+        queueLength: state.promptQueue._queue.length,
+        cwd: state.cwd,
+      })
+      return { ok: true, status: { ...base, ...extras } }
+    }
+    case 'shutdown':
+    case 'shutdown_self':
+      state.onShutdown()
+      return { ok: true }
+    default:
+      return { ok: false, error: `unknown cmd: ${req.cmd}` }
+  }
+}
+```
+
+Inside `startSocket`, replace the existing inline `handleRequest` with a wrapper that delegates:
+
+```javascript
+async function handleRequest(req) {
+  return handleSupervisorRequest(req, {
+    promptQueue,
+    cwd,
+    getQuery,
+    getStatus,
+    onShutdown,
+  })
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd lib/agent-supervisor && node --test supervisor.test.mjs
+```
+
+Expected: PASS (all tests including prior `computeStatusExtras` ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/agent-supervisor/supervisor.mjs lib/agent-supervisor/supervisor.test.mjs
+git commit -m "Extract handleSupervisorRequest and add shutdown_self command alias"
+```
+
+---
+
+### Task 6: Add shared MCP-tool helpers (socket send+status, envelope builder, error envelope)
+
+**Files:**
+- Modify: `lib/agent-supervisor/sdk-mcp-tools.mjs`
+- Create: `lib/agent-supervisor/sdk-mcp-tools.test.mjs`
+
+Adds internal helpers that all subsequent send/ask/reply tools use. No tool registration yet.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/agent-supervisor/sdk-mcp-tools.test.mjs`:
+
+```javascript
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import net from 'node:net'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  sendAndFetchStatus,
+  buildDeliveredEnvelope,
+  buildErrorEnvelope,
+} from './sdk-mcp-tools.mjs'
+
+function startFakeSupervisor(sockPath, statusReply) {
+  const srv = net.createServer((conn) => {
+    let buf = ''
+    conn.on('data', (chunk) => {
+      buf += chunk.toString('utf-8')
+      while (true) {
+        const idx = buf.indexOf('\n')
+        if (idx < 0) break
+        const line = buf.slice(0, idx)
+        buf = buf.slice(idx + 1)
+        const req = JSON.parse(line)
+        if (req.cmd === 'send_user_message') {
+          conn.write(JSON.stringify({ ok: true }) + '\n')
+        } else if (req.cmd === 'status') {
+          conn.write(JSON.stringify({ ok: true, status: statusReply }) + '\n')
+        }
+      }
+    })
+  })
+  return new Promise((resolve) => srv.listen(sockPath, () => resolve(srv)))
+}
+
+test('sendAndFetchStatus delivers message and returns status', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sup-'))
+  const sockPath = path.join(tmp, 'supervisor.sock')
+  const statusReply = {
+    role: 'agent',
+    instance: 'decision-maker',
+    sessionId: 'abc',
+    turns: 7,
+    lastActivityMs: 10_000,
+    queue_depth: 1,
+    git_branch: 'main',
+  }
+  const srv = await startFakeSupervisor(sockPath, statusReply)
+  try {
+    const r = await sendAndFetchStatus(sockPath, 'hello')
+    assert.equal(r.delivered, true)
+    assert.equal(r.status.instance, 'decision-maker')
+    assert.equal(r.status.git_branch, 'main')
+  } finally {
+    srv.close()
+  }
+})
+
+test('sendAndFetchStatus returns delivered:false for missing socket', async () => {
+  const r = await sendAndFetchStatus('/tmp/does-not-exist-xyzzy.sock', 'hello')
+  assert.equal(r.delivered, false)
+  assert.match(r.error, /not present|connect|ENOENT/)
+})
+
+test('buildDeliveredEnvelope shape', () => {
+  const env = buildDeliveredEnvelope({
+    recipient: 'decision-maker',
+    status: { git_branch: 'main', turns: 5, lastActivityMs: 1000, queue_depth: 0, sessionId: 's' },
+    expectedReplyWindow: '~2-10 min',
+    guidance: 'Continue your current task.',
+  })
+  assert.equal(env.delivered, true)
+  assert.equal(env.recipient, 'decision-maker')
+  assert.equal(env.recipient_status.git_branch, 'main')
+  assert.equal(env.recipient_status.idle_for_seconds, 1)
+  assert.equal(env.expected_reply_window, '~2-10 min')
+})
+
+test('buildErrorEnvelope shape', () => {
+  const env = buildErrorEnvelope({
+    recipient: 'gone',
+    sockPath: '/tmp/gone.sock',
+    reason: 'socket not present',
+  })
+  assert.equal(env.delivered, false)
+  assert.equal(env.recipient, 'gone')
+  assert.match(env.error, /not reachable/)
+  assert.match(env.suggestion, /restart/)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: FAIL with named exports missing.
+
+- [ ] **Step 3: Implement helpers**
+
+In `lib/agent-supervisor/sdk-mcp-tools.mjs`, after the existing `trySocketRequest` / `sockPathFor` helpers, add:
+
+```javascript
+/**
+ * Send a user message to a supervisor's socket and then probe its status.
+ * Returns `{delivered, status, error?}`. On delivery failure (no socket,
+ * bad reply), returns `{delivered: false, error: <reason>}`.
+ */
+export async function sendAndFetchStatus(sockPath, text) {
+  const sendReply = await trySocketRequest(sockPath, { cmd: 'send_user_message', text })
+  if (!sendReply.ok) {
+    return { delivered: false, error: sendReply.error || 'send failed' }
+  }
+  const statusReply = await trySocketRequest(sockPath, { cmd: 'status' })
+  if (!statusReply.ok || !statusReply.status) {
+    return { delivered: true, status: null, error: statusReply.error || 'status unavailable' }
+  }
+  return { delivered: true, status: statusReply.status }
+}
+
+/**
+ * Build the standard send-tool return envelope for a successful delivery.
+ */
+export function buildDeliveredEnvelope({ recipient, status, expectedReplyWindow, guidance }) {
+  const recipientStatus = status
+    ? {
+        git_branch: status.git_branch || 'unknown',
+        turns_completed: status.turns ?? 0,
+        idle_for_seconds: Math.round((status.lastActivityMs ?? 0) / 1000),
+        queue_depth: status.queue_depth ?? 0,
+        session_id: status.sessionId || null,
+      }
+    : null
+  return {
+    delivered: true,
+    recipient,
+    recipient_status: recipientStatus,
+    expected_reply_window: expectedReplyWindow,
+    guidance,
+  }
+}
+
+/**
+ * Build the standard send-tool return envelope for a delivery failure.
+ */
+export function buildErrorEnvelope({ recipient, sockPath, reason }) {
+  return {
+    delivered: false,
+    recipient,
+    error: `recipient's supervisor not reachable at ${sockPath} (${reason})`,
+    suggestion: `restart the recipient (e.g. \`cspace advisor restart ${recipient}\` for advisors, or \`cspace restart-supervisor ${recipient}\` for workers)`,
+  }
+}
+
+/**
+ * Wrap the envelope in the { content: [{type: 'text', text: ...}] }
+ * shape that MCP tools return.
+ */
+export function toolResult(envelope) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(envelope, null, 2) }],
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/agent-supervisor/sdk-mcp-tools.mjs lib/agent-supervisor/sdk-mcp-tools.test.mjs
+git commit -m "Add MCP-tool helpers for socket send+status and envelope building"
+```
+
+---
+
+### Task 7: Expose advisor recipient enum at supervisor startup
+
+**Files:**
+- Modify: `lib/agent-supervisor/args.mjs` (new `--advisors` flag)
+- Modify: `lib/agent-supervisor/supervisor.mjs` (read flag, pass to MCP builder)
+- Modify: `lib/agent-supervisor/sdk-mcp-tools.mjs` (accept `advisorNames` parameter)
+
+The MCP tool schemas need an enum of advisor names. Since `sdk-mcp-tools.mjs` is purely Node (no cspace config access), the Go launcher passes the list via a new CLI flag.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `lib/agent-supervisor/args.test.mjs` (file exists or creatable):
+
+```javascript
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseArgsForTest } from './args.mjs'
+
+test('--advisors accepts comma-separated list', () => {
+  const args = parseArgsForTest([
+    'node', 'supervisor.mjs',
+    '--role', 'agent',
+    '--instance', 'issue-42',
+    '--prompt-file', '/tmp/p',
+    '--advisors', 'decision-maker,critic',
+  ])
+  assert.deepEqual(args.advisors, ['decision-maker', 'critic'])
+})
+
+test('--advisors absent yields empty list', () => {
+  const args = parseArgsForTest([
+    'node', 'supervisor.mjs',
+    '--role', 'agent',
+    '--instance', 'issue-42',
+    '--prompt-file', '/tmp/p',
+  ])
+  assert.deepEqual(args.advisors, [])
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd lib/agent-supervisor && node --test args.test.mjs
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add the flag to parser**
+
+In `lib/agent-supervisor/args.mjs`:
+
+- In the initial `args` object, add `advisors: []`.
+- In the parse loop, add:
+
+```javascript
+else if (arg === '--advisors') {
+  const val = argv[++i] || ''
+  args.advisors = val.split(',').map((s) => s.trim()).filter(Boolean)
+}
+```
+
+- In the help text, add `  --advisors <csv>              Comma-separated advisor names (populates MCP tool enums).`
+
+- [ ] **Step 4: Thread through `supervisor.mjs`**
+
+In `supervisor.mjs`, find `buildMessengerMcpServer({ role: args.role, ... })` and pass `advisorNames: args.advisors`:
+
+```javascript
+const { server: messengerServer, toolNames } = buildMessengerMcpServer({
+  role: args.role,
+  msgDir,
+  instance: args.instance,
+  eventLogRoot: args.eventLogDir || '/logs/events',
+  advisorNames: args.advisors,
+})
+```
+
+In `sdk-mcp-tools.mjs`, update the `buildMessengerMcpServer` signature to accept `advisorNames`:
+
+```javascript
+export function buildMessengerMcpServer({ role, msgDir, instance, eventLogRoot, advisorNames }) {
+  advisorNames = advisorNames || []
+  const tools = []
+  // ...
+}
+```
+
+No tool changes yet — we just plumb the parameter. Validated by subsequent task tests.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd lib/agent-supervisor && node --test args.test.mjs supervisor.test.mjs sdk-mcp-tools.test.mjs
+```
+
+Expected: PASS for all.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/agent-supervisor/args.mjs lib/agent-supervisor/supervisor.mjs lib/agent-supervisor/sdk-mcp-tools.mjs lib/agent-supervisor/args.test.mjs
+git commit -m "Plumb advisor-name list through supervisor args into MCP builder"
+```
+
+---
+
+### Task 8: Worker MCP tools — `notify_coordinator`, `ask_coordinator`, `shutdown_self`
+
+**Files:**
+- Modify: `lib/agent-supervisor/sdk-mcp-tools.mjs`
+- Test: `lib/agent-supervisor/sdk-mcp-tools.test.mjs`
+
+The simplest role set — worker → coordinator and worker self-shutdown. Advisors come next.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sdk-mcp-tools.test.mjs`:
+
+```javascript
+import { buildMessengerMcpServer } from './sdk-mcp-tools.mjs'
+
+function findTool(server, name) {
+  const full = `mcp__agent-messenger__${name}`
+  // createSdkMcpServer stores tools internally; we test via toolNames listing.
+  return full
+}
+
+test('worker role exposes notify_coordinator, ask_coordinator, shutdown_self', () => {
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'agent',
+    msgDir: '/tmp',
+    instance: 'issue-42',
+    eventLogRoot: '/tmp',
+    advisorNames: [],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__notify_coordinator'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__ask_coordinator'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__shutdown_self'))
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: FAIL (tool names missing).
+
+- [ ] **Step 3: Register the tools**
+
+In `sdk-mcp-tools.mjs`, after the existing `if (role === 'coordinator') { ... }` block, add:
+
+```javascript
+if (role === 'agent') {
+  tools.push(
+    tool(
+      'notify_coordinator',
+      'Send a status update or completion message to the coordinator. Fire-and-forget — no reply expected. Use this for: "issue-N complete, PR: ...", progress updates, and error reports.',
+      {
+        message: z.string().describe('The message body. Plain text.'),
+      },
+      async ({ message }) => {
+        const sockPath = sockPathFor(msgDir, '_coordinator')
+        const r = await sendAndFetchStatus(sockPath, message)
+        if (!r.delivered) {
+          return toolResult(buildErrorEnvelope({
+            recipient: '_coordinator',
+            sockPath,
+            reason: r.error,
+          }))
+        }
+        return toolResult(buildDeliveredEnvelope({
+          recipient: '_coordinator',
+          status: r.status,
+          expectedReplyWindow: 'none (fire-and-forget notification)',
+          guidance: 'Continue your current task. The coordinator will see this as a new user turn on its side.',
+        }))
+      },
+    ),
+
+    tool(
+      'ask_coordinator',
+      'Ask the coordinator a question. Expect a reply arriving later as a new user turn on your session (not as a tool result). Use when your task scope is ambiguous and only the coordinator can resolve it.',
+      {
+        question: z.string().describe('The question to ask. Be specific; include context the coordinator may not remember.'),
+      },
+      async ({ question }) => {
+        const sockPath = sockPathFor(msgDir, '_coordinator')
+        const r = await sendAndFetchStatus(sockPath, `[question from ${instance}] ${question}`)
+        if (!r.delivered) {
+          return toolResult(buildErrorEnvelope({
+            recipient: '_coordinator',
+            sockPath,
+            reason: r.error,
+          }))
+        }
+        return toolResult(buildDeliveredEnvelope({
+          recipient: '_coordinator',
+          status: r.status,
+          expectedReplyWindow: '~1-5 min (coordinator reply time)',
+          guidance: 'Continue work on parts of your task that do not depend on the answer. When the reply arrives as a new user message, integrate it and proceed.',
+        }))
+      },
+    ),
+
+    tool(
+      'shutdown_self',
+      'Close your own supervisor cleanly. Call this ONLY after notify_coordinator with your final completion message (task done, PR opened, etc.). Your container stays up; the coordinator can reclaim it.',
+      {},
+      async () => {
+        const sockPath = sockPathFor(msgDir, instance)
+        const reply = await trySocketRequest(sockPath, { cmd: 'shutdown_self' })
+        if (!reply.ok) {
+          return toolResult({ ok: false, error: reply.error || 'shutdown failed' })
+        }
+        return toolResult({ ok: true, message: 'Shutdown requested. Supervisor will exit shortly.' })
+      },
+    ),
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/agent-supervisor/sdk-mcp-tools.mjs lib/agent-supervisor/sdk-mcp-tools.test.mjs
+git commit -m "Add worker MCP tools: notify_coordinator, ask_coordinator, shutdown_self"
+```
+
+---
+
+### Task 9: Advisor-targeting tools for workers and coordinators
+
+**Files:**
+- Modify: `lib/agent-supervisor/sdk-mcp-tools.mjs`
+- Test: `lib/agent-supervisor/sdk-mcp-tools.test.mjs`
+
+Adds `handshake_advisor`, `ask_advisor`, and `send_to_advisor`. The `name` parameter is validated against the `advisorNames` enum.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sdk-mcp-tools.test.mjs`:
+
+```javascript
+test('worker role exposes handshake_advisor and ask_advisor when advisors are configured', () => {
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'agent',
+    msgDir: '/tmp',
+    instance: 'issue-42',
+    eventLogRoot: '/tmp',
+    advisorNames: ['decision-maker'],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__handshake_advisor'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__ask_advisor'))
+})
+
+test('coordinator role exposes ask_advisor and send_to_advisor when advisors are configured', () => {
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'coordinator',
+    msgDir: '/tmp',
+    eventLogRoot: '/tmp',
+    advisorNames: ['decision-maker'],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__ask_advisor'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__send_to_advisor'))
+})
+
+test('advisor tools are omitted when no advisors configured', () => {
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'agent',
+    msgDir: '/tmp',
+    instance: 'issue-42',
+    eventLogRoot: '/tmp',
+    advisorNames: [],
+  })
+  assert.ok(!toolNames.includes('mcp__agent-messenger__handshake_advisor'))
+  assert.ok(!toolNames.includes('mcp__agent-messenger__ask_advisor'))
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Register the advisor-targeting tools**
+
+In `sdk-mcp-tools.mjs`, add a helper first (near the top of `buildMessengerMcpServer`):
+
+```javascript
+function advisorNameSchema(names) {
+  if (names.length === 0) {
+    // empty enum is invalid; callers guard against this by checking length first
+    return z.string()
+  }
+  return z.enum(names)
+}
+
+const HANDSHAKE_GUIDANCE =
+  'No reply expected. The advisor will do a shallow research pass so it is warm for later questions.'
+const QUESTION_GUIDANCE =
+  'Continue work on parts of your task that do not depend on the answer. When the reply arrives as a new user message, integrate it and proceed.'
+```
+
+Then, inside `buildMessengerMcpServer`, gate on `advisorNames.length > 0`:
+
+```javascript
+const hasAdvisors = advisorNames.length > 0
+
+if (role === 'agent' && hasAdvisors) {
+  tools.push(
+    tool(
+      'handshake_advisor',
+      'Tell an advisor what you are about to work on, so it warms its research context. Fire-and-forget — the advisor will not reply to you. Call once per task, near the start.',
+      {
+        name: advisorNameSchema(advisorNames),
+        summary: z.string().describe('One-line summary of what you are working on (e.g. "issue #42: add retry logic to webhook handler")'),
+        hints: z.array(z.string()).optional().describe('Up to ~5 file or module hints that might be relevant'),
+      },
+      async ({ name, summary, hints }) => {
+        const sockPath = sockPathFor(msgDir, name)
+        const body = `[handshake from ${instance}] ${summary}\nHints: ${(hints || []).join(', ') || '(none)'}`
+        const r = await sendAndFetchStatus(sockPath, body)
+        if (!r.delivered) {
+          return toolResult(buildErrorEnvelope({ recipient: name, sockPath, reason: r.error }))
+        }
+        return toolResult(buildDeliveredEnvelope({
+          recipient: name,
+          status: r.status,
+          expectedReplyWindow: 'none (handshake)',
+          guidance: HANDSHAKE_GUIDANCE,
+        }))
+      },
+    ),
+  )
+}
+
+if ((role === 'agent' || role === 'coordinator') && hasAdvisors) {
+  tools.push(
+    tool(
+      'ask_advisor',
+      'Ask an advisor a question. Reply arrives later as a new user turn on your session, not as a tool result.',
+      {
+        name: advisorNameSchema(advisorNames),
+        question: z.string().describe('The question. Be specific; the advisor only sees what you send.'),
+        kind: z.enum(['question', 'followup']).default('question').describe('"question" = first ask; "followup" = tighter question in an ongoing consultation'),
+      },
+      async ({ name, question, kind }) => {
+        const sockPath = sockPathFor(msgDir, name)
+        const sender = instance || '_coordinator'
+        const body = `[${kind} from ${sender}] ${question}`
+        const r = await sendAndFetchStatus(sockPath, body)
+        if (!r.delivered) {
+          return toolResult(buildErrorEnvelope({ recipient: name, sockPath, reason: r.error }))
+        }
+        return toolResult(buildDeliveredEnvelope({
+          recipient: name,
+          status: r.status,
+          expectedReplyWindow: kind === 'followup' ? '~1-5 min' : '~2-10 min (complex question)',
+          guidance: QUESTION_GUIDANCE,
+        }))
+      },
+    ),
+  )
+}
+
+if (role === 'coordinator' && hasAdvisors) {
+  tools.push(
+    tool(
+      'send_to_advisor',
+      'Send a fire-and-forget note to an advisor (no reply expected). Use for informational updates like "issue-42 has been merged" or "new principle added to principles.md".',
+      {
+        name: advisorNameSchema(advisorNames),
+        message: z.string(),
+      },
+      async ({ name, message }) => {
+        const sockPath = sockPathFor(msgDir, name)
+        const r = await sendAndFetchStatus(sockPath, `[note from _coordinator] ${message}`)
+        if (!r.delivered) {
+          return toolResult(buildErrorEnvelope({ recipient: name, sockPath, reason: r.error }))
+        }
+        return toolResult(buildDeliveredEnvelope({
+          recipient: name,
+          status: r.status,
+          expectedReplyWindow: 'none (note)',
+          guidance: 'No reply expected.',
+        }))
+      },
+    ),
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: PASS (3 new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/agent-supervisor/sdk-mcp-tools.mjs lib/agent-supervisor/sdk-mcp-tools.test.mjs
+git commit -m "Add advisor-targeting MCP tools: handshake_advisor, ask_advisor, send_to_advisor"
+```
+
+---
+
+### Task 10: Coordinator `send_to_worker` tool
+
+**Files:**
+- Modify: `lib/agent-supervisor/sdk-mcp-tools.mjs`
+- Test: `lib/agent-supervisor/sdk-mcp-tools.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sdk-mcp-tools.test.mjs`:
+
+```javascript
+test('coordinator role exposes send_to_worker', () => {
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'coordinator',
+    msgDir: '/tmp',
+    eventLogRoot: '/tmp',
+    advisorNames: [],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__send_to_worker'))
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Register the tool**
+
+In the existing `if (role === 'coordinator') { ... }` block inside `buildMessengerMcpServer`, add a new `tools.push(tool(...))` entry alongside the diagnostic tools:
+
+```javascript
+tool(
+  'send_to_worker',
+  'Send a message to a worker agent. Fire-and-forget but the worker will process it as a new user turn. Use for directives like "rebase onto feature/x and resolve conflicts" or answers to ask_coordinator questions.',
+  {
+    instance: z.string().describe('Worker instance name (e.g. "issue-42")'),
+    message: z.string(),
+  },
+  async ({ instance: target, message }) => {
+    const sockPath = sockPathFor(msgDir, target)
+    const r = await sendAndFetchStatus(sockPath, `[directive from _coordinator] ${message}`)
+    if (!r.delivered) {
+      return toolResult(buildErrorEnvelope({ recipient: target, sockPath, reason: r.error }))
+    }
+    return toolResult(buildDeliveredEnvelope({
+      recipient: target,
+      status: r.status,
+      expectedReplyWindow: 'worker acts on the message; no automatic reply',
+      guidance: 'If you expect the worker to notify you back, wait for a new user turn from that worker.',
+    }))
+  },
+),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/agent-supervisor/sdk-mcp-tools.mjs lib/agent-supervisor/sdk-mcp-tools.test.mjs
+git commit -m "Add send_to_worker MCP tool for the coordinator"
+```
+
+---
+
+### Task 11: Advisor role MCP tools — `reply_to_coordinator`, `reply_to_worker`, `note_to_coordinator`
+
+**Files:**
+- Modify: `lib/agent-supervisor/sdk-mcp-tools.mjs`
+- Test: `lib/agent-supervisor/sdk-mcp-tools.test.mjs`
+
+Registers the advisor role's tool set. The advisor is identified as `role === 'advisor'` — supervisor.mjs support for that role comes next task.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sdk-mcp-tools.test.mjs`:
+
+```javascript
+test('advisor role exposes reply and note tools', () => {
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'advisor',
+    msgDir: '/tmp',
+    instance: 'decision-maker',
+    eventLogRoot: '/tmp',
+    advisorNames: ['decision-maker'],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__reply_to_coordinator'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__reply_to_worker'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__note_to_coordinator'))
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Register the advisor role's tools**
+
+In `sdk-mcp-tools.mjs`, add a new block in `buildMessengerMcpServer`:
+
+```javascript
+if (role === 'advisor') {
+  tools.push(
+    tool(
+      'reply_to_coordinator',
+      'Send your recommendation/answer back to the coordinator. The coordinator will see this as a new user turn. Use this as the final step of a consultation when the coordinator asked you via ask_advisor.',
+      {
+        message: z.string().describe('Your full reply. Follow the response shape in your system prompt.'),
+      },
+      async ({ message }) => {
+        const sockPath = sockPathFor(msgDir, '_coordinator')
+        const r = await sendAndFetchStatus(sockPath, `[advisor ${instance} reply] ${message}`)
+        if (!r.delivered) {
+          return toolResult(buildErrorEnvelope({
+            recipient: '_coordinator',
+            sockPath,
+            reason: r.error,
+          }))
+        }
+        return toolResult(buildDeliveredEnvelope({
+          recipient: '_coordinator',
+          status: r.status,
+          expectedReplyWindow: 'none (coordinator reads it on its next turn)',
+          guidance: 'Consultation delivered.',
+        }))
+      },
+    ),
+
+    tool(
+      'reply_to_worker',
+      'Send your answer back to a worker that asked you via ask_advisor. The worker will see it as a new user turn mid-task.',
+      {
+        instance: z.string().describe('Worker instance name (e.g. "issue-42")'),
+        message: z.string(),
+      },
+      async ({ instance: target, message }) => {
+        const sockPath = sockPathFor(msgDir, target)
+        const r = await sendAndFetchStatus(sockPath, `[advisor ${instance} reply] ${message}`)
+        if (!r.delivered) {
+          return toolResult(buildErrorEnvelope({ recipient: target, sockPath, reason: r.error }))
+        }
+        return toolResult(buildDeliveredEnvelope({
+          recipient: target,
+          status: r.status,
+          expectedReplyWindow: 'none',
+          guidance: 'Consultation delivered.',
+        }))
+      },
+    ),
+
+    tool(
+      'note_to_coordinator',
+      'Proactively ping the coordinator with a short note (e.g. during handshake research you found a conflicting prior decision the coordinator should see). Use sparingly — the default on handshakes is silence.',
+      {
+        message: z.string(),
+      },
+      async ({ message }) => {
+        const sockPath = sockPathFor(msgDir, '_coordinator')
+        const r = await sendAndFetchStatus(sockPath, `[advisor ${instance} note] ${message}`)
+        if (!r.delivered) {
+          return toolResult(buildErrorEnvelope({
+            recipient: '_coordinator',
+            sockPath,
+            reason: r.error,
+          }))
+        }
+        return toolResult(buildDeliveredEnvelope({
+          recipient: '_coordinator',
+          status: r.status,
+          expectedReplyWindow: 'none',
+          guidance: 'Note delivered.',
+        }))
+      },
+    ),
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd lib/agent-supervisor && node --test sdk-mcp-tools.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/agent-supervisor/sdk-mcp-tools.mjs lib/agent-supervisor/sdk-mcp-tools.test.mjs
+git commit -m "Add advisor-role MCP tools: reply_to_coordinator, reply_to_worker, note_to_coordinator"
+```
+
+---
+
+### Task 12: Teach supervisor.mjs about `role=advisor`
+
+**Files:**
+- Modify: `lib/agent-supervisor/args.mjs`
+- Modify: `lib/agent-supervisor/supervisor.mjs`
+- Test: `lib/agent-supervisor/args.test.mjs`, `lib/agent-supervisor/supervisor.test.mjs`
+
+Advisor mode is agent-like (socket path = `/logs/messages/<name>/supervisor.sock`) but always multi-turn (like coordinator).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `lib/agent-supervisor/args.test.mjs`:
+
+```javascript
+test('role=advisor is accepted', () => {
+  const args = parseArgsForTest([
+    'node', 'supervisor.mjs',
+    '--role', 'advisor',
+    '--instance', 'decision-maker',
+    '--prompt-file', '/tmp/p',
+  ])
+  assert.equal(args.role, 'advisor')
+})
+
+test('role=unknown throws', () => {
+  assert.throws(() => parseArgsForTest([
+    'node', 'supervisor.mjs',
+    '--role', 'bogus',
+    '--instance', 'x',
+    '--prompt-file', '/tmp/p',
+  ]))
+})
+```
+
+And to `supervisor.test.mjs` (test the helper):
+
+```javascript
+import { deriveRoleBehavior } from './supervisor.mjs'
+
+test('role=advisor is multi-turn and uses instance subdir', () => {
+  const b = deriveRoleBehavior({ role: 'advisor', instance: 'decision-maker' })
+  assert.equal(b.isMultiTurn, true)
+  assert.equal(b.socketInstance, 'decision-maker')
+  assert.equal(b.eventSubdir, 'decision-maker')
+})
+
+test('role=coordinator is multi-turn and uses _coordinator subdir', () => {
+  const b = deriveRoleBehavior({ role: 'coordinator' })
+  assert.equal(b.isMultiTurn, true)
+  assert.equal(b.socketInstance, '_coordinator')
+  assert.equal(b.eventSubdir, '_coordinator')
+})
+
+test('role=agent is one-shot by default', () => {
+  const b = deriveRoleBehavior({ role: 'agent', instance: 'issue-42', persistent: false })
+  assert.equal(b.isMultiTurn, false)
+  assert.equal(b.socketInstance, 'issue-42')
+})
+
+test('role=agent with --persistent is multi-turn', () => {
+  const b = deriveRoleBehavior({ role: 'agent', instance: 'issue-42', persistent: true })
+  assert.equal(b.isMultiTurn, true)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd lib/agent-supervisor && node --test args.test.mjs supervisor.test.mjs
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add role validation and helper**
+
+In `args.mjs`, after parsing the role, add:
+
+```javascript
+if (!['agent', 'coordinator', 'advisor'].includes(args.role)) {
+  throw new Error(`unknown role: ${args.role}`)
+}
+```
+
+In `supervisor.mjs`, add near the other top-level helpers:
+
+```javascript
+/**
+ * Derive role-dependent behavior. Pure function for testability.
+ */
+export function deriveRoleBehavior({ role, instance, persistent }) {
+  const isMultiTurn = role === 'coordinator' || role === 'advisor' || persistent === true
+  const socketInstance = role === 'coordinator' ? '_coordinator' : instance
+  const eventSubdir = role === 'coordinator' ? '_coordinator' : instance
+  return { isMultiTurn, socketInstance, eventSubdir }
+}
+```
+
+And replace the existing computation of `isMultiTurn` and `eventSubdir` in `main()` with calls to this helper. Also update `socketPathFor` to accept a pre-resolved instance:
+
+```javascript
+// Before: const isMultiTurn = args.role === 'coordinator' || args.persistent === true
+// After:
+const behavior = deriveRoleBehavior({
+  role: args.role,
+  instance: args.instance,
+  persistent: args.persistent,
+})
+const isMultiTurn = behavior.isMultiTurn
+const eventSubdir = behavior.eventSubdir
+```
+
+And `socketPathFor(args.role, msgDir, args.instance)` becomes:
+
+```javascript
+const sockPath = path.join(msgDir, behavior.socketInstance, 'supervisor.sock')
+```
+
+(Remove `socketPathFor` or keep it — whichever is less churn. Simpler: keep it but update its internals to use role/instance directly without special-casing.)
+
+- [ ] **Step 4: Also handle the system prompt fallback**
+
+For role=advisor, agents and advisors share the `agent-system-prompt.txt` fallback (advisors always pass `--system-prompt-file` so this is rarely used, but match the pattern). In `main()`:
+
+```javascript
+const systemPromptFile =
+  args.systemPromptFile ||
+  path.join(
+    __dirname,
+    args.role === 'coordinator' ? 'coordinator-system-prompt.txt' : 'agent-system-prompt.txt',
+  )
+```
+
+This works unchanged — `args.role === 'coordinator'` is false for advisor, so it falls through to agent. No change needed here.
+
+- [ ] **Step 5: Also handle the status reply role field**
+
+In the idle timer and elsewhere where `args.role` is stringified in log messages, add `advisor` to the label logic if present (grep for `'coordinator' ? 'coordinator' : 'persistent agent'`):
+
+Replace:
+```javascript
+const label = args.role === 'coordinator' ? 'coordinator' : 'persistent agent'
+```
+
+With:
+```javascript
+const label = args.role === 'coordinator' ? 'coordinator' : args.role === 'advisor' ? 'advisor' : 'persistent agent'
+```
+
+Apply in both occurrences inside `main()` (idle timer log line and result-turn log line).
+
+- [ ] **Step 6: Run tests**
+
+```bash
+cd lib/agent-supervisor && node --test args.test.mjs supervisor.test.mjs sdk-mcp-tools.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/agent-supervisor/args.mjs lib/agent-supervisor/supervisor.mjs lib/agent-supervisor/args.test.mjs lib/agent-supervisor/supervisor.test.mjs
+git commit -m "Teach supervisor.mjs about role=advisor (multi-turn, instance-scoped socket)"
+```
+
+---
+
+### Task 13: Add `RoleAdvisor` constant and thread advisor options through `LaunchParams`
+
+**Files:**
+- Modify: `internal/supervisor/dispatch.go`
+- Modify: `internal/supervisor/launch.go`
+- Test: `internal/supervisor/launch_test.go`
+
+The current `buildSupervisorArgs` pulls `cfg.Claude.Model` and `cfg.Claude.Effort`. Advisors need per-advisor overrides.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/supervisor/launch_test.go`:
+
+```go
+func TestBuildSupervisorArgsAdvisor(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Claude.Model = "default-model"
+	cfg.Claude.Effort = "high"
+
+	params := LaunchParams{
+		Name:          "decision-maker",
+		Role:          RoleAdvisor,
+		PromptFile:    "/tmp/p",
+		StderrLog:     "/tmp/err",
+		ModelOverride: "claude-opus-4-7",
+		EffortOverride: "max",
+		AdvisorNames:  []string{"decision-maker", "critic"},
+	}
+	args := buildSupervisorArgs(params, cfg)
+
+	if !containsArg(args, "--role", "advisor") {
+		t.Errorf("expected --role advisor; got %v", args)
+	}
+	if !containsArg(args, "--model", "claude-opus-4-7") {
+		t.Errorf("expected --model claude-opus-4-7 (override); got %v", args)
+	}
+	if !containsArg(args, "--effort", "max") {
+		t.Errorf("expected --effort max (override); got %v", args)
+	}
+	if !containsArg(args, "--advisors", "decision-maker,critic") {
+		t.Errorf("expected --advisors decision-maker,critic; got %v", args)
+	}
+	if !containsArg(args, "--instance", "decision-maker") {
+		t.Errorf("expected --instance decision-maker; got %v", args)
+	}
+}
+
+// Helper: walks pairs and returns true if [flag, value] appears consecutively.
+func containsArg(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/supervisor/ -run TestBuildSupervisorArgsAdvisor -v
+```
+
+Expected: FAIL — fields undefined.
+
+- [ ] **Step 3: Add `RoleAdvisor` constant**
+
+In `internal/supervisor/dispatch.go`:
+
+```go
+const (
+	RoleAgent       = "agent"
+	RoleCoordinator = "coordinator"
+	RoleAdvisor     = "advisor"
+)
+```
+
+- [ ] **Step 4: Add override fields to `LaunchParams`**
+
+In `internal/supervisor/launch.go`, extend `LaunchParams`:
+
+```go
+type LaunchParams struct {
+	// ... existing fields ...
+
+	// ModelOverride, if non-empty, takes precedence over cfg.Claude.Model
+	// on the supervisor command line. Used by advisors to pin their model
+	// independently of the rest of the cspace session.
+	ModelOverride string
+
+	// EffortOverride, if non-empty, takes precedence over cfg.Claude.Effort.
+	EffortOverride string
+
+	// AdvisorNames is the list of configured advisor names to pass to the
+	// supervisor for MCP tool enum population.
+	AdvisorNames []string
+}
+```
+
+- [ ] **Step 5: Update `buildSupervisorArgs`**
+
+In `buildSupervisorArgs`, replace the `cfg.Claude.Model` / `cfg.Claude.Effort` block with:
+
+```go
+	model := params.ModelOverride
+	if model == "" {
+		model = cfg.Claude.Model
+	}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+
+	effort := params.EffortOverride
+	if effort == "" {
+		effort = cfg.Claude.Effort
+	}
+	if effort == "" {
+		effort = "max"
+	}
+	args = append(args, "--effort", effort)
+
+	if len(params.AdvisorNames) > 0 {
+		args = append(args, "--advisors", strings.Join(params.AdvisorNames, ","))
+	}
+```
+
+Also update the `--instance` emit condition:
+
+```go
+	if params.Role == RoleAgent || params.Role == RoleAdvisor {
+		args = append(args, "--instance", params.Name)
+	}
+```
+
+(Before: `if params.Role == RoleAgent { ... }`.)
+
+- [ ] **Step 6: Run test to verify it passes**
+
+```bash
+go test ./internal/supervisor/ -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/supervisor/dispatch.go internal/supervisor/launch.go internal/supervisor/launch_test.go
+git commit -m "Add RoleAdvisor and thread model/effort/advisorNames through LaunchParams"
+```
+
+---
+
+### Task 14: Create `internal/advisor` package with `Launch`, `IsAlive`, `Teardown`
+
+**Files:**
+- Create: `internal/advisor/advisor.go`
+- Create: `internal/advisor/advisor_test.go`
+
+This package centralizes advisor lifecycle. `cspace coordinate` and `cspace advisor` both call into it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/advisor/advisor_test.go`:
+
+```go
+package advisor
+
+import (
+	"testing"
+
+	"github.com/elliottregan/cspace/internal/config"
+)
+
+func TestBuildLaunchParams(t *testing.T) {
+	cfg := &config.Config{
+		ProjectRoot: "/tmp/proj",
+		AssetsDir:   "/opt/assets",
+		Advisors: map[string]config.AdvisorConfig{
+			"decision-maker": {
+				Model:      "claude-opus-4-7",
+				Effort:     "max",
+				BaseBranch: "main",
+			},
+		},
+	}
+
+	params, err := BuildLaunchParams(cfg, "decision-maker")
+	if err != nil {
+		t.Fatalf("BuildLaunchParams: %v", err)
+	}
+	if params.ModelOverride != "claude-opus-4-7" {
+		t.Errorf("Model: %s", params.ModelOverride)
+	}
+	if params.EffortOverride != "max" {
+		t.Errorf("Effort: %s", params.EffortOverride)
+	}
+	if len(params.AdvisorNames) != 1 || params.AdvisorNames[0] != "decision-maker" {
+		t.Errorf("AdvisorNames: %v", params.AdvisorNames)
+	}
+	if params.Name != "decision-maker" {
+		t.Errorf("Name: %s", params.Name)
+	}
+}
+
+func TestBuildLaunchParamsUnknownAdvisor(t *testing.T) {
+	cfg := &config.Config{Advisors: map[string]config.AdvisorConfig{}}
+	_, err := BuildLaunchParams(cfg, "missing")
+	if err == nil {
+		t.Fatal("expected error for unknown advisor")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/advisor/... -v
+```
+
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Create `internal/advisor/advisor.go`**
+
+```go
+// Package advisor manages the lifecycle of long-running advisor agents.
+// See docs/superpowers/specs/2026-04-18-advisor-agents-design.md.
+package advisor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/elliottregan/cspace/internal/config"
+	"github.com/elliottregan/cspace/internal/supervisor"
+)
+
+// BuildLaunchParams assembles the LaunchParams for a configured advisor.
+// Returns an error if the advisor is not in cfg.Advisors.
+func BuildLaunchParams(cfg *config.Config, name string) (supervisor.LaunchParams, error) {
+	spec, ok := cfg.Advisors[name]
+	if !ok {
+		return supervisor.LaunchParams{}, fmt.Errorf("advisor %q not configured", name)
+	}
+
+	return supervisor.LaunchParams{
+		Name:             name,
+		Role:             supervisor.RoleAdvisor,
+		ModelOverride:    spec.Model,
+		EffortOverride:   spec.Effort,
+		AdvisorNames:     sortedAdvisorNames(cfg),
+		SystemPromptFile: "", // caller stages the system-prompt file; see Launch
+		Persistent:       true,
+	}, nil
+}
+
+// sortedAdvisorNames returns the configured advisor names in sorted order
+// so the --advisors CLI flag is deterministic.
+func sortedAdvisorNames(cfg *config.Config) []string {
+	names := make([]string, 0, len(cfg.Advisors))
+	for n := range cfg.Advisors {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// IsAlive returns true when the advisor's supervisor socket answers a
+// status request. Reused from the coordinator's liveness probe pattern.
+func IsAlive(cfg *config.Config, name string) bool {
+	logsPath := supervisor.ResolveLogsVolumePath(cfg)
+	if logsPath == "" {
+		return false
+	}
+	sockPath := filepath.Join(logsPath, name, "supervisor.sock")
+	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	req, _ := json.Marshal(map[string]string{"cmd": "status"})
+	if _, err := conn.Write(append(req, '\n')); err != nil {
+		return false
+	}
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	if err != nil || n == 0 {
+		return false
+	}
+	var reply struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal(buf[:n], &reply); err != nil {
+		return false
+	}
+	return reply.OK
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/advisor/... -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/advisor/advisor.go internal/advisor/advisor_test.go
+git commit -m "Add internal/advisor package with BuildLaunchParams and IsAlive"
+```
+
+---
+
+### Task 15: Implement `advisor.Launch` and `advisor.Teardown`
+
+**Files:**
+- Modify: `internal/advisor/advisor.go`
+
+These are thin wrappers over existing `provision.Run`, `supervisor.LaunchSupervisor` (detached), and container stop. No new unit tests — launching a real container is integration-level, covered in Task 21.
+
+- [ ] **Step 1: Add `Launch`**
+
+Append to `internal/advisor/advisor.go`:
+
+```go
+import (
+	// existing imports...
+	"os"
+	"github.com/elliottregan/cspace/internal/instance"
+	"github.com/elliottregan/cspace/internal/provision"
+)
+
+// Launch brings the named advisor up if not already alive. It:
+//   1. provisions the container if missing
+//   2. checks out the configured baseBranch
+//   3. stages the system prompt and bootstrap prompt
+//   4. launches the supervisor detached (role=advisor, persistent)
+//
+// If the advisor is already alive, Launch is a no-op (returns nil).
+func Launch(cfg *config.Config, name string) error {
+	spec, ok := cfg.Advisors[name]
+	if !ok {
+		return fmt.Errorf("advisor %q not configured", name)
+	}
+
+	if IsAlive(cfg, name) {
+		return nil
+	}
+
+	if _, err := provision.Run(provision.Params{Name: name, Cfg: cfg}); err != nil {
+		return fmt.Errorf("provisioning advisor %s: %w", name, err)
+	}
+
+	composeName := cfg.ComposeName(name)
+	_ = instance.SkipOnboarding(composeName)
+
+	// Re-copy host .env so the advisor inherits GH_TOKEN, etc. (matches coordinator behavior).
+	envFile := filepath.Join(cfg.ProjectRoot, ".env")
+	if _, err := os.Stat(envFile); err == nil {
+		_ = instance.DcCp(composeName, envFile, "/workspace/.env")
+		_, _ = instance.DcExecRoot(composeName, "chown", "dev:dev", "/workspace/.env")
+	}
+
+	// Check out the configured baseBranch (default main) inside the advisor's workspace.
+	// The advisor can switch branches itself later if a consultation requires it.
+	baseBranch := spec.BaseBranch
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	// git fetch is best-effort; container may be offline. checkout must succeed.
+	_, _ = instance.DcExec(composeName, "git", "-C", "/workspace", "fetch", "origin")
+	if _, err := instance.DcExec(composeName, "git", "-C", "/workspace", "checkout", baseBranch); err != nil {
+		return fmt.Errorf("checking out advisor baseBranch %s: %w", baseBranch, err)
+	}
+
+	// Stage the system prompt (ResolveAdvisor handles override/fallback).
+	systemPromptHost := cfg.ResolveAdvisor(name)
+	if systemPromptHost == "" {
+		return fmt.Errorf("no system prompt resolved for advisor %s", name)
+	}
+	const containerSystemPromptPath = "/tmp/advisor-system-prompt.txt"
+	if err := supervisor.StagePromptFile(composeName, systemPromptHost, containerSystemPromptPath); err != nil {
+		return fmt.Errorf("staging advisor system prompt: %w", err)
+	}
+
+	// Render and stage the bootstrap prompt.
+	bootstrap := renderBootstrapPrompt(name)
+	const containerBootstrapPath = "/tmp/advisor-bootstrap.txt"
+	if err := supervisor.StagePromptText(composeName, bootstrap, containerBootstrapPath); err != nil {
+		return fmt.Errorf("staging advisor bootstrap prompt: %w", err)
+	}
+
+	params, err := BuildLaunchParams(cfg, name)
+	if err != nil {
+		return err
+	}
+	params.PromptFile = containerBootstrapPath
+	params.StderrLog = supervisor.ContainerAgentStderrLog
+	params.SystemPromptFile = containerSystemPromptPath
+
+	// Detached launch — the coordinator does not block on advisor stdout.
+	return supervisor.RelaunchDetached(params, cfg, 0)
+}
+
+func renderBootstrapPrompt(name string) string {
+	return fmt.Sprintf(`You are the %s advisor. Your role is defined in your system prompt
+(already applied to this session).
+
+Project principles, direction, and decisions live in the cspace-context
+server — call read_context at the start of each consultation for current
+values.
+
+You will receive messages via the agent-messenger MCP tools. Reply via
+reply_to_coordinator / reply_to_worker. See your system prompt for
+response format and quality bar.
+
+Do a light read of read_context(["direction","principles","roadmap"])
+now so you have baseline context. Then wait for messages.`, name)
+}
+
+// Teardown shuts down the advisor's supervisor and stops its container.
+// Session state is lost.
+func Teardown(cfg *config.Config, name string) error {
+	if _, ok := cfg.Advisors[name]; !ok {
+		return fmt.Errorf("advisor %q not configured", name)
+	}
+	composeName := cfg.ComposeName(name)
+
+	// Best-effort interrupt the supervisor (closes prompt queue cleanly).
+	_ = supervisor.Dispatch(composeName, "interrupt", name)
+
+	// Stop the container and remove volumes — same path as `cspace down`.
+	if err := compose.Run(name, cfg, "down", "--volumes"); err != nil {
+		return fmt.Errorf("stopping advisor container: %w", err)
+	}
+	return nil
+}
+```
+
+Add `"github.com/elliottregan/cspace/internal/compose"` to the import block.
+
+- [ ] **Step 2: Verify the package still builds**
+
+```bash
+go build ./...
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run the advisor tests**
+
+```bash
+go test ./internal/advisor/... -v
+```
+
+Expected: PASS (still, existing tests unaffected).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/advisor/advisor.go
+git commit -m "Add advisor.Launch and advisor.Teardown"
+```
+
+---
+
+### Task 16: `cspace coordinate` launches configured advisors at startup
+
+**Files:**
+- Modify: `internal/cli/coordinate.go`
+
+On startup, iterate `cfg.Advisors`, call `advisor.Launch(cfg, name)` (which is a no-op if already alive), then proceed to launch the coordinator. Errors in advisor launch are logged but don't abort the coordinator.
+
+- [ ] **Step 1: Add import and launch loop**
+
+In `internal/cli/coordinate.go`:
+
+Add to imports:
+
+```go
+"github.com/elliottregan/cspace/internal/advisor"
+```
+
+In `runCoordinateWithArgs`, after the `coordinatorIsAlive()` check but before `provision.Run(provision.Params{Name: name, Cfg: cfg})`, insert:
+
+```go
+	// Bring up all configured advisors. A fresh advisor is provisioned and
+	// launched persistent; an already-alive advisor is reused so its session
+	// continuity is preserved across cspace coordinate calls.
+	for adName := range cfg.Advisors {
+		if err := advisor.Launch(cfg, adName); err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: advisor %s failed to launch: %v\n", adName, err)
+		} else if advisor.IsAlive(cfg, adName) {
+			fmt.Fprintf(os.Stderr, "Advisor %s ready.\n", adName)
+		}
+	}
+```
+
+- [ ] **Step 2: Also pass `AdvisorNames` to the coordinator's own LaunchParams**
+
+In the final `supervisor.LaunchSupervisor(supervisor.LaunchParams{...}, cfg)` call in `runCoordinateWithArgs`, add the `AdvisorNames` field:
+
+```go
+return supervisor.LaunchSupervisor(supervisor.LaunchParams{
+    Name:             name,
+    Role:             supervisor.RoleCoordinator,
+    PromptFile:       supervisor.ContainerCoordPromptPath,
+    StderrLog:        supervisor.ContainerCoordStderrLog,
+    SystemPromptFile: containerSystemPrompt,
+    AdvisorNames:     advisor.SortedAdvisorNames(cfg),
+}, cfg)
+```
+
+To use `SortedAdvisorNames`, export it from the advisor package. In `internal/advisor/advisor.go`, rename `sortedAdvisorNames` to `SortedAdvisorNames` and update the call inside `BuildLaunchParams`.
+
+- [ ] **Step 3: Build and test**
+
+```bash
+make vet && go build ./... && go test ./...
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/cli/coordinate.go internal/advisor/advisor.go
+git commit -m "cspace coordinate launches configured advisors at startup"
+```
+
+---
+
+### Task 17: Render advisor roster into coordinator's first user turn
+
+**Files:**
+- Modify: `internal/cli/coordinate.go`
+
+The coordinator playbook references an advisor roster placeholder; render it from config.
+
+- [ ] **Step 1: Add the roster rendering**
+
+In `internal/cli/coordinate.go`, after reading `playbookBytes` and before constructing `fullPrompt`, add a roster string:
+
+```go
+// Render the advisor roster into the coordinator's first user turn so it
+// knows what names are valid for ask_advisor/send_to_advisor.
+var rosterBuilder strings.Builder
+if len(cfg.Advisors) > 0 {
+    rosterBuilder.WriteString("\n\n## Advisor roster (available via ask_advisor / send_to_advisor)\n\n")
+    for _, adName := range advisor.SortedAdvisorNames(cfg) {
+        spec := cfg.Advisors[adName]
+        model := spec.Model
+        if model == "" {
+            model = "(account default)"
+        }
+        effort := spec.Effort
+        if effort == "" {
+            effort = "(default)"
+        }
+        fmt.Fprintf(&rosterBuilder, "- **%s** — model=%s, effort=%s\n", adName, model, effort)
+    }
+}
+```
+
+Add `"strings"` to the imports if not already present.
+
+Then update the `fullPrompt` assembly for the default (non-systemPromptFile) branch:
+
+```go
+fullPrompt = string(playbookBytes) + rosterBuilder.String() + "\n\nUSER INSTRUCTIONS:\n\n" + userBody
+```
+
+(Before: just playbookBytes + userBody.)
+
+- [ ] **Step 2: Verify build**
+
+```bash
+make vet && go build ./...
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cli/coordinate.go
+git commit -m "Render advisor roster into coordinator's first user turn"
+```
+
+---
+
+### Task 18: Default coordinator to Sonnet with effort=high
+
+**Files:**
+- Modify: `internal/cli/coordinate.go`
+
+When the user has not set `claude.model` in config, default the coordinator to Sonnet. Per-advisor models are independent.
+
+- [ ] **Step 1: Add defaults**
+
+In `runCoordinateWithArgs`, before the final `supervisor.LaunchSupervisor` call, insert:
+
+```go
+	// Coordinator defaults to Sonnet — deep reasoning is delegated to
+	// advisors (Opus). User can override via claude.model in .cspace.json.
+	coordModel := cfg.Claude.Model
+	if coordModel == "" {
+		coordModel = "claude-sonnet-4-6"
+	}
+	coordEffort := cfg.Claude.Effort
+	if coordEffort == "" {
+		coordEffort = "high"
+	}
+```
+
+Update the `LaunchSupervisor` call to pass overrides:
+
+```go
+return supervisor.LaunchSupervisor(supervisor.LaunchParams{
+    Name:             name,
+    Role:             supervisor.RoleCoordinator,
+    PromptFile:       supervisor.ContainerCoordPromptPath,
+    StderrLog:        supervisor.ContainerCoordStderrLog,
+    SystemPromptFile: containerSystemPrompt,
+    AdvisorNames:     advisor.SortedAdvisorNames(cfg),
+    ModelOverride:    coordModel,
+    EffortOverride:   coordEffort,
+}, cfg)
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+make vet && go build ./...
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cli/coordinate.go
+git commit -m "Default coordinator to Sonnet with effort=high"
+```
+
+---
+
+### Task 19: `cspace advisor` subcommand group
+
+**Files:**
+- Create: `internal/cli/advisor.go`
+- Modify: `internal/cli/root.go`
+
+- [ ] **Step 1: Create the subcommand group**
+
+Create `internal/cli/advisor.go`:
+
+```go
+package cli
+
+import (
+	"fmt"
+
+	"github.com/elliottregan/cspace/internal/advisor"
+	"github.com/spf13/cobra"
+)
+
+func newAdvisorCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "advisor",
+		Short:   "Manage long-running advisor agents (decision-maker, etc.)",
+		GroupID: "agents",
+	}
+	cmd.AddCommand(newAdvisorListCmd())
+	cmd.AddCommand(newAdvisorDownCmd())
+	cmd.AddCommand(newAdvisorRestartCmd())
+	return cmd
+}
+
+func newAdvisorListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured advisors and their liveness",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(cfg.Advisors) == 0 {
+				fmt.Println("No advisors configured. See `advisors` in defaults.json.")
+				return nil
+			}
+			for _, name := range advisor.SortedAdvisorNames(cfg) {
+				spec := cfg.Advisors[name]
+				alive := advisor.IsAlive(cfg, name)
+				status := "stopped"
+				if alive {
+					status = "alive"
+				}
+				fmt.Printf("%-20s model=%s effort=%s %s\n",
+					name,
+					fallback(spec.Model, "(default)"),
+					fallback(spec.Effort, "(default)"),
+					status,
+				)
+			}
+			return nil
+		},
+	}
+}
+
+func newAdvisorDownCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "down [name]",
+		Short: "Stop an advisor (or all with --all)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			all, _ := cmd.Flags().GetBool("all")
+			if all {
+				for _, name := range advisor.SortedAdvisorNames(cfg) {
+					if err := advisor.Teardown(cfg, name); err != nil {
+						fmt.Printf("WARN: %s: %v\n", name, err)
+					} else {
+						fmt.Printf("%s stopped.\n", name)
+					}
+				}
+				return nil
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("usage: cspace advisor down <name> | --all")
+			}
+			return advisor.Teardown(cfg, args[0])
+		},
+	}
+	cmd.Flags().Bool("all", false, "Tear down every configured advisor")
+	return cmd
+}
+
+func newAdvisorRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart <name>",
+		Short: "Tear down and relaunch an advisor with a fresh session",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := advisor.Teardown(cfg, args[0]); err != nil {
+				fmt.Printf("WARN during teardown: %v\n", err)
+			}
+			return advisor.Launch(cfg, args[0])
+		},
+	}
+}
+
+func fallback(s, d string) string {
+	if s == "" {
+		return d
+	}
+	return s
+}
+```
+
+- [ ] **Step 2: Register the command**
+
+In `internal/cli/root.go`, find the spot where other commands are added (search for `rootCmd.AddCommand(newCoordinateCmd())` or similar) and add:
+
+```go
+rootCmd.AddCommand(newAdvisorCmd())
+```
+
+- [ ] **Step 3: Verify the help output**
+
+```bash
+make build && ./bin/cspace-go advisor --help
+```
+
+Expected: shows `list`, `down`, `restart` subcommands.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/cli/advisor.go internal/cli/root.go
+git commit -m "Add cspace advisor list|down|restart subcommand group"
+```
+
+---
+
+### Task 20: Update coordinator playbook — Phase 0.5, triggers, worker `--persistent`
+
+**Files:**
+- Modify: `lib/agents/coordinator.md`
+
+Pure markdown edit. No TDD — the supervisor integration tests (Task 21) exercise the resulting flow.
+
+- [ ] **Step 1: Insert Phase 0.5**
+
+In `lib/agents/coordinator.md`, find `## Phase 1 — Setup` and insert immediately before it:
+
+```markdown
+## Phase 0.5 — Advisors
+
+You have a bench of advisors available — long-running specialists you can consult. The advisor roster is rendered into this prompt by `cspace coordinate` at launch (see above).
+
+**Consulting an advisor:** use the `ask_advisor(name, question, kind)` MCP tool. The reply arrives later as a new user turn on your session, not as a tool result. This means:
+
+- Your current turn ends after the tool returns (the tool only delivers the question).
+- You keep your full session context; the reply, when it arrives, has access to everything you were thinking about.
+- You can process other events (worker completions, directives) while waiting.
+
+**Consult the decision-maker when:**
+- Picking a base branch or merge ordering when dependencies are ambiguous.
+- Dispatching an implementer for an underspecified issue (multiple valid interpretations).
+- A worker reports a design-level blocker (e.g. "need to introduce abstraction X — proceed?").
+- A PR's diff doesn't cleanly match its acceptance criteria.
+- A prior decision or finding seems to conflict with the current work.
+- Any choice you judge architecturally significant.
+
+**Do NOT consult for:**
+- Routine orchestration (which port, which file, which commit message).
+- Choices the existing playbook already prescribes.
+- Questions that don't touch principles.md or direction.md.
+
+If you're unsure whether a choice qualifies, ask. A tight question is cheaper than the wrong call.
+
+For fire-and-forget notes (e.g. "issue-42 merged, decisions log updated"), use `send_to_advisor(name, message)`.
+
+---
+```
+
+- [ ] **Step 2: Update the Phase 2 launch command to pass `--persistent`**
+
+In the same file, find the `cspace up` command inside Phase 2:
+
+```bash
+cspace up issue-$N --base $BASE --prompt-file /tmp/implementer-$N.txt
+```
+
+Replace with:
+
+```bash
+cspace up issue-$N --base $BASE --prompt-file /tmp/implementer-$N.txt --persistent
+```
+
+- [ ] **Step 3: Update the "direct cspace send" passages to prefer MCP tools**
+
+Find `cspace send _coordinator` / `cspace send issue-<N>` references throughout the playbook. Add a short note at the end of the "Rules" section at the bottom:
+
+```markdown
+- **Prefer MCP tools over `cspace send`** for inter-agent messaging: `send_to_worker`, `ask_advisor`, `send_to_advisor` give you typed recipient names and structured return values. `cspace send` still works as the underlying transport and is fine for humans/scripts/debugging.
+```
+
+- [ ] **Step 4: Sync embedded assets**
+
+```bash
+make sync-embedded
+```
+
+Expected: embedded copy refreshed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/agents/coordinator.md internal/assets/embedded
+git commit -m "Coordinator playbook: add Phase 0.5 advisors, --persistent on worker launch, prefer MCP tools"
+```
+
+---
+
+### Task 21: Update implementer playbook — handshake, ask_advisor, shutdown_self
+
+**Files:**
+- Modify: `lib/agents/implementer.md`
+
+- [ ] **Step 1: Handshake at Setup**
+
+Open `lib/agents/implementer.md` and find the Setup phase. Add at the end of that phase:
+
+```markdown
+### Advisor handshake
+
+After reading your task prompt and initial `read_context`, call:
+
+```
+handshake_advisor(
+  name="decision-maker",
+  summary="<one-line summary of your task>",
+  hints=["path/to/file1", "module/name", "..."]
+)
+```
+
+This warms the decision-maker's context so it's ready for any consultations later in the task. Do not wait for a reply (the advisor will not reply to a handshake). Continue to Explore.
+
+You may receive mid-task messages from the advisor if it finds something urgent (e.g. a conflicting prior decision). Treat these the way you'd treat a new directive from the coordinator: read, adjust, continue.
+```
+
+- [ ] **Step 2: `ask_advisor` in Design/Implement phases**
+
+Find the Design or Implement phase. Add a new subsection:
+
+```markdown
+### When to ask the decision-maker
+
+If you hit an architectural choice you can't confidently resolve against `principles.md` and prior decisions in the context server, call:
+
+```
+ask_advisor(
+  name="decision-maker",
+  question="<specific question with context>",
+  kind="question"
+)
+```
+
+The reply arrives later as a new user turn on your session, not as a tool result. Continue working on parts of the task that don't depend on the answer. When the reply lands, integrate it and proceed.
+
+Don't ask for: trivial naming, formatting, or which file to edit. Do ask for: cross-cutting design decisions that affect other agents' work or conflict with existing decisions.
+```
+
+- [ ] **Step 3: `shutdown_self` at Ship phase**
+
+Find the Ship phase. After the `notify_coordinator` (or `cspace send _coordinator`) step at the end, add:
+
+```markdown
+### Release your supervisor
+
+After the coordinator-notification message has been delivered, call:
+
+```
+shutdown_self()
+```
+
+This closes your supervisor cleanly so the coordinator isn't left tracking an idle persistent agent. Your container stays up; the coordinator can reclaim it with `cspace down` or reuse it with `cspace up`.
+```
+
+- [ ] **Step 4: Replace `cspace send _coordinator` references with `notify_coordinator`**
+
+Search the file for `cspace send _coordinator`. For each occurrence, add a note right after the bash snippet:
+
+```markdown
+(Equivalent MCP tool: `notify_coordinator(message="...")`. Preferred for structured return values.)
+```
+
+Don't delete the bash form — both are valid.
+
+- [ ] **Step 5: Sync embedded assets**
+
+```bash
+make sync-embedded
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/agents/implementer.md internal/assets/embedded
+git commit -m "Implementer playbook: advisor handshake, ask_advisor mid-task, shutdown_self at Ship"
+```
+
+---
+
+### Task 22: Add "Advisors" section to CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Insert the section**
+
+In `CLAUDE.md`, after the "Project Context" section (or next to it — anywhere logical), add:
+
+```markdown
+## Advisors
+
+Advisors are long-running specialist agents consulted alongside the coordinator. Each runs in its own cspace container as `role=advisor` — persistent, session-continuous across `cspace coordinate` invocations. They are declared in `.cspace.json` under `advisors` (see defaults for the decision-maker).
+
+- **Role prompts** live at `lib/advisors/<name>.md` (shipped) or `.cspace/advisors/<name>.md` (per-project override).
+- **Opinions** come from `.cspace/context/principles.md` (human-owned per the context-server spec). Populate it with the project's architectural preferences; the decision-maker reads it on each consultation.
+- **Lifecycle:** `cspace coordinate` auto-launches configured advisors. `cspace advisor list|down|restart` manages them explicitly. Advisors persist across coordinator sessions so their SDK sessions accumulate project context.
+- **Communication:** coordinators and workers consult via the `ask_advisor` MCP tool on the agent-messenger server. Replies arrive as new user turns, not tool results.
+
+See `docs/superpowers/specs/2026-04-18-advisor-agents-design.md` for the full design.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "Document advisors in CLAUDE.md"
+```
+
+---
+
+### Task 23: End-to-end smoke test — supervisor advisor round-trip
+
+**Files:**
+- Create: `lib/agent-supervisor/supervisor.integration.test.mjs`
+
+Integration-style test using real Unix sockets and a simplified advisor stub. Skipped unless `RUN_INTEGRATION=1` so CI doesn't need Docker.
+
+- [ ] **Step 1: Create the integration test**
+
+Create `lib/agent-supervisor/supervisor.integration.test.mjs`:
+
+```javascript
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import net from 'node:net'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  sendAndFetchStatus,
+} from './sdk-mcp-tools.mjs'
+
+const enabled = process.env.RUN_INTEGRATION === '1'
+
+function makeFakeSupervisor(sockPath, statusReply) {
+  const received = []
+  const srv = net.createServer((conn) => {
+    let buf = ''
+    conn.on('data', (chunk) => {
+      buf += chunk.toString('utf-8')
+      while (true) {
+        const idx = buf.indexOf('\n')
+        if (idx < 0) break
+        const line = buf.slice(0, idx)
+        buf = buf.slice(idx + 1)
+        try {
+          const req = JSON.parse(line)
+          received.push(req)
+          if (req.cmd === 'send_user_message') {
+            conn.write(JSON.stringify({ ok: true }) + '\n')
+          } else if (req.cmd === 'status') {
+            conn.write(JSON.stringify({ ok: true, status: statusReply }) + '\n')
+          }
+        } catch (e) {
+          conn.write(JSON.stringify({ ok: false, error: e.message }) + '\n')
+        }
+      }
+    })
+  })
+  return new Promise((resolve) =>
+    srv.listen(sockPath, () => resolve({ srv, received })),
+  )
+}
+
+test('send_to_advisor round-trip delivers and reports status', { skip: !enabled }, async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'advisor-int-'))
+  const sockPath = path.join(tmp, 'supervisor.sock')
+  const { srv, received } = await makeFakeSupervisor(sockPath, {
+    role: 'advisor',
+    instance: 'decision-maker',
+    sessionId: 'session-1',
+    turns: 3,
+    lastActivityMs: 0,
+    queue_depth: 0,
+    git_branch: 'main',
+  })
+  try {
+    const r = await sendAndFetchStatus(sockPath, 'test message')
+    assert.equal(r.delivered, true)
+    assert.equal(r.status.instance, 'decision-maker')
+    assert.equal(r.status.git_branch, 'main')
+    assert.deepEqual(
+      received.map((req) => req.cmd),
+      ['send_user_message', 'status'],
+    )
+  } finally {
+    srv.close()
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+```
+
+- [ ] **Step 2: Run the test (with flag)**
+
+```bash
+cd lib/agent-supervisor && RUN_INTEGRATION=1 node --test supervisor.integration.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify it's skipped by default**
+
+```bash
+cd lib/agent-supervisor && node --test supervisor.integration.test.mjs
+```
+
+Expected: 1 test, 0 failures, 1 skipped (or `ok 1 - SKIP`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/agent-supervisor/supervisor.integration.test.mjs
+git commit -m "Add advisor round-trip integration test (opt-in via RUN_INTEGRATION=1)"
+```
+
+---
+
+### Task 24: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+make vet && make test
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Full build**
+
+```bash
+make build
+```
+
+Expected: `./bin/cspace-go` produced.
+
+- [ ] **Step 3: Smoke-test the CLI**
+
+```bash
+./bin/cspace-go advisor list
+./bin/cspace-go advisor --help
+./bin/cspace-go coordinate --help
+```
+
+Expected: commands list advisors (decision-maker, stopped), help text renders cleanly.
+
+- [ ] **Step 4: Commit any stray fixups discovered**
+
+If verification surfaced issues, fix them inline and commit with a fixup message.
+
+---
+
+## Summary of commits
+
+Expected commit history after executing this plan:
+
+1. Add AdvisorConfig struct and Advisors map to Config
+2. Add ResolveAdvisor for advisor system-prompt path resolution
+3. Ship default decision-maker system prompt and defaults.json advisors block
+4. Extend supervisor status socket with queue_depth and cached git_branch
+5. Extract handleSupervisorRequest and add shutdown_self command alias
+6. Add MCP-tool helpers for socket send+status and envelope building
+7. Plumb advisor-name list through supervisor args into MCP builder
+8. Add worker MCP tools: notify_coordinator, ask_coordinator, shutdown_self
+9. Add advisor-targeting MCP tools: handshake_advisor, ask_advisor, send_to_advisor
+10. Add send_to_worker MCP tool for the coordinator
+11. Add advisor-role MCP tools: reply_to_coordinator, reply_to_worker, note_to_coordinator
+12. Teach supervisor.mjs about role=advisor (multi-turn, instance-scoped socket)
+13. Add RoleAdvisor and thread model/effort/advisorNames through LaunchParams
+14. Add internal/advisor package with BuildLaunchParams and IsAlive
+15. Add advisor.Launch and advisor.Teardown
+16. cspace coordinate launches configured advisors at startup
+17. Render advisor roster into coordinator's first user turn
+18. Default coordinator to Sonnet with effort=high
+19. Add cspace advisor list|down|restart subcommand group
+20. Coordinator playbook: Phase 0.5 advisors, --persistent on worker launch, prefer MCP tools
+21. Implementer playbook: advisor handshake, ask_advisor mid-task, shutdown_self at Ship
+22. Document advisors in CLAUDE.md
+23. Add advisor round-trip integration test (opt-in via RUN_INTEGRATION=1)

--- a/docs/superpowers/specs/2026-04-18-advisor-agents-design.md
+++ b/docs/superpowers/specs/2026-04-18-advisor-agents-design.md
@@ -1,0 +1,391 @@
+# Advisor Agents — Design
+
+**Date:** 2026-04-18
+**Status:** Approved for implementation planning
+
+## Problem
+
+The coordinator handles orchestration and dispatch; implementers handle the actual work. Both roles occasionally face architecturally significant choices — picking a base branch when dependencies are ambiguous, interpreting an underspecified issue, deciding whether to introduce a new abstraction — that would benefit from deeper reasoning than either role's day-to-day work warrants.
+
+Running the coordinator itself on a max-thinking Opus is expensive and misdirected: most of what the coordinator does (rendering prompts, merging PRs, tracking a dependency graph) is mechanical. And each time an implementer hits a design question, its session has no prior architectural context; it either over-commits to the first plausible answer or burns tokens re-deriving conclusions that were already made.
+
+We want a dedicated reasoning agent that is consulted on hard calls, retains context across consultations, and grounds its answers in the project's stated principles. Beyond the one agent, we want a general mechanism so additional long-running specialist agents (critic, historian, security-reviewer, etc.) can plug in without rearchitecting.
+
+## Solution
+
+A new first-class agent class, **advisors**: long-running `role=agent --persistent` supervisors, each in its own cspace container, auto-launched by `cspace coordinate`, consulted by the coordinator and implementers via the existing socket bus. Advisors are declared in `.cspace.json`; adding a new advisor is a config entry plus an optional system prompt.
+
+The first shipped advisor is the **decision-maker**: Opus + max effort, read-only consulting (no code edits), grounded in `.cspace/context/principles.md`. The coordinator defaults to Sonnet so deep reasoning is concentrated in the advisor, not spent on orchestration.
+
+Inter-agent messaging moves from bash `cspace send` to typed MCP tools on the existing `agent-messenger` in-process server. Tools are role-scoped (coordinators see `ask_advisor`, advisors see `reply_to_coordinator`, etc.) and the recipient name is a schema-level enum populated from `.cspace.json` — no more free-form strings on the hot path.
+
+## Architecture
+
+```
+┌─────────────────────┐        ┌─────────────────────────┐
+│  coordinator        │        │  decision-maker advisor │
+│  (Sonnet, effort    │◄──────►│  (Opus, effort=max,     │
+│   high)             │ socket │   --persistent)         │
+│                     │   bus  │                         │
+│  role=coordinator   │        │  role=agent             │
+└──────────┬──────────┘        └────────────┬────────────┘
+           │                                ▲
+           │ ask_advisor                    │ handshake_advisor
+           │ send_to_worker                 │ ask_advisor
+           ▼                                │
+┌─────────────────────┐                     │
+│  implementer(s)     │─────────────────────┘
+│  (--persistent)     │
+│  role=agent         │
+└─────────────────────┘
+
+Arrows above show the new links introduced by this design. The pre-existing
+coordinator <-> worker bus (notify_coordinator / send_to_worker / ask_coordinator)
+continues unchanged. Advisor <-> worker arrows are bidirectional: advisor
+replies via reply_to_worker when a worker used ask_advisor.
+
+All three tiers share /logs/messages/<name>/supervisor.sock via bind mount.
+All three tiers share .cspace/context/ via bind mount (cspace-context MCP).
+```
+
+### Properties
+
+- **Session continuity.** Advisor supervisors stay alive across turns and across `cspace coordinate` invocations. SDK sessions accumulate project understanding; consultations reuse that context instead of cold-starting.
+- **Dedicated containers.** One advisor, one container, one supervisor. Mirrors the existing "one session, one container" convention. Advisor can check out its own branch without disturbing any worker.
+- **Typed messaging.** The existing `agent-messenger` MCP server gains role-scoped write tools. Recipient names are an enum from config. Return envelopes include recipient git branch, idle time, queue depth, and an `expected_reply_window` hint.
+- **Pluggable via config.** `advisors` block in `.cspace.json`. No Go changes to add a new advisor — just config plus a system prompt file.
+- **Principles from context server.** Advisor opinions come from `.cspace/context/principles.md` (human-owned per the context-server spec), read on each consultation. An empty `principles.md` yields generic behavior; a populated one yields opinionated advice.
+
+## Configuration
+
+New `advisors` block in `.cspace.json`, merged through the existing three-layer config loader (`defaults.json` → `.cspace.json` → `.cspace.local.json`).
+
+```json
+{
+  "advisors": {
+    "decision-maker": {
+      "model": "claude-opus-4-7",
+      "effort": "max",
+      "baseBranch": "main"
+    }
+  }
+}
+```
+
+Fields:
+
+| Field | Required | Default | Meaning |
+|---|---|---|---|
+| `model` | no | account default | Any Claude model id. |
+| `effort` | no | `max` | `low\|medium\|high\|xhigh\|max\|auto`. |
+| `systemPromptFile` | no | (see below) | Explicit project-relative path to the advisor's system prompt. |
+| `baseBranch` | no | `main` | Literal branch name. Advisor checks out this branch at provision. |
+
+**System prompt resolution** (mirrors the existing `cfg.ResolveAgent` pattern):
+
+1. If `systemPromptFile` is explicitly set in config, use that path.
+2. Else look for a project override at `.cspace/advisors/<name>.md`.
+3. Else fall back to the cspace-embedded default at `lib/advisors/<name>.md`.
+
+No config entry needed to pick up the shipped decision-maker prompt.
+
+The `advisors` key is also the enum source for the MCP tools' `name` parameter — the supervisor reads the merged config at startup and encodes the known advisor names into the tool schemas it serves.
+
+`defaults.json` ships with the decision-maker entry above. A project can:
+- Delete the advisor entirely by setting `"advisors": {}` in `.cspace.json`.
+- Override model/effort while keeping the shipped system prompt.
+- Customize behavior by placing `.cspace/advisors/decision-maker.md`.
+- Add new advisors by adding config entries and writing `.cspace/advisors/<name>.md`.
+
+## Lifecycle
+
+### Launch
+
+`cspace coordinate` iterates `cfg.Advisors`. For each advisor:
+
+1. Probe the advisor's supervisor socket (`/logs/messages/<name>/supervisor.sock`). If alive, reuse — session continuity preserved.
+2. Otherwise: provision the container if absent (`provision.Run`), then `LaunchSupervisor` with:
+   - `Role = RoleAgent`
+   - `Persistent = true`
+   - `Name = <advisor>`
+   - Model, effort, system-prompt-file from config
+   - `PromptFile = <rendered bootstrap prompt>` (see below)
+   - Detached (the coordinator does not block on advisor stdout)
+   - Stderr to the existing per-instance log path used for agent roles (`supervisor.ContainerAgentStderrLog`) — no new log conventions.
+
+The coordinator then launches normally. Its rendered prompt includes the advisor roster — names, one-line descriptions, model/effort — so it knows what `ask_advisor(name: ...)` names are valid.
+
+### Persistence across sessions
+
+Ending a `cspace coordinate` session tears down the **coordinator supervisor only**. Advisor supervisors keep running; their containers keep running. The next `cspace coordinate` finds them alive and reuses them, so the advisor's SDK session continues to accumulate context over weeks.
+
+### Teardown
+
+New subcommand group:
+- `cspace advisor list` — list configured advisors and their supervisor status.
+- `cspace advisor down <name>` — kill the named advisor's supervisor and stop its container. Session state lost.
+- `cspace advisor down --all` — tear down every advisor.
+- `cspace advisor restart <name>` — kill the supervisor and relaunch with a fresh bootstrap prompt. For when accumulated context has gone stale.
+
+### Branch handling
+
+Advisors sit on their configured `baseBranch` (default `main`). No auto-follow of the coordinator's feature branch, no pre-supervisor checkout hook. If a consultation needs a different branch, the advisor runs `git` itself — it has write access to its own workspace.
+
+### Bootstrap prompt
+
+Rendered into a file and passed via `--prompt-file` on first launch only. On resumed sessions (socket was alive), no bootstrap — the SDK session continues from where it left off.
+
+```
+You are the <name> advisor. Your role is defined in your system prompt
+(already applied to this session).
+
+Project principles, direction, and decisions live in the cspace-context
+server — call read_context at the start of each consultation for current
+values.
+
+You will receive messages via the agent-messenger MCP tools. Reply via
+reply_to_coordinator / reply_to_worker. See your system prompt for
+response format and quality bar.
+
+Do a light read of read_context(["direction","principles","roadmap"])
+now so you have baseline context. Then wait for messages.
+```
+
+## Inter-agent messaging MCP tools
+
+Extending `lib/agent-supervisor/sdk-mcp-tools.mjs`'s in-process `agent-messenger` server. Role-scoped tool surface: each role sees only the tools that make sense.
+
+| Role | Write tools added |
+|---|---|
+| Coordinator | `send_to_worker`, `ask_advisor`, `send_to_advisor` |
+| Worker (implementer) | `notify_coordinator`, `ask_coordinator`, `handshake_advisor`, `ask_advisor`, `shutdown_self` |
+| Advisor | `reply_to_coordinator`, `reply_to_worker`, `note_to_coordinator` |
+
+Read tools (`agent_health`, `read_agent_stream`, etc.) remain role-appropriate as today.
+
+### Recipient enum
+
+For `ask_advisor`, `send_to_advisor`, `handshake_advisor`: the `name` parameter is a schema enum populated from `cfg.Advisors` at supervisor startup. Typos fail schema validation at the model's tool-call layer, before any socket dial.
+
+For `send_to_worker`: `instance` is a free-form string (worker names are dynamic, issue-N style). The tool handles an unreachable socket by returning a structured error (see below).
+
+### Return envelope
+
+Every send tool returns:
+
+```json
+{
+  "delivered": true,
+  "recipient": "decision-maker",
+  "recipient_status": {
+    "git_branch": "main",
+    "turns_completed": 17,
+    "idle_for_seconds": 42,
+    "queue_depth": 1,
+    "session_id": "abc-123"
+  },
+  "expected_reply_window": "~2-10 min (complex question)",
+  "guidance": "Continue your current task. If the reply changes scope, you'll see it as a new user message."
+}
+```
+
+`expected_reply_window` and `guidance` are hardcoded per tool and `kind` parameter. E.g. `ask_advisor(kind: "question")` returns `"~2-10 min"`; `kind: "handshake"` returns `"no reply expected; advisor will warm its context"`.
+
+### Transport
+
+The tool dials `/logs/messages/<recipient>/supervisor.sock` directly (bind-mounted into every container) and writes two NDJSON commands:
+
+1. `{"cmd": "send_user_message", "text": "<message>"}` — enqueues on the recipient's `PromptQueue`. Same command `cspace send` uses.
+2. `{"cmd": "status"}` — pulls recipient metadata for the return envelope.
+
+Both are handled by the existing socket server in `supervisor.mjs`; only `status` needs extending (see below).
+
+### Error surfacing
+
+If the recipient's socket is stale (supervisor crashed, container stopped, wrong name), the tool returns:
+
+```json
+{
+  "delivered": false,
+  "recipient": "decision-maker",
+  "error": "recipient's supervisor not reachable at /logs/messages/decision-maker/supervisor.sock",
+  "suggestion": "coordinator may need to `cspace advisor restart decision-maker`"
+}
+```
+
+Structured output — the model can act on it (try a different advisor, retry after a restart) rather than parsing an opaque bash failure.
+
+### Supervisor status extension
+
+The existing `status` socket command in `supervisor.mjs` returns `{role, instance, sessionId, turns, lastActivityMs}`. Extend to also include:
+
+- `git_branch` — `git -C <cwd> rev-parse --abbrev-ref HEAD`, cached with a 2s TTL so rapid back-to-back sends don't fork repeatedly.
+- `queue_depth` — `this._queue.length` on `PromptQueue`.
+
+Small change; existing callers continue to work since they ignore unknown fields.
+
+### `shutdown_self`
+
+New socket command. Called by the implementer at Ship phase after `notify_coordinator`. Closes the `PromptQueue` and cleans up, same path as `SIGTERM`. The container keeps running; only the supervisor exits. The coordinator can later `cspace interrupt` or `cspace down` to reclaim resources.
+
+### `cspace send` CLI stays
+
+Still the underlying transport, still useful for humans, scripts, tests, and as an escape hatch if the MCP tools fail. Agent playbooks move to the MCP tools. Deprecation is a later conversation.
+
+## Worker persistence
+
+Workers launched by the coordinator in Phase 2 now pass `--persistent` so their sessions are alive when advisor replies (or coordinator directives) land on their queue as new user turns.
+
+This is a one-line change in the coordinator playbook's `cspace up` invocation. The worker completion flow (coordinator watches for `notify_coordinator` messages) is unchanged.
+
+The Ship phase of `implementer.md` gains a final `shutdown_self` call so the coordinator isn't left with orphaned persistent workers after they've reported done.
+
+## Coordinator playbook changes
+
+### Model default
+
+`runCoordinateWithArgs` in `internal/cli/coordinate.go` sets coordinator model defaults to `claude-sonnet-4-6` and effort `high` unless `cfg.Claude.Model` / `cfg.Claude.Effort` are explicitly set. Existing users who've configured a model keep that model.
+
+### New Phase 0.5 — Advisors
+
+Inserted between the existing Phase 0 (feature branch & dependency graph) and Phase 1 (setup). Content:
+
+> You have a bench of advisors available — long-running specialists you can consult. Use `ask_advisor(name, question, kind)`. The reply arrives later as a new user turn, not as a tool result.
+>
+> **Roster (rendered at launch):** [name, model/effort, one-line role per configured advisor]
+>
+> **Consult the decision-maker when:**
+> - Picking a base branch or merge ordering when dependencies are ambiguous.
+> - Dispatching an implementer for an underspecified issue (multiple valid interpretations).
+> - A worker reports a design-level blocker (e.g. "need to introduce abstraction X — proceed?").
+> - A PR's diff doesn't cleanly match its acceptance criteria.
+> - A prior decision or finding seems to conflict with the current work.
+> - Any choice you judge architecturally significant.
+>
+> **Do NOT consult for:**
+> - Routine orchestration (which port, which file, which commit message).
+> - Choices the existing playbook already prescribes.
+> - Questions that don't touch principles.md or direction.md.
+>
+> If you're unsure whether a choice qualifies, ask. A tight question is cheaper than the wrong call.
+
+### Worker launch
+
+Phase 2 `cspace up` invocation gains `--persistent`.
+
+## Implementer playbook changes
+
+### Setup phase
+
+After reading the task prompt and `read_context`:
+
+> Call `handshake_advisor("decision-maker", summary, hints)` with a one-line summary of what you're working on and 3-5 file/module hints. This warms the advisor's context for later consultations. Do not wait for a reply — continue to Explore phase.
+
+### Implement / Design phases
+
+> If you hit an architectural choice you can't confidently resolve against principles.md and prior decisions, call `ask_advisor("decision-maker", question, kind: "question")`. The reply arrives later as a new user message — continue working in the meantime on parts of the task that don't depend on the answer. When the reply lands, integrate it and proceed.
+
+### Ship phase
+
+After successful verification and `notify_coordinator("issue-N complete, PR: ...")`:
+
+> Call `shutdown_self()` to release your supervisor. The coordinator will reclaim the container.
+
+## Shipped decision-maker
+
+### `lib/advisors/decision-maker.md` (system prompt)
+
+```
+You are a decision-making consultant to the cspace coordinator and
+implementer agents. You do not write code. You read, reason, and reply.
+
+## Your job
+Weigh architectural trade-offs against the project's stated principles
+and direction. When consulted, produce a recommendation with explicit
+reasoning.
+
+## On each consultation
+1. Call read_context(["direction","principles","roadmap"]) for fresh
+   values (humans edit these; your session cache may be stale).
+2. Call list_findings(status=["open","acknowledged"]) and read any that
+   bear on the question.
+3. Call list_entries(kind="decisions") and read any prior decisions that
+   touch the same area.
+4. Read code as needed — grep, read, follow references.
+
+## Response shape
+- Recommendation (one sentence).
+- Key reasoning (3-8 bullets, each tied to a principle, constraint, or
+  prior decision).
+- Alternatives considered and why they lose.
+- Follow-ups for the caller if any.
+
+## Record your conclusions
+For non-trivial calls, call log_decision(...) so the reasoning survives
+beyond your session. The coordinator/implementer reading it later should
+be able to act without re-consulting you.
+
+## On handshakes
+If the message is a handshake_advisor (an implementer saying "starting
+work on X"), do a shallow research pass: read the issue, grep the hinted
+files, skim related decisions/findings. Do not reply to the implementer.
+Your SDK session now has that context and will be warm for later questions.
+
+The note_to_coordinator tool is available if during research you discover
+something the coordinator needs to know right away (a conflict with a
+prior decision, a finding that invalidates the issue's premise). Use it
+sparingly — the default on handshakes is silence.
+
+## Anti-patterns
+- Do not edit code, open PRs, run verify commands, or take side effects
+  beyond context-server writes.
+- Do not answer questions that aren't architectural — redirect to the
+  coordinator.
+- Do not speculate past what principles.md and direction.md actually say.
+  If they're silent on a question, say so explicitly.
+```
+
+### Principles
+
+Live in `.cspace/context/principles.md` (human-owned per the context-server spec). The decision-maker reads them on each consultation. Empty file → generic decision-maker behavior; populated → opinionated advice.
+
+This is the correct place because the user's architectural preferences are **data the project commits and evolves**, not code that cspace ships. A project that inherits the decision-maker gets project-specific advice the moment someone writes their principles down.
+
+## Files
+
+### New
+
+- `lib/advisors/decision-maker.md` — shipped system prompt.
+- `internal/cli/advisor.go` — `cspace advisor list|down|restart` subcommand group.
+- `internal/advisor/` — Go package for advisor launch/teardown (`Launch`, `IsAlive`, `Teardown`). Mirrors `internal/supervisor` surface but config-driven per-advisor.
+
+### Modified
+
+- `internal/config/` — `Advisors map[string]AdvisorConfig` on `Config`; defaults entry in `defaults.json`.
+- `internal/cli/coordinate.go` — iterate `cfg.Advisors`, skip-if-alive, provision-if-missing, launch persistent supervisor detached; Sonnet default for coordinator; render advisor roster into the coordinator's prompt.
+- `internal/supervisor/launch.go` — thread advisor config (model/effort/system-prompt) through `LaunchParams`; `Persistent` flag wiring already exists.
+- `lib/agent-supervisor/sdk-mcp-tools.mjs` — new role-scoped send/ask tools; socket-direct transport; recipient-enum validation; structured error returns.
+- `lib/agent-supervisor/supervisor.mjs` — `status` command adds `git_branch` (2s-cached) and `queue_depth`; new `shutdown_self` handling (graceful prompt-queue close).
+- `lib/agents/coordinator.md` — Phase 0.5 (advisors), consult triggers, `--persistent` on worker launch.
+- `lib/agents/implementer.md` — handshake on boot, `ask_advisor` mid-task, `shutdown_self` at Ship.
+- `CLAUDE.md` — short "Advisors" section pointing at `.cspace/advisors/` and the role of `principles.md`.
+
+## Testing
+
+- Go unit tests for config parsing of `Advisors` block (empty, partial, override, full cases).
+- Go unit tests for `internal/advisor` launch-decision logic (alive-reuse vs fresh-provision).
+- Node tests for the new MCP tools: recipient-enum validation, socket-dial error surfacing, return-envelope shape. Mock socket server; no live Claude.
+- Node test for supervisor `status` response shape (includes `git_branch`, `queue_depth`).
+- Node test for `shutdown_self` (prompt queue closes, process exits cleanly).
+- One integration test: start a coordinator + decision-maker locally with stub prompts, coordinator calls `ask_advisor`, advisor replies via `reply_to_coordinator`, coordinator receives it as a user turn. Asserts the round-trip envelope and session persistence across two `cspace coordinate` calls.
+- No tests for `decision-maker.md` content (it's a prompt).
+
+## Out of scope
+
+- **Additional advisors** beyond decision-maker (critic, historian, security-reviewer). The mechanism supports them; shipping them is separate.
+- **Removing `cspace send` CLI.** Stays as the transport and human escape hatch.
+- **Queue prioritization** on advisor inboxes (consultations vs. handshakes). FIFO for v1.
+- **Cross-project advisor sharing** (one advisor container serving multiple repos). Each project owns its own.
+- **UI for advisor visibility** (TUI panel, dashboard). Stream goes to the event log; `cspace ssh <advisor>` or `read_agent_stream` suffice for now.
+- **Auto-expiry of stale advisor sessions.** Humans restart them when they want.
+- **Editing `principles.md` via MCP.** It's human-owned per the context-server spec; that contract doesn't change here.

--- a/internal/advisor/advisor.go
+++ b/internal/advisor/advisor.go
@@ -1,0 +1,77 @@
+// Package advisor manages the lifecycle of long-running advisor agents.
+// See docs/superpowers/specs/2026-04-18-advisor-agents-design.md.
+package advisor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/elliottregan/cspace/internal/config"
+	"github.com/elliottregan/cspace/internal/supervisor"
+)
+
+// BuildLaunchParams assembles the LaunchParams for a configured advisor.
+// Returns an error if the advisor is not in cfg.Advisors.
+func BuildLaunchParams(cfg *config.Config, name string) (supervisor.LaunchParams, error) {
+	spec, ok := cfg.Advisors[name]
+	if !ok {
+		return supervisor.LaunchParams{}, fmt.Errorf("advisor %q not configured", name)
+	}
+
+	return supervisor.LaunchParams{
+		Name:             name,
+		Role:             supervisor.RoleAdvisor,
+		ModelOverride:    spec.Model,
+		EffortOverride:   spec.Effort,
+		AdvisorNames:     sortedAdvisorNames(cfg),
+		SystemPromptFile: "", // caller stages the system-prompt file; see Launch
+		Persistent:       true,
+	}, nil
+}
+
+// sortedAdvisorNames returns the configured advisor names in sorted order
+// so the --advisors CLI flag is deterministic.
+func sortedAdvisorNames(cfg *config.Config) []string {
+	names := make([]string, 0, len(cfg.Advisors))
+	for n := range cfg.Advisors {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// IsAlive returns true when the advisor's supervisor socket answers a
+// status request. Reused from the coordinator's liveness probe pattern.
+func IsAlive(cfg *config.Config, name string) bool {
+	logsPath := supervisor.ResolveLogsVolumePath(cfg)
+	if logsPath == "" {
+		return false
+	}
+	sockPath := filepath.Join(logsPath, name, "supervisor.sock")
+	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	req, _ := json.Marshal(map[string]string{"cmd": "status"})
+	if _, err := conn.Write(append(req, '\n')); err != nil {
+		return false
+	}
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	if err != nil || n == 0 {
+		return false
+	}
+	var reply struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal(buf[:n], &reply); err != nil {
+		return false
+	}
+	return reply.OK
+}

--- a/internal/advisor/advisor.go
+++ b/internal/advisor/advisor.go
@@ -86,19 +86,22 @@ func IsAlive(cfg *config.Config, name string) bool {
 //  3. stages the system prompt and bootstrap prompt
 //  4. launches the supervisor detached (role=advisor, persistent)
 //
-// If the advisor is already alive, Launch is a no-op (returns nil).
-func Launch(cfg *config.Config, name string) error {
+// Returns reused=true when the advisor was already alive (no-op), reused=false
+// when a fresh provision+launch was initiated. A fresh launch is detached
+// and asynchronous — the supervisor socket may not be ready immediately
+// after Launch returns.
+func Launch(cfg *config.Config, name string) (reused bool, err error) {
 	spec, ok := cfg.Advisors[name]
 	if !ok {
-		return fmt.Errorf("advisor %q not configured", name)
+		return false, fmt.Errorf("advisor %q not configured", name)
 	}
 
 	if IsAlive(cfg, name) {
-		return nil
+		return true, nil
 	}
 
 	if _, err := provision.Run(provision.Params{Name: name, Cfg: cfg}); err != nil {
-		return fmt.Errorf("provisioning advisor %s: %w", name, err)
+		return false, fmt.Errorf("provisioning advisor %s: %w", name, err)
 	}
 
 	composeName := cfg.ComposeName(name)
@@ -120,36 +123,39 @@ func Launch(cfg *config.Config, name string) error {
 	// git fetch is best-effort; container may be offline. checkout must succeed.
 	_, _ = instance.DcExec(composeName, "git", "-C", "/workspace", "fetch", "origin")
 	if _, err := instance.DcExec(composeName, "git", "-C", "/workspace", "checkout", baseBranch); err != nil {
-		return fmt.Errorf("checking out advisor baseBranch %s: %w", baseBranch, err)
+		return false, fmt.Errorf("checking out advisor baseBranch %s: %w", baseBranch, err)
 	}
 
 	// Stage the system prompt (ResolveAdvisor handles override/fallback).
 	systemPromptHost := cfg.ResolveAdvisor(name)
 	if systemPromptHost == "" {
-		return fmt.Errorf("no system prompt resolved for advisor %s", name)
+		return false, fmt.Errorf("no system prompt resolved for advisor %s", name)
 	}
 	const containerSystemPromptPath = "/tmp/advisor-system-prompt.txt"
 	if err := supervisor.StagePromptFile(composeName, systemPromptHost, containerSystemPromptPath); err != nil {
-		return fmt.Errorf("staging advisor system prompt: %w", err)
+		return false, fmt.Errorf("staging advisor system prompt: %w", err)
 	}
 
 	// Render and stage the bootstrap prompt.
 	bootstrap := renderBootstrapPrompt(name)
 	const containerBootstrapPath = "/tmp/advisor-bootstrap.txt"
 	if err := supervisor.StagePromptText(composeName, bootstrap, containerBootstrapPath); err != nil {
-		return fmt.Errorf("staging advisor bootstrap prompt: %w", err)
+		return false, fmt.Errorf("staging advisor bootstrap prompt: %w", err)
 	}
 
 	params, err := BuildLaunchParams(cfg, name)
 	if err != nil {
-		return err
+		return false, err
 	}
 	params.PromptFile = containerBootstrapPath
 	params.StderrLog = supervisor.ContainerAgentStderrLog
 	params.SystemPromptFile = containerSystemPromptPath
 
 	// Detached launch — the coordinator does not block on advisor stdout.
-	return supervisor.RelaunchDetached(params, cfg, 0)
+	if err := supervisor.RelaunchDetached(params, cfg, 0); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 func renderBootstrapPrompt(name string) string {

--- a/internal/advisor/advisor.go
+++ b/internal/advisor/advisor.go
@@ -31,15 +31,15 @@ func BuildLaunchParams(cfg *config.Config, name string) (supervisor.LaunchParams
 		Role:             supervisor.RoleAdvisor,
 		ModelOverride:    spec.Model,
 		EffortOverride:   spec.Effort,
-		AdvisorNames:     sortedAdvisorNames(cfg),
+		AdvisorNames:     SortedAdvisorNames(cfg),
 		SystemPromptFile: "", // caller stages the system-prompt file; see Launch
 		Persistent:       true,
 	}, nil
 }
 
-// sortedAdvisorNames returns the configured advisor names in sorted order
+// SortedAdvisorNames returns the configured advisor names in sorted order
 // so the --advisors CLI flag is deterministic.
-func sortedAdvisorNames(cfg *config.Config) []string {
+func SortedAdvisorNames(cfg *config.Config) []string {
 	names := make([]string, 0, len(cfg.Advisors))
 	for n := range cfg.Advisors {
 		names = append(names, n)

--- a/internal/advisor/advisor.go
+++ b/internal/advisor/advisor.go
@@ -81,10 +81,10 @@ func IsAlive(cfg *config.Config, name string) bool {
 }
 
 // Launch brings the named advisor up if not already alive. It:
-//   1. provisions the container if missing
-//   2. checks out the configured baseBranch
-//   3. stages the system prompt and bootstrap prompt
-//   4. launches the supervisor detached (role=advisor, persistent)
+//  1. provisions the container if missing
+//  2. checks out the configured baseBranch
+//  3. stages the system prompt and bootstrap prompt
+//  4. launches the supervisor detached (role=advisor, persistent)
 //
 // If the advisor is already alive, Launch is a no-op (returns nil).
 func Launch(cfg *config.Config, name string) error {

--- a/internal/advisor/advisor.go
+++ b/internal/advisor/advisor.go
@@ -6,11 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"sort"
 	"time"
 
+	"github.com/elliottregan/cspace/internal/compose"
 	"github.com/elliottregan/cspace/internal/config"
+	"github.com/elliottregan/cspace/internal/instance"
+	"github.com/elliottregan/cspace/internal/provision"
 	"github.com/elliottregan/cspace/internal/supervisor"
 )
 
@@ -74,4 +78,110 @@ func IsAlive(cfg *config.Config, name string) bool {
 		return false
 	}
 	return reply.OK
+}
+
+// Launch brings the named advisor up if not already alive. It:
+//   1. provisions the container if missing
+//   2. checks out the configured baseBranch
+//   3. stages the system prompt and bootstrap prompt
+//   4. launches the supervisor detached (role=advisor, persistent)
+//
+// If the advisor is already alive, Launch is a no-op (returns nil).
+func Launch(cfg *config.Config, name string) error {
+	spec, ok := cfg.Advisors[name]
+	if !ok {
+		return fmt.Errorf("advisor %q not configured", name)
+	}
+
+	if IsAlive(cfg, name) {
+		return nil
+	}
+
+	if _, err := provision.Run(provision.Params{Name: name, Cfg: cfg}); err != nil {
+		return fmt.Errorf("provisioning advisor %s: %w", name, err)
+	}
+
+	composeName := cfg.ComposeName(name)
+	_ = instance.SkipOnboarding(composeName)
+
+	// Re-copy host .env so the advisor inherits GH_TOKEN, etc. (matches coordinator behavior).
+	envFile := filepath.Join(cfg.ProjectRoot, ".env")
+	if _, err := os.Stat(envFile); err == nil {
+		_ = instance.DcCp(composeName, envFile, "/workspace/.env")
+		_, _ = instance.DcExecRoot(composeName, "chown", "dev:dev", "/workspace/.env")
+	}
+
+	// Check out the configured baseBranch (default main) inside the advisor's workspace.
+	// The advisor can switch branches itself later if a consultation requires it.
+	baseBranch := spec.BaseBranch
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	// git fetch is best-effort; container may be offline. checkout must succeed.
+	_, _ = instance.DcExec(composeName, "git", "-C", "/workspace", "fetch", "origin")
+	if _, err := instance.DcExec(composeName, "git", "-C", "/workspace", "checkout", baseBranch); err != nil {
+		return fmt.Errorf("checking out advisor baseBranch %s: %w", baseBranch, err)
+	}
+
+	// Stage the system prompt (ResolveAdvisor handles override/fallback).
+	systemPromptHost := cfg.ResolveAdvisor(name)
+	if systemPromptHost == "" {
+		return fmt.Errorf("no system prompt resolved for advisor %s", name)
+	}
+	const containerSystemPromptPath = "/tmp/advisor-system-prompt.txt"
+	if err := supervisor.StagePromptFile(composeName, systemPromptHost, containerSystemPromptPath); err != nil {
+		return fmt.Errorf("staging advisor system prompt: %w", err)
+	}
+
+	// Render and stage the bootstrap prompt.
+	bootstrap := renderBootstrapPrompt(name)
+	const containerBootstrapPath = "/tmp/advisor-bootstrap.txt"
+	if err := supervisor.StagePromptText(composeName, bootstrap, containerBootstrapPath); err != nil {
+		return fmt.Errorf("staging advisor bootstrap prompt: %w", err)
+	}
+
+	params, err := BuildLaunchParams(cfg, name)
+	if err != nil {
+		return err
+	}
+	params.PromptFile = containerBootstrapPath
+	params.StderrLog = supervisor.ContainerAgentStderrLog
+	params.SystemPromptFile = containerSystemPromptPath
+
+	// Detached launch — the coordinator does not block on advisor stdout.
+	return supervisor.RelaunchDetached(params, cfg, 0)
+}
+
+func renderBootstrapPrompt(name string) string {
+	return fmt.Sprintf(`You are the %s advisor. Your role is defined in your system prompt
+(already applied to this session).
+
+Project principles, direction, and decisions live in the cspace-context
+server — call read_context at the start of each consultation for current
+values.
+
+You will receive messages via the agent-messenger MCP tools. Reply via
+reply_to_coordinator / reply_to_worker. See your system prompt for
+response format and quality bar.
+
+Do a light read of read_context(["direction","principles","roadmap"])
+now so you have baseline context. Then wait for messages.`, name)
+}
+
+// Teardown shuts down the advisor's supervisor and stops its container.
+// Session state is lost.
+func Teardown(cfg *config.Config, name string) error {
+	if _, ok := cfg.Advisors[name]; !ok {
+		return fmt.Errorf("advisor %q not configured", name)
+	}
+	composeName := cfg.ComposeName(name)
+
+	// Best-effort interrupt the supervisor (closes prompt queue cleanly).
+	_ = supervisor.Dispatch(composeName, "interrupt", name)
+
+	// Stop the container and remove volumes — same path as `cspace down`.
+	if err := compose.Run(name, cfg, "down", "--volumes"); err != nil {
+		return fmt.Errorf("stopping advisor container: %w", err)
+	}
+	return nil
 }

--- a/internal/advisor/advisor_test.go
+++ b/internal/advisor/advisor_test.go
@@ -1,0 +1,46 @@
+package advisor
+
+import (
+	"testing"
+
+	"github.com/elliottregan/cspace/internal/config"
+)
+
+func TestBuildLaunchParams(t *testing.T) {
+	cfg := &config.Config{
+		ProjectRoot: "/tmp/proj",
+		AssetsDir:   "/opt/assets",
+		Advisors: map[string]config.AdvisorConfig{
+			"decision-maker": {
+				Model:      "claude-opus-4-7",
+				Effort:     "max",
+				BaseBranch: "main",
+			},
+		},
+	}
+
+	params, err := BuildLaunchParams(cfg, "decision-maker")
+	if err != nil {
+		t.Fatalf("BuildLaunchParams: %v", err)
+	}
+	if params.ModelOverride != "claude-opus-4-7" {
+		t.Errorf("Model: %s", params.ModelOverride)
+	}
+	if params.EffortOverride != "max" {
+		t.Errorf("Effort: %s", params.EffortOverride)
+	}
+	if len(params.AdvisorNames) != 1 || params.AdvisorNames[0] != "decision-maker" {
+		t.Errorf("AdvisorNames: %v", params.AdvisorNames)
+	}
+	if params.Name != "decision-maker" {
+		t.Errorf("Name: %s", params.Name)
+	}
+}
+
+func TestBuildLaunchParamsUnknownAdvisor(t *testing.T) {
+	cfg := &config.Config{Advisors: map[string]config.AdvisorConfig{}}
+	_, err := BuildLaunchParams(cfg, "missing")
+	if err == nil {
+		t.Fatal("expected error for unknown advisor")
+	}
+}

--- a/internal/cli/advisor.go
+++ b/internal/cli/advisor.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/elliottregan/cspace/internal/advisor"
 	"github.com/spf13/cobra"
@@ -37,7 +38,7 @@ func newAdvisorListCmd() *cobra.Command {
 				}
 				fmt.Printf("%-20s model=%s effort=%s %s\n",
 					name,
-					fallback(spec.Model, "(default)"),
+					fallback(spec.Model, "(account default)"),
 					fallback(spec.Effort, "(default)"),
 					status,
 				)
@@ -56,7 +57,7 @@ func newAdvisorDownCmd() *cobra.Command {
 			if all {
 				for _, name := range advisor.SortedAdvisorNames(cfg) {
 					if err := advisor.Teardown(cfg, name); err != nil {
-						fmt.Printf("WARN: %s: %v\n", name, err)
+						fmt.Fprintf(os.Stderr, "WARNING: %s: %v\n", name, err)
 					} else {
 						fmt.Printf("%s stopped.\n", name)
 					}
@@ -80,16 +81,10 @@ func newAdvisorRestartCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := advisor.Teardown(cfg, args[0]); err != nil {
-				fmt.Printf("WARN during teardown: %v\n", err)
+				fmt.Fprintf(os.Stderr, "WARNING during teardown: %v\n", err)
 			}
-			return advisor.Launch(cfg, args[0])
+			_, err := advisor.Launch(cfg, args[0])
+			return err
 		},
 	}
-}
-
-func fallback(s, d string) string {
-	if s == "" {
-		return d
-	}
-	return s
 }

--- a/internal/cli/advisor.go
+++ b/internal/cli/advisor.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/elliottregan/cspace/internal/advisor"
+	"github.com/spf13/cobra"
+)
+
+func newAdvisorCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "advisor",
+		Short:   "Manage long-running advisor agents (decision-maker, etc.)",
+		GroupID: "agents",
+	}
+	cmd.AddCommand(newAdvisorListCmd())
+	cmd.AddCommand(newAdvisorDownCmd())
+	cmd.AddCommand(newAdvisorRestartCmd())
+	return cmd
+}
+
+func newAdvisorListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured advisors and their liveness",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(cfg.Advisors) == 0 {
+				fmt.Println("No advisors configured. See `advisors` in defaults.json.")
+				return nil
+			}
+			for _, name := range advisor.SortedAdvisorNames(cfg) {
+				spec := cfg.Advisors[name]
+				alive := advisor.IsAlive(cfg, name)
+				status := "stopped"
+				if alive {
+					status = "alive"
+				}
+				fmt.Printf("%-20s model=%s effort=%s %s\n",
+					name,
+					fallback(spec.Model, "(default)"),
+					fallback(spec.Effort, "(default)"),
+					status,
+				)
+			}
+			return nil
+		},
+	}
+}
+
+func newAdvisorDownCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "down [name]",
+		Short: "Stop an advisor (or all with --all)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			all, _ := cmd.Flags().GetBool("all")
+			if all {
+				for _, name := range advisor.SortedAdvisorNames(cfg) {
+					if err := advisor.Teardown(cfg, name); err != nil {
+						fmt.Printf("WARN: %s: %v\n", name, err)
+					} else {
+						fmt.Printf("%s stopped.\n", name)
+					}
+				}
+				return nil
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("usage: cspace advisor down <name> | --all")
+			}
+			return advisor.Teardown(cfg, args[0])
+		},
+	}
+	cmd.Flags().Bool("all", false, "Tear down every configured advisor")
+	return cmd
+}
+
+func newAdvisorRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart <name>",
+		Short: "Tear down and relaunch an advisor with a fresh session",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := advisor.Teardown(cfg, args[0]); err != nil {
+				fmt.Printf("WARN during teardown: %v\n", err)
+			}
+			return advisor.Launch(cfg, args[0])
+		},
+	}
+}
+
+func fallback(s, d string) string {
+	if s == "" {
+		return d
+	}
+	return s
+}

--- a/internal/cli/coordinate.go
+++ b/internal/cli/coordinate.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/elliottregan/cspace/internal/advisor"
 	"github.com/elliottregan/cspace/internal/instance"
 	"github.com/elliottregan/cspace/internal/provision"
 	"github.com/elliottregan/cspace/internal/supervisor"
@@ -118,6 +119,17 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 			"or stop it first with 'cspace interrupt _coordinator'")
 	}
 
+	// Bring up all configured advisors. A fresh advisor is provisioned and
+	// launched persistent; an already-alive advisor is reused so its session
+	// continuity is preserved across cspace coordinate calls.
+	for adName := range cfg.Advisors {
+		if err := advisor.Launch(cfg, adName); err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: advisor %s failed to launch: %v\n", adName, err)
+		} else if advisor.IsAlive(cfg, adName) {
+			fmt.Fprintf(os.Stderr, "Advisor %s ready.\n", adName)
+		}
+	}
+
 	_, err := provision.Run(provision.Params{
 		Name: name,
 		Cfg:  cfg,
@@ -183,5 +195,6 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 		PromptFile:       supervisor.ContainerCoordPromptPath,
 		StderrLog:        supervisor.ContainerCoordStderrLog,
 		SystemPromptFile: containerSystemPrompt,
+		AdvisorNames:     advisor.SortedAdvisorNames(cfg),
 	}, cfg)
 }

--- a/internal/cli/coordinate.go
+++ b/internal/cli/coordinate.go
@@ -209,9 +209,10 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 		return err
 	}
 
-	// Coordinator defaults to Sonnet — deep reasoning is delegated to
-	// advisors (Opus). User can override via claude.model in .cspace.json.
-	coordModel := cfg.Claude.Model
+	// Coordinator uses its own model setting (Sonnet default), independent of
+	// claude.model which drives workers and advisor fallbacks. Deep reasoning
+	// is delegated to advisors, so the coordinator shouldn't run on Opus.
+	coordModel := cfg.Claude.CoordinatorModel
 	if coordModel == "" {
 		coordModel = "claude-sonnet-4-6"
 	}

--- a/internal/cli/coordinate.go
+++ b/internal/cli/coordinate.go
@@ -208,6 +208,17 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 		return err
 	}
 
+	// Coordinator defaults to Sonnet — deep reasoning is delegated to
+	// advisors (Opus). User can override via claude.model in .cspace.json.
+	coordModel := cfg.Claude.Model
+	if coordModel == "" {
+		coordModel = "claude-sonnet-4-6"
+	}
+	coordEffort := cfg.Claude.Effort
+	if coordEffort == "" {
+		coordEffort = "high"
+	}
+
 	return supervisor.LaunchSupervisor(supervisor.LaunchParams{
 		Name:             name,
 		Role:             supervisor.RoleCoordinator,
@@ -215,5 +226,7 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 		StderrLog:        supervisor.ContainerCoordStderrLog,
 		SystemPromptFile: containerSystemPrompt,
 		AdvisorNames:     advisor.SortedAdvisorNames(cfg),
+		ModelOverride:    coordModel,
+		EffortOverride:   coordEffort,
 	}, cfg)
 }

--- a/internal/cli/coordinate.go
+++ b/internal/cli/coordinate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/elliottregan/cspace/internal/advisor"
@@ -182,7 +183,25 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 		if err != nil {
 			return fmt.Errorf("reading coordinator playbook: %w", err)
 		}
-		fullPrompt = string(playbookBytes) + "\n\nUSER INSTRUCTIONS:\n\n" + userBody
+		// Render the advisor roster into the coordinator's first user turn so it
+		// knows what names are valid for ask_advisor/send_to_advisor.
+		var rosterBuilder strings.Builder
+		if len(cfg.Advisors) > 0 {
+			rosterBuilder.WriteString("\n\n## Advisor roster (available via ask_advisor / send_to_advisor)\n\n")
+			for _, adName := range advisor.SortedAdvisorNames(cfg) {
+				spec := cfg.Advisors[adName]
+				model := spec.Model
+				if model == "" {
+					model = "(account default)"
+				}
+				effort := spec.Effort
+				if effort == "" {
+					effort = "(default)"
+				}
+				fmt.Fprintf(&rosterBuilder, "- **%s** — model=%s, effort=%s\n", adName, model, effort)
+			}
+		}
+		fullPrompt = string(playbookBytes) + rosterBuilder.String() + "\n\nUSER INSTRUCTIONS:\n\n" + userBody
 	}
 
 	if err := supervisor.StagePromptText(composeName, fullPrompt, supervisor.ContainerCoordPromptPath); err != nil {

--- a/internal/cli/coordinate.go
+++ b/internal/cli/coordinate.go
@@ -123,11 +123,16 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 	// Bring up all configured advisors. A fresh advisor is provisioned and
 	// launched persistent; an already-alive advisor is reused so its session
 	// continuity is preserved across cspace coordinate calls.
-	for adName := range cfg.Advisors {
-		if err := advisor.Launch(cfg, adName); err != nil {
+	for _, adName := range advisor.SortedAdvisorNames(cfg) {
+		reused, err := advisor.Launch(cfg, adName)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "WARNING: advisor %s failed to launch: %v\n", adName, err)
-		} else if advisor.IsAlive(cfg, adName) {
-			fmt.Fprintf(os.Stderr, "Advisor %s ready.\n", adName)
+			continue
+		}
+		if reused {
+			fmt.Fprintf(os.Stderr, "Advisor %s reused (already alive).\n", adName)
+		} else {
+			fmt.Fprintf(os.Stderr, "Advisor %s launched (detached; supervisor starting in container).\n", adName)
 		}
 	}
 
@@ -190,15 +195,11 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 			rosterBuilder.WriteString("\n\n## Advisor roster (available via ask_advisor / send_to_advisor)\n\n")
 			for _, adName := range advisor.SortedAdvisorNames(cfg) {
 				spec := cfg.Advisors[adName]
-				model := spec.Model
-				if model == "" {
-					model = "(account default)"
-				}
-				effort := spec.Effort
-				if effort == "" {
-					effort = "(default)"
-				}
-				fmt.Fprintf(&rosterBuilder, "- **%s** — model=%s, effort=%s\n", adName, model, effort)
+				fmt.Fprintf(&rosterBuilder, "- **%s** — model=%s, effort=%s\n",
+					adName,
+					fallback(spec.Model, "(account default)"),
+					fallback(spec.Effort, "(default)"),
+				)
 			}
 		}
 		fullPrompt = string(playbookBytes) + rosterBuilder.String() + "\n\nUSER INSTRUCTIONS:\n\n" + userBody
@@ -229,4 +230,13 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 		ModelOverride:    coordModel,
 		EffortOverride:   coordEffort,
 	}, cfg)
+}
+
+// fallback returns s if non-empty, else d. Used for consistent display of
+// config defaults in coordinate and advisor list output.
+func fallback(s, d string) string {
+	if s == "" {
+		return d
+	}
+	return s
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -92,6 +92,7 @@ and network firewalls, then run autonomous Claude agents against GitHub issues.`
 		newRebuildCmd(),
 
 		// Autonomous Agents
+		newAdvisorCmd(),
 		newCoordinateCmd(),
 		newIssueCmd(),
 		newResumeCmd(),

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/elliottregan/cspace/internal/advisor"
 	"github.com/elliottregan/cspace/internal/overlay"
 	"github.com/elliottregan/cspace/internal/planets"
 	"github.com/elliottregan/cspace/internal/ports"
@@ -158,11 +159,12 @@ func runUpWithArgs(name, branch string, noClaude, verbose bool, prompt, promptFi
 	}
 
 	return supervisor.LaunchSupervisor(supervisor.LaunchParams{
-		Name:       name,
-		Role:       supervisor.RoleAgent,
-		PromptFile: supervisor.ContainerPromptPath,
-		StderrLog:  supervisor.ContainerAgentStderrLog,
-		Persistent: persistent,
+		Name:         name,
+		Role:         supervisor.RoleAgent,
+		PromptFile:   supervisor.ContainerPromptPath,
+		StderrLog:    supervisor.ContainerAgentStderrLog,
+		Persistent:   persistent,
+		AdvisorNames: advisor.SortedAdvisorNames(cfg),
 	}, cfg)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,8 +80,9 @@ type FirewallConfig struct {
 
 // ClaudeConfig holds Claude model settings.
 type ClaudeConfig struct {
-	Model  string `json:"model"`
-	Effort string `json:"effort"`
+	Model            string `json:"model"`
+	Effort           string `json:"effort"`
+	CoordinatorModel string `json:"coordinatorModel,omitempty"`
 }
 
 // VerifyConfig holds verification command paths.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Verify     VerifyConfig           `json:"verify"`
 	Agent      AgentConfig            `json:"agent"`
 	Plugins    PluginsConfig          `json:"plugins"`
+	Advisors   map[string]AdvisorConfig `json:"advisors,omitempty"`
 	Services   string                 `json:"services"`
 	PostSetup  string                 `json:"post_setup"`
 
@@ -46,6 +47,15 @@ type Config struct {
 	// Runtime fields (not from JSON)
 	ProjectRoot string `json:"-"`
 	AssetsDir   string `json:"-"`
+}
+
+// AdvisorConfig configures a single long-running advisor agent.
+// See docs/superpowers/specs/2026-04-18-advisor-agents-design.md.
+type AdvisorConfig struct {
+	Model            string `json:"model,omitempty"`
+	Effort           string `json:"effort,omitempty"`
+	SystemPromptFile string `json:"systemPromptFile,omitempty"`
+	BaseBranch       string `json:"baseBranch,omitempty"`
 }
 
 // ProjectConfig holds project identification fields.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,17 +25,17 @@ var gitRepoRe = regexp.MustCompile(`github\.com[:/](.+)$`)
 
 // Config represents the merged cspace configuration.
 type Config struct {
-	Project    ProjectConfig          `json:"project"`
-	Container  ContainerConfig        `json:"container"`
-	Firewall   FirewallConfig         `json:"firewall"`
-	Claude     ClaudeConfig           `json:"claude"`
-	MCPServers map[string]interface{} `json:"mcpServers,omitempty"`
-	Verify     VerifyConfig           `json:"verify"`
-	Agent      AgentConfig            `json:"agent"`
-	Plugins    PluginsConfig          `json:"plugins"`
+	Project    ProjectConfig            `json:"project"`
+	Container  ContainerConfig          `json:"container"`
+	Firewall   FirewallConfig           `json:"firewall"`
+	Claude     ClaudeConfig             `json:"claude"`
+	MCPServers map[string]interface{}   `json:"mcpServers,omitempty"`
+	Verify     VerifyConfig             `json:"verify"`
+	Agent      AgentConfig              `json:"agent"`
+	Plugins    PluginsConfig            `json:"plugins"`
 	Advisors   map[string]AdvisorConfig `json:"advisors,omitempty"`
-	Services   string                 `json:"services"`
-	PostSetup  string                 `json:"post_setup"`
+	Services   string                   `json:"services"`
+	PostSetup  string                   `json:"post_setup"`
 
 	// ServiceURLs declares Traefik-routed project services whose URLs cspace
 	// should inject into the main container as env vars. Key is the subdomain

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -208,11 +208,11 @@ func TestLoad_DefaultsOnly(t *testing.T) {
 		t.Error("expected firewall.enabled=true from defaults")
 	}
 
-	// Claude model default pins to the "opus" alias so cspace always uses
-	// the latest Opus model (independent of the container's account default,
-	// which may be a lower-tier model like sonnet).
-	if cfg.Claude.Model != "opus[1m]" {
-		t.Errorf("expected model=opus[1m], got %s", cfg.Claude.Model)
+	// Claude model defaults to empty so each role can pick its own:
+	// coordinator gets Sonnet (via coordinate.go fallback), workers fall back
+	// to account default, advisors use their per-advisor model.
+	if cfg.Claude.Model != "" {
+		t.Errorf("expected model=<empty>, got %s", cfg.Claude.Model)
 	}
 
 	// Plugins should have the default list

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -518,3 +518,66 @@ func TestLoad_RealProjectConfig(t *testing.T) {
 	}
 	t.Logf("Merged config:\n%s", string(data))
 }
+
+// loadConfigFromJSON is a test helper that creates a temporary project
+// with the given JSON overlay in .cspace.json, then loads it.
+func loadConfigFromJSON(t *testing.T, overlay string) (*Config, error) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".cspace.json"), []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return Load(dir, "")
+}
+
+func TestConfigAdvisorsBlock(t *testing.T) {
+	cfg, err := loadConfigFromJSON(t, `{
+		"advisors": {
+			"decision-maker": {
+				"model": "claude-opus-4-7",
+				"effort": "max",
+				"baseBranch": "main"
+			},
+			"custom": {
+				"systemPromptFile": ".cspace/advisors/custom.md"
+			}
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if len(cfg.Advisors) != 2 {
+		t.Fatalf("want 2 advisors, got %d", len(cfg.Advisors))
+	}
+	dm, ok := cfg.Advisors["decision-maker"]
+	if !ok {
+		t.Fatalf("missing decision-maker entry")
+	}
+	if dm.Model != "claude-opus-4-7" {
+		t.Errorf("Model = %q, want claude-opus-4-7", dm.Model)
+	}
+	if dm.Effort != "max" {
+		t.Errorf("Effort = %q, want max", dm.Effort)
+	}
+	if dm.BaseBranch != "main" {
+		t.Errorf("BaseBranch = %q, want main", dm.BaseBranch)
+	}
+	custom := cfg.Advisors["custom"]
+	if custom.SystemPromptFile != ".cspace/advisors/custom.md" {
+		t.Errorf("SystemPromptFile = %q", custom.SystemPromptFile)
+	}
+}
+
+func TestConfigAdvisorsEmptyByDefault(t *testing.T) {
+	cfg, err := loadConfigFromJSON(t, `{}`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Advisors == nil {
+		t.Fatal("Advisors should be non-nil (possibly empty map from defaults.json)")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -208,11 +208,11 @@ func TestLoad_DefaultsOnly(t *testing.T) {
 		t.Error("expected firewall.enabled=true from defaults")
 	}
 
-	// Claude model defaults to empty so each role can pick its own:
-	// coordinator gets Sonnet (via coordinate.go fallback), workers fall back
-	// to account default, advisors use their per-advisor model.
-	if cfg.Claude.Model != "" {
-		t.Errorf("expected model=<empty>, got %s", cfg.Claude.Model)
+	// Claude model defaults to opus[1m] for workers and advisor fallbacks.
+	// Coordinator has a separate setting (coordinatorModel) that defaults to
+	// Sonnet via coordinate.go logic.
+	if cfg.Claude.Model != "opus[1m]" {
+		t.Errorf("expected model=opus[1m], got %s", cfg.Claude.Model)
 	}
 
 	// Plugins should have the default list
@@ -579,5 +579,29 @@ func TestConfigAdvisorsNonNilAfterDefaults(t *testing.T) {
 	}
 	if cfg.Advisors == nil {
 		t.Fatal("Advisors should be non-nil — defaults.json ships a decision-maker entry and DeepMerge preserves it when the overlay omits the key")
+	}
+}
+
+func TestConfigCoordinatorModelOverride(t *testing.T) {
+	cfg, err := loadConfigFromJSON(t, `{"claude": {"coordinatorModel": "claude-opus-4-7"}}`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Claude.CoordinatorModel != "claude-opus-4-7" {
+		t.Errorf("CoordinatorModel = %q, want claude-opus-4-7", cfg.Claude.CoordinatorModel)
+	}
+	// Defaults still supply Model for workers/advisors.
+	if cfg.Claude.Model != "opus[1m]" {
+		t.Errorf("Model = %q, want opus[1m] (unchanged by coordinator override)", cfg.Claude.Model)
+	}
+}
+
+func TestConfigCoordinatorModelEmptyByDefault(t *testing.T) {
+	cfg, err := loadConfigFromJSON(t, `{}`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Claude.CoordinatorModel != "" {
+		t.Errorf("CoordinatorModel default = %q, want empty", cfg.Claude.CoordinatorModel)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -572,12 +572,12 @@ func TestConfigAdvisorsBlock(t *testing.T) {
 	}
 }
 
-func TestConfigAdvisorsEmptyByDefault(t *testing.T) {
+func TestConfigAdvisorsNonNilAfterDefaults(t *testing.T) {
 	cfg, err := loadConfigFromJSON(t, `{}`)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
 	if cfg.Advisors == nil {
-		t.Fatal("Advisors should be non-nil (possibly empty map from defaults.json)")
+		t.Fatal("Advisors should be non-nil — defaults.json ships a decision-maker entry and DeepMerge preserves it when the overlay omits the key")
 	}
 }

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -67,6 +67,20 @@ func ResolveAgent(projectRoot, assetsDir, name string) string {
 	return path
 }
 
+// ResolveAdvisor resolves an advisor system-prompt file, checking the project
+// override directory first, then falling back to the extracted embedded assets.
+//
+// Resolution order:
+//  1. $PROJECT_ROOT/.cspace/advisors/<name>.md
+//  2. $ASSETS_DIR/advisors/<name>.md
+//
+// Used when AdvisorConfig.SystemPromptFile is empty (the default). Callers
+// that want to respect an explicit SystemPromptFile should check that first.
+func ResolveAdvisor(projectRoot, assetsDir, name string) string {
+	path, _ := resolveFile(projectRoot, assetsDir, "advisors", "advisors", name+".md")
+	return path
+}
+
 // --- Config methods for convenience ---
 
 // ResolveTemplate resolves a template file using this config's paths.
@@ -82,4 +96,18 @@ func (c *Config) ResolveScript(name string) string {
 // ResolveAgent resolves an agent playbook file using this config's paths.
 func (c *Config) ResolveAgent(name string) string {
 	return ResolveAgent(c.ProjectRoot, c.AssetsDir, name)
+}
+
+// ResolveAdvisor resolves an advisor system-prompt file using this config's paths.
+// If the named advisor's config has an explicit SystemPromptFile, that path is
+// returned directly (joined against project root if relative); otherwise the
+// default override/fallback resolution applies.
+func (c *Config) ResolveAdvisor(name string) string {
+	if a, ok := c.Advisors[name]; ok && a.SystemPromptFile != "" {
+		if filepath.IsAbs(a.SystemPromptFile) {
+			return a.SystemPromptFile
+		}
+		return filepath.Join(c.ProjectRoot, a.SystemPromptFile)
+	}
+	return ResolveAdvisor(c.ProjectRoot, c.AssetsDir, name)
 }

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -133,3 +133,36 @@ func TestResolveAgent_FallbackToAssets(t *testing.T) {
 		t.Errorf("expected assets fallback %s, got %s", expected, result)
 	}
 }
+
+func TestResolveAdvisor(t *testing.T) {
+	project := t.TempDir()
+	assets := t.TempDir()
+
+	// Fallback: assets/advisors/decision-maker.md exists.
+	if err := os.MkdirAll(filepath.Join(assets, "advisors"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fallback := filepath.Join(assets, "advisors", "decision-maker.md")
+	if err := os.WriteFile(fallback, []byte("fallback"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ResolveAdvisor(project, assets, "decision-maker")
+	if got != fallback {
+		t.Errorf("fallback: got %s, want %s", got, fallback)
+	}
+
+	// Override: .cspace/advisors/decision-maker.md wins.
+	if err := os.MkdirAll(filepath.Join(project, ".cspace", "advisors"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	override := filepath.Join(project, ".cspace", "advisors", "decision-maker.md")
+	if err := os.WriteFile(override, []byte("override"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got = ResolveAdvisor(project, assets, "decision-maker")
+	if got != override {
+		t.Errorf("override: got %s, want %s", got, override)
+	}
+}

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -489,9 +489,7 @@ func formatPortLine(p portEntry) string {
 	host := p.URL
 	// Strip "http://localhost" prefix when present so the row fits.
 	const localhost = "http://localhost"
-	if strings.HasPrefix(host, localhost) {
-		host = host[len(localhost):]
-	}
+	host = strings.TrimPrefix(host, localhost)
 	label := truncate(p.Label, 16)
 	// Pad label to a consistent column so ports align across rows.
 	padded := label + strings.Repeat(" ", max(0, 16-runeLen(label)))

--- a/internal/supervisor/dispatch.go
+++ b/internal/supervisor/dispatch.go
@@ -11,6 +11,7 @@ import (
 const (
 	RoleAgent       = "agent"
 	RoleCoordinator = "coordinator"
+	RoleAdvisor     = "advisor"
 )
 
 // Well-known container paths used by the supervisor protocol.

--- a/internal/supervisor/launch.go
+++ b/internal/supervisor/launch.go
@@ -20,7 +20,7 @@ import (
 // is a programmer error and is rejected at LaunchSupervisor entry.
 type LaunchParams struct {
 	Name            string // Instance name (e.g. "mercury")
-	Role            string // RoleAgent or RoleCoordinator
+	Role            string // RoleAgent, RoleCoordinator, or RoleAdvisor
 	PromptFile      string // Container-side path to prompt file. Required unless ResumeSessionID is set.
 	StderrLog       string // Container-side path for stderr log
 	ResumeSessionID string // If set, supervisor resumes this session instead of starting from PromptFile.
@@ -35,7 +35,7 @@ type LaunchParams struct {
 	// each result so external callers (`cspace send <instance> …`) can drive
 	// the agent through multiple turns. Default is the one-shot behavior —
 	// the supervisor closes the queue after the first result and exits.
-	// Only meaningful for RoleAgent; RoleCoordinator is always persistent.
+	// Only meaningful for RoleAgent; RoleCoordinator and RoleAdvisor are always persistent.
 	Persistent bool
 
 	// ModelOverride, if non-empty, takes precedence over cfg.Claude.Model

--- a/internal/supervisor/launch.go
+++ b/internal/supervisor/launch.go
@@ -39,8 +39,9 @@ type LaunchParams struct {
 	Persistent bool
 
 	// ModelOverride, if non-empty, takes precedence over cfg.Claude.Model
-	// on the supervisor command line. Used by advisors to pin their model
-	// independently of the rest of the cspace session.
+	// on the supervisor command line. Used by coordinators (pinning to
+	// Sonnet) and advisors (pinning to their configured per-advisor model)
+	// to set a specific model independent of the global cfg.Claude.Model.
 	ModelOverride string
 
 	// EffortOverride, if non-empty, takes precedence over cfg.Claude.Effort.

--- a/internal/supervisor/launch.go
+++ b/internal/supervisor/launch.go
@@ -37,6 +37,18 @@ type LaunchParams struct {
 	// the supervisor closes the queue after the first result and exits.
 	// Only meaningful for RoleAgent; RoleCoordinator is always persistent.
 	Persistent bool
+
+	// ModelOverride, if non-empty, takes precedence over cfg.Claude.Model
+	// on the supervisor command line. Used by advisors to pin their model
+	// independently of the rest of the cspace session.
+	ModelOverride string
+
+	// EffortOverride, if non-empty, takes precedence over cfg.Claude.Effort.
+	EffortOverride string
+
+	// AdvisorNames is the list of configured advisor names to pass to the
+	// supervisor for MCP tool enum population.
+	AdvisorNames []string
 }
 
 // LaunchSupervisor runs the agent-supervisor inside the named instance
@@ -273,21 +285,30 @@ func buildSupervisorArgs(params LaunchParams, cfg *config.Config) []string {
 		args = append(args, "--prompt-file", params.PromptFile)
 	}
 
-	if params.Role == RoleAgent {
+	if params.Role == RoleAgent || params.Role == RoleAdvisor {
 		args = append(args, "--instance", params.Name)
 	}
 
-	if cfg.Claude.Model != "" {
-		args = append(args, "--model", cfg.Claude.Model)
+	model := params.ModelOverride
+	if model == "" {
+		model = cfg.Claude.Model
+	}
+	if model != "" {
+		args = append(args, "--model", model)
 	}
 
-	// Autonomous supervisor runs default to max thinking. An explicit
-	// claude.effort in cspace settings wins, so users can dial it down.
-	effort := cfg.Claude.Effort
+	effort := params.EffortOverride
+	if effort == "" {
+		effort = cfg.Claude.Effort
+	}
 	if effort == "" {
 		effort = "max"
 	}
 	args = append(args, "--effort", effort)
+
+	if len(params.AdvisorNames) > 0 {
+		args = append(args, "--advisors", strings.Join(params.AdvisorNames, ","))
+	}
 
 	if params.Persistent {
 		args = append(args, "--persistent")

--- a/internal/supervisor/launch_test.go
+++ b/internal/supervisor/launch_test.go
@@ -178,3 +178,46 @@ func TestLaunchSupervisorRejectsBothSet(t *testing.T) {
 		t.Errorf("expected 'mutually exclusive' error, got: %v", err)
 	}
 }
+
+func TestBuildSupervisorArgsAdvisor(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Claude.Model = "default-model"
+	cfg.Claude.Effort = "high"
+
+	params := LaunchParams{
+		Name:           "decision-maker",
+		Role:           RoleAdvisor,
+		PromptFile:     "/tmp/p",
+		StderrLog:      "/tmp/err",
+		ModelOverride:  "claude-opus-4-7",
+		EffortOverride: "max",
+		AdvisorNames:   []string{"decision-maker", "critic"},
+	}
+	args := buildSupervisorArgs(params, cfg)
+
+	if !containsArg(args, "--role", "advisor") {
+		t.Errorf("expected --role advisor; got %v", args)
+	}
+	if !containsArg(args, "--model", "claude-opus-4-7") {
+		t.Errorf("expected --model claude-opus-4-7 (override); got %v", args)
+	}
+	if !containsArg(args, "--effort", "max") {
+		t.Errorf("expected --effort max (override); got %v", args)
+	}
+	if !containsArg(args, "--advisors", "decision-maker,critic") {
+		t.Errorf("expected --advisors decision-maker,critic; got %v", args)
+	}
+	if !containsArg(args, "--instance", "decision-maker") {
+		t.Errorf("expected --instance decision-maker; got %v", args)
+	}
+}
+
+// Helper: walks pairs and returns true if [flag, value] appears consecutively.
+func containsArg(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/lib/advisors/decision-maker.md
+++ b/lib/advisors/decision-maker.md
@@ -1,0 +1,47 @@
+You are a decision-making consultant to the cspace coordinator and
+implementer agents. You do not write code. You read, reason, and reply.
+
+## Your job
+Weigh architectural trade-offs against the project's stated principles
+and direction. When consulted, produce a recommendation with explicit
+reasoning.
+
+## On each consultation
+1. Call read_context(["direction","principles","roadmap"]) for fresh
+   values (humans edit these; your session cache may be stale).
+2. Call list_findings(status=["open","acknowledged"]) and read any that
+   bear on the question.
+3. Call list_entries(kind="decisions") and read any prior decisions that
+   touch the same area.
+4. Read code as needed — grep, read, follow references.
+
+## Response shape
+- Recommendation (one sentence).
+- Key reasoning (3-8 bullets, each tied to a principle, constraint, or
+  prior decision).
+- Alternatives considered and why they lose.
+- Follow-ups for the caller if any.
+
+## Record your conclusions
+For non-trivial calls, call log_decision(...) so the reasoning survives
+beyond your session. The coordinator/implementer reading it later should
+be able to act without re-consulting you.
+
+## On handshakes
+If the message is a handshake_advisor (an implementer saying "starting
+work on X"), do a shallow research pass: read the issue, grep the hinted
+files, skim related decisions/findings. Do not reply to the implementer.
+Your SDK session now has that context and will be warm for later questions.
+
+The note_to_coordinator tool is available if during research you discover
+something the coordinator needs to know right away (a conflict with a
+prior decision, a finding that invalidates the issue's premise). Use it
+sparingly — the default on handshakes is silence.
+
+## Anti-patterns
+- Do not edit code, open PRs, run verify commands, or take side effects
+  beyond context-server writes.
+- Do not answer questions that aren't architectural — redirect to the
+  coordinator.
+- Do not speculate past what principles.md and direction.md actually say.
+  If they're silent on a question, say so explicitly.

--- a/lib/agent-supervisor/args.mjs
+++ b/lib/agent-supervisor/args.mjs
@@ -49,6 +49,9 @@ export function parseArgsForTest(argv) {
   if (args.resumeSession && args.promptFile) {
     throw new Error('--resume-session and --prompt-file are mutually exclusive')
   }
+  if (!['agent', 'coordinator', 'advisor'].includes(args.role)) {
+    throw new Error(`unknown role: ${args.role}`)
+  }
   return args
 }
 

--- a/lib/agent-supervisor/args.mjs
+++ b/lib/agent-supervisor/args.mjs
@@ -18,6 +18,7 @@ export function parseArgsForTest(argv) {
     idleTimeoutMs: 10 * 60 * 1000,
     eventLogDir: '/logs/events',
     ignoreInboxBefore: 0,
+    advisors: [],
   }
   for (let i = 2; i < argv.length; i++) {
     const arg = argv[i]
@@ -35,6 +36,10 @@ export function parseArgsForTest(argv) {
     else if (arg === '--persistent') args.persistent = true
     else if (arg === '--event-log-dir') args.eventLogDir = argv[++i]
     else if (arg === '--ignore-inbox-before') args.ignoreInboxBefore = Number.parseInt(argv[++i], 10)
+    else if (arg === '--advisors') {
+      const val = argv[++i] || ''
+      args.advisors = val.split(',').map((s) => s.trim()).filter(Boolean)
+    }
     else if (arg === '--help' || arg === '-h') {
       throw new Error('__help__')
     } else {

--- a/lib/agent-supervisor/args.test.mjs
+++ b/lib/agent-supervisor/args.test.mjs
@@ -22,3 +22,22 @@ test('--advisors absent yields empty list', () => {
   ])
   assert.deepEqual(args.advisors, [])
 })
+
+test('role=advisor is accepted', () => {
+  const args = parseArgsForTest([
+    'node', 'supervisor.mjs',
+    '--role', 'advisor',
+    '--instance', 'decision-maker',
+    '--prompt-file', '/tmp/p',
+  ])
+  assert.equal(args.role, 'advisor')
+})
+
+test('role=unknown throws', () => {
+  assert.throws(() => parseArgsForTest([
+    'node', 'supervisor.mjs',
+    '--role', 'bogus',
+    '--instance', 'x',
+    '--prompt-file', '/tmp/p',
+  ]))
+})

--- a/lib/agent-supervisor/args.test.mjs
+++ b/lib/agent-supervisor/args.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseArgsForTest } from './args.mjs'
+
+test('--advisors accepts comma-separated list', () => {
+  const args = parseArgsForTest([
+    'node', 'supervisor.mjs',
+    '--role', 'agent',
+    '--instance', 'issue-42',
+    '--prompt-file', '/tmp/p',
+    '--advisors', 'decision-maker,critic',
+  ])
+  assert.deepEqual(args.advisors, ['decision-maker', 'critic'])
+})
+
+test('--advisors absent yields empty list', () => {
+  const args = parseArgsForTest([
+    'node', 'supervisor.mjs',
+    '--role', 'agent',
+    '--instance', 'issue-42',
+    '--prompt-file', '/tmp/p',
+  ])
+  assert.deepEqual(args.advisors, [])
+})

--- a/lib/agent-supervisor/sdk-mcp-tools.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.mjs
@@ -23,121 +23,23 @@ import {
   readAllEnvelopes,
   readTailEnvelopes,
 } from './event-log.mjs'
+import {
+  trySocketRequest,
+  sockPathFor,
+  sendAndFetchStatus,
+  buildDeliveredEnvelope,
+  buildErrorEnvelope,
+  toolResult,
+} from './socket-protocol.mjs'
 
-// --- Helpers ---
-
-/**
- * Send a request to a supervisor's Unix socket and return the reply.
- * Used for status probes and live message injection.
- */
-function trySocketRequest(sockPath, request, timeoutMs = 2000) {
-  return new Promise((resolve) => {
-    if (!fs.existsSync(sockPath)) {
-      resolve({ ok: false, error: 'socket not present' })
-      return
-    }
-    const conn = net.createConnection(sockPath)
-    let settled = false
-    const finish = (value) => {
-      if (settled) return
-      settled = true
-      try {
-        conn.end()
-      } catch {}
-      clearTimeout(timer)
-      resolve(value)
-    }
-    const timer = setTimeout(
-      () => finish({ ok: false, error: 'timeout' }),
-      timeoutMs,
-    )
-    let buf = ''
-    conn.on('connect', () =>
-      conn.write(JSON.stringify(request) + '\n'),
-    )
-    conn.on('data', (chunk) => {
-      buf += chunk.toString('utf-8')
-      const idx = buf.indexOf('\n')
-      if (idx >= 0) {
-        try {
-          finish(JSON.parse(buf.slice(0, idx)))
-        } catch (e) {
-          finish({ ok: false, error: `parse error: ${e.message}` })
-        }
-      }
-    })
-    conn.on('error', (e) =>
-      finish({ ok: false, error: e.message }),
-    )
-    conn.on('end', () =>
-      finish({ ok: false, error: 'connection closed' }),
-    )
-  })
-}
-
-function sockPathFor(msgDir, instance) {
-  return path.join(msgDir, instance, 'supervisor.sock')
-}
-
-/**
- * Send a user message to a supervisor's socket and then probe its status.
- * Returns `{delivered, status, error?}`. On delivery failure (no socket,
- * bad reply), returns `{delivered: false, error: <reason>}`.
- */
-export async function sendAndFetchStatus(sockPath, text) {
-  const sendReply = await trySocketRequest(sockPath, { cmd: 'send_user_message', text })
-  if (!sendReply.ok) {
-    return { delivered: false, error: sendReply.error || 'send failed' }
-  }
-  const statusReply = await trySocketRequest(sockPath, { cmd: 'status' })
-  if (!statusReply.ok || !statusReply.status) {
-    return { delivered: true, status: null, error: statusReply.error || 'status unavailable' }
-  }
-  return { delivered: true, status: statusReply.status }
-}
-
-/**
- * Build the standard send-tool return envelope for a successful delivery.
- */
-export function buildDeliveredEnvelope({ recipient, status, expectedReplyWindow, guidance }) {
-  const recipientStatus = status
-    ? {
-        git_branch: status.git_branch || 'unknown',
-        turns_completed: status.turns ?? 0,
-        idle_for_seconds: Math.round((status.lastActivityMs ?? 0) / 1000),
-        queue_depth: status.queue_depth ?? 0,
-        session_id: status.sessionId || null,
-      }
-    : null
-  return {
-    delivered: true,
-    recipient,
-    recipient_status: recipientStatus,
-    expected_reply_window: expectedReplyWindow,
-    guidance,
-  }
-}
-
-/**
- * Build the standard send-tool return envelope for a delivery failure.
- */
-export function buildErrorEnvelope({ recipient, sockPath, reason }) {
-  return {
-    delivered: false,
-    recipient,
-    error: `recipient's supervisor not reachable at ${sockPath} (${reason})`,
-    suggestion: `restart the recipient (e.g. \`cspace advisor restart ${recipient}\` for advisors, or \`cspace restart-supervisor ${recipient}\` for workers)`,
-  }
-}
-
-/**
- * Wrap the envelope in the { content: [{type: 'text', text: ...}] }
- * shape that MCP tools return.
- */
-export function toolResult(envelope) {
-  return {
-    content: [{ type: 'text', text: JSON.stringify(envelope, null, 2) }],
-  }
+// Re-export socket protocol helpers for backward compatibility
+export {
+  trySocketRequest,
+  sockPathFor,
+  sendAndFetchStatus,
+  buildDeliveredEnvelope,
+  buildErrorEnvelope,
+  toolResult,
 }
 
 /**

--- a/lib/agent-supervisor/sdk-mcp-tools.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.mjs
@@ -530,6 +530,82 @@ export function buildMessengerMcpServer({ role, msgDir, instance, eventLogRoot, 
     )
   }
 
+  if (role === 'advisor') {
+    tools.push(
+      tool(
+        'reply_to_coordinator',
+        'Send your recommendation/answer back to the coordinator. The coordinator will see this as a new user turn. Use this as the final step of a consultation when the coordinator asked you via ask_advisor.',
+        {
+          message: z.string().describe('Your full reply. Follow the response shape in your system prompt.'),
+        },
+        async ({ message }) => {
+          const sockPath = sockPathFor(msgDir, '_coordinator')
+          const r = await sendAndFetchStatus(sockPath, `[advisor ${instance} reply] ${message}`)
+          if (!r.delivered) {
+            return toolResult(buildErrorEnvelope({
+              recipient: '_coordinator',
+              sockPath,
+              reason: r.error,
+            }))
+          }
+          return toolResult(buildDeliveredEnvelope({
+            recipient: '_coordinator',
+            status: r.status,
+            expectedReplyWindow: 'none (coordinator reads it on its next turn)',
+            guidance: 'Consultation delivered.',
+          }))
+        },
+      ),
+
+      tool(
+        'reply_to_worker',
+        'Send your answer back to a worker that asked you via ask_advisor. The worker will see it as a new user turn mid-task.',
+        {
+          instance: z.string().describe('Worker instance name (e.g. "issue-42")'),
+          message: z.string(),
+        },
+        async ({ instance: target, message }) => {
+          const sockPath = sockPathFor(msgDir, target)
+          const r = await sendAndFetchStatus(sockPath, `[advisor ${instance} reply] ${message}`)
+          if (!r.delivered) {
+            return toolResult(buildErrorEnvelope({ recipient: target, sockPath, reason: r.error }))
+          }
+          return toolResult(buildDeliveredEnvelope({
+            recipient: target,
+            status: r.status,
+            expectedReplyWindow: 'none',
+            guidance: 'Consultation delivered.',
+          }))
+        },
+      ),
+
+      tool(
+        'note_to_coordinator',
+        'Proactively ping the coordinator with a short note (e.g. during handshake research you found a conflicting prior decision the coordinator should see). Use sparingly — the default on handshakes is silence.',
+        {
+          message: z.string(),
+        },
+        async ({ message }) => {
+          const sockPath = sockPathFor(msgDir, '_coordinator')
+          const r = await sendAndFetchStatus(sockPath, `[advisor ${instance} note] ${message}`)
+          if (!r.delivered) {
+            return toolResult(buildErrorEnvelope({
+              recipient: '_coordinator',
+              sockPath,
+              reason: r.error,
+            }))
+          }
+          return toolResult(buildDeliveredEnvelope({
+            recipient: '_coordinator',
+            status: r.status,
+            expectedReplyWindow: 'none',
+            guidance: 'Note delivered.',
+          }))
+        },
+      ),
+    )
+  }
+
   const server = createSdkMcpServer({
     name: 'agent-messenger',
     version: '3.0.0',

--- a/lib/agent-supervisor/sdk-mcp-tools.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.mjs
@@ -354,6 +354,28 @@ export function buildMessengerMcpServer({ role, msgDir, instance, eventLogRoot, 
           }
         },
       ),
+
+      tool(
+        'send_to_worker',
+        'Send a message to a worker agent. Fire-and-forget but the worker will process it as a new user turn. Use for directives like "rebase onto feature/x and resolve conflicts" or answers to ask_coordinator questions.',
+        {
+          instance: z.string().describe('Worker instance name (e.g. "issue-42")'),
+          message: z.string(),
+        },
+        async ({ instance: target, message }) => {
+          const sockPath = sockPathFor(msgDir, target)
+          const r = await sendAndFetchStatus(sockPath, `[directive from _coordinator] ${message}`)
+          if (!r.delivered) {
+            return toolResult(buildErrorEnvelope({ recipient: target, sockPath, reason: r.error }))
+          }
+          return toolResult(buildDeliveredEnvelope({
+            recipient: target,
+            status: r.status,
+            expectedReplyWindow: 'worker acts on the message; no automatic reply',
+            guidance: 'If you expect the worker to notify you back, wait for a new user turn from that worker.',
+          }))
+        },
+      ),
     )
   }
 

--- a/lib/agent-supervisor/sdk-mcp-tools.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.mjs
@@ -342,6 +342,74 @@ export function buildMessengerMcpServer({ role, msgDir, instance, eventLogRoot, 
     )
   }
 
+  if (role === 'agent') {
+    tools.push(
+      tool(
+        'notify_coordinator',
+        'Send a status update or completion message to the coordinator. Fire-and-forget — no reply expected. Use this for: "issue-N complete, PR: ...", progress updates, and error reports.',
+        {
+          message: z.string().describe('The message body. Plain text.'),
+        },
+        async ({ message }) => {
+          const sockPath = sockPathFor(msgDir, '_coordinator')
+          const r = await sendAndFetchStatus(sockPath, message)
+          if (!r.delivered) {
+            return toolResult(buildErrorEnvelope({
+              recipient: '_coordinator',
+              sockPath,
+              reason: r.error,
+            }))
+          }
+          return toolResult(buildDeliveredEnvelope({
+            recipient: '_coordinator',
+            status: r.status,
+            expectedReplyWindow: 'none (fire-and-forget notification)',
+            guidance: 'Continue your current task. The coordinator will see this as a new user turn on its side.',
+          }))
+        },
+      ),
+
+      tool(
+        'ask_coordinator',
+        'Ask the coordinator a question. Expect a reply arriving later as a new user turn on your session (not as a tool result). Use when your task scope is ambiguous and only the coordinator can resolve it.',
+        {
+          question: z.string().describe('The question to ask. Be specific; include context the coordinator may not remember.'),
+        },
+        async ({ question }) => {
+          const sockPath = sockPathFor(msgDir, '_coordinator')
+          const r = await sendAndFetchStatus(sockPath, `[question from ${instance}] ${question}`)
+          if (!r.delivered) {
+            return toolResult(buildErrorEnvelope({
+              recipient: '_coordinator',
+              sockPath,
+              reason: r.error,
+            }))
+          }
+          return toolResult(buildDeliveredEnvelope({
+            recipient: '_coordinator',
+            status: r.status,
+            expectedReplyWindow: '~1-5 min (coordinator reply time)',
+            guidance: 'Continue work on parts of your task that do not depend on the answer. When the reply arrives as a new user message, integrate it and proceed.',
+          }))
+        },
+      ),
+
+      tool(
+        'shutdown_self',
+        'Close your own supervisor cleanly. Call this ONLY after notify_coordinator with your final completion message (task done, PR opened, etc.). Your container stays up; the coordinator can reclaim it.',
+        {},
+        async () => {
+          const sockPath = sockPathFor(msgDir, instance)
+          const reply = await trySocketRequest(sockPath, { cmd: 'shutdown_self' })
+          if (!reply.ok) {
+            return toolResult({ ok: false, error: reply.error || 'shutdown failed' })
+          }
+          return toolResult({ ok: true, message: 'Shutdown requested. Supervisor will exit shortly.' })
+        },
+      ),
+    )
+  }
+
   const server = createSdkMcpServer({
     name: 'agent-messenger',
     version: '3.0.0',

--- a/lib/agent-supervisor/sdk-mcp-tools.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.mjs
@@ -194,6 +194,21 @@ function findPendingToolCall(envelopes) {
  */
 export function buildMessengerMcpServer({ role, msgDir, instance, eventLogRoot, advisorNames }) {
   advisorNames = advisorNames || []
+
+  function advisorNameSchema(names) {
+    if (names.length === 0) {
+      // empty enum is invalid; callers guard against this by checking length first
+      return z.string()
+    }
+    return z.enum(names)
+  }
+
+  const HANDSHAKE_GUIDANCE =
+    'No reply expected. The advisor will do a shallow research pass so it is warm for later questions.'
+  const QUESTION_GUIDANCE =
+    'Continue work on parts of your task that do not depend on the answer. When the reply arrives as a new user message, integrate it and proceed.'
+
+  const hasAdvisors = advisorNames.length > 0
   const tools = []
 
   if (role === 'coordinator') {
@@ -405,6 +420,89 @@ export function buildMessengerMcpServer({ role, msgDir, instance, eventLogRoot, 
             return toolResult({ ok: false, error: reply.error || 'shutdown failed' })
           }
           return toolResult({ ok: true, message: 'Shutdown requested. Supervisor will exit shortly.' })
+        },
+      ),
+    )
+  }
+
+  if (role === 'agent' && hasAdvisors) {
+    tools.push(
+      tool(
+        'handshake_advisor',
+        'Tell an advisor what you are about to work on, so it warms its research context. Fire-and-forget — the advisor will not reply to you. Call once per task, near the start.',
+        {
+          name: advisorNameSchema(advisorNames),
+          summary: z.string().describe('One-line summary of what you are working on (e.g. "issue #42: add retry logic to webhook handler")'),
+          hints: z.array(z.string()).optional().describe('Up to ~5 file or module hints that might be relevant'),
+        },
+        async ({ name, summary, hints }) => {
+          const sockPath = sockPathFor(msgDir, name)
+          const body = `[handshake from ${instance}] ${summary}\nHints: ${(hints || []).join(', ') || '(none)'}`
+          const r = await sendAndFetchStatus(sockPath, body)
+          if (!r.delivered) {
+            return toolResult(buildErrorEnvelope({ recipient: name, sockPath, reason: r.error }))
+          }
+          return toolResult(buildDeliveredEnvelope({
+            recipient: name,
+            status: r.status,
+            expectedReplyWindow: 'none (handshake)',
+            guidance: HANDSHAKE_GUIDANCE,
+          }))
+        },
+      ),
+    )
+  }
+
+  if ((role === 'agent' || role === 'coordinator') && hasAdvisors) {
+    tools.push(
+      tool(
+        'ask_advisor',
+        'Ask an advisor a question. Reply arrives later as a new user turn on your session, not as a tool result.',
+        {
+          name: advisorNameSchema(advisorNames),
+          question: z.string().describe('The question. Be specific; the advisor only sees what you send.'),
+          kind: z.enum(['question', 'followup']).default('question').describe('"question" = first ask; "followup" = tighter question in an ongoing consultation'),
+        },
+        async ({ name, question, kind }) => {
+          const sockPath = sockPathFor(msgDir, name)
+          const sender = instance || '_coordinator'
+          const body = `[${kind} from ${sender}] ${question}`
+          const r = await sendAndFetchStatus(sockPath, body)
+          if (!r.delivered) {
+            return toolResult(buildErrorEnvelope({ recipient: name, sockPath, reason: r.error }))
+          }
+          return toolResult(buildDeliveredEnvelope({
+            recipient: name,
+            status: r.status,
+            expectedReplyWindow: kind === 'followup' ? '~1-5 min' : '~2-10 min (complex question)',
+            guidance: QUESTION_GUIDANCE,
+          }))
+        },
+      ),
+    )
+  }
+
+  if (role === 'coordinator' && hasAdvisors) {
+    tools.push(
+      tool(
+        'send_to_advisor',
+        'Send a fire-and-forget note to an advisor (no reply expected). Use for informational updates like "issue-42 has been merged" or "new principle added to principles.md".',
+        {
+          name: advisorNameSchema(advisorNames),
+          message: z.string(),
+        },
+        async ({ name, message }) => {
+          const sockPath = sockPathFor(msgDir, name)
+          const r = await sendAndFetchStatus(sockPath, `[note from _coordinator] ${message}`)
+          if (!r.delivered) {
+            return toolResult(buildErrorEnvelope({ recipient: name, sockPath, reason: r.error }))
+          }
+          return toolResult(buildDeliveredEnvelope({
+            recipient: name,
+            status: r.status,
+            expectedReplyWindow: 'none (note)',
+            guidance: 'No reply expected.',
+          }))
         },
       ),
     )

--- a/lib/agent-supervisor/sdk-mcp-tools.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.mjs
@@ -192,7 +192,8 @@ function findPendingToolCall(envelopes) {
  * @param {string} [config.eventLogRoot] usually /logs/events
  * @returns {{ server: object, toolNames: string[] }}
  */
-export function buildMessengerMcpServer({ role, msgDir, instance, eventLogRoot }) {
+export function buildMessengerMcpServer({ role, msgDir, instance, eventLogRoot, advisorNames }) {
+  advisorNames = advisorNames || []
   const tools = []
 
   if (role === 'coordinator') {

--- a/lib/agent-supervisor/sdk-mcp-tools.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.mjs
@@ -80,6 +80,67 @@ function sockPathFor(msgDir, instance) {
 }
 
 /**
+ * Send a user message to a supervisor's socket and then probe its status.
+ * Returns `{delivered, status, error?}`. On delivery failure (no socket,
+ * bad reply), returns `{delivered: false, error: <reason>}`.
+ */
+export async function sendAndFetchStatus(sockPath, text) {
+  const sendReply = await trySocketRequest(sockPath, { cmd: 'send_user_message', text })
+  if (!sendReply.ok) {
+    return { delivered: false, error: sendReply.error || 'send failed' }
+  }
+  const statusReply = await trySocketRequest(sockPath, { cmd: 'status' })
+  if (!statusReply.ok || !statusReply.status) {
+    return { delivered: true, status: null, error: statusReply.error || 'status unavailable' }
+  }
+  return { delivered: true, status: statusReply.status }
+}
+
+/**
+ * Build the standard send-tool return envelope for a successful delivery.
+ */
+export function buildDeliveredEnvelope({ recipient, status, expectedReplyWindow, guidance }) {
+  const recipientStatus = status
+    ? {
+        git_branch: status.git_branch || 'unknown',
+        turns_completed: status.turns ?? 0,
+        idle_for_seconds: Math.round((status.lastActivityMs ?? 0) / 1000),
+        queue_depth: status.queue_depth ?? 0,
+        session_id: status.sessionId || null,
+      }
+    : null
+  return {
+    delivered: true,
+    recipient,
+    recipient_status: recipientStatus,
+    expected_reply_window: expectedReplyWindow,
+    guidance,
+  }
+}
+
+/**
+ * Build the standard send-tool return envelope for a delivery failure.
+ */
+export function buildErrorEnvelope({ recipient, sockPath, reason }) {
+  return {
+    delivered: false,
+    recipient,
+    error: `recipient's supervisor not reachable at ${sockPath} (${reason})`,
+    suggestion: `restart the recipient (e.g. \`cspace advisor restart ${recipient}\` for advisors, or \`cspace restart-supervisor ${recipient}\` for workers)`,
+  }
+}
+
+/**
+ * Wrap the envelope in the { content: [{type: 'text', text: ...}] }
+ * shape that MCP tools return.
+ */
+export function toolResult(envelope) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(envelope, null, 2) }],
+  }
+}
+
+/**
  * Scan envelopes (in order) for the most recent tool_use whose paired
  * tool_result hasn't arrived yet. Stops at the first `result` envelope
  * from the end (clean turn boundary). Returns { tool, tool_id, started_at,

--- a/lib/agent-supervisor/sdk-mcp-tools.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.mjs
@@ -1,15 +1,20 @@
 /**
- * In-process MCP tools for the agent-supervisor.
+ * In-process MCP tools for the agent-supervisor. Exposed per role:
  *
- * All inter-agent messaging goes through `cspace send`:
- *   worker → coordinator:  cspace send _coordinator "..."
- *   coordinator → worker:  cspace send <instance> "..."
+ *   agent       — notify_coordinator, ask_coordinator, shutdown_self,
+ *                 handshake_advisor, ask_advisor (if advisors configured)
+ *   coordinator — agent_health, agent_recent_activity, read_agent_stream
+ *                 (diagnostics), send_to_worker, ask_advisor,
+ *                 send_to_advisor (if advisors configured)
+ *   advisor     — reply_to_coordinator, reply_to_worker, note_to_coordinator
  *
- * The tools here are coordinator-only diagnostics for inspecting agent
- * state when the live `cspace up` BashOutput is insufficient:
- *   agent_health          socket liveness + event log pending-tool-call check
- *   agent_recent_activity last N event-log envelopes
- *   read_agent_stream     full event stream with incremental polling
+ * Each send/ask/reply tool dials `/logs/messages/<recipient>/supervisor.sock`
+ * directly and returns a structured envelope (delivered, recipient_status,
+ * expected_reply_window, guidance) or an error envelope on failure.
+ *
+ * The bash `cspace send` CLI remains as the underlying transport and a
+ * human/scripts escape hatch; agents prefer these MCP tools for typed
+ * recipient names and structured returns.
  */
 
 import fs from 'node:fs'
@@ -84,14 +89,15 @@ function findPendingToolCall(envelopes) {
 // --- MCP server ---
 
 /**
- * Build the in-process MCP server with diagnostic tools for coordinators.
- * Agent role gets no in-process tools — agents communicate via `cspace send`.
+ * Build the in-process MCP server exposing role-scoped inter-agent
+ * messaging tools + coordinator diagnostics.
  *
  * @param {object} config
- * @param {'agent'|'coordinator'} config.role
+ * @param {'agent'|'coordinator'|'advisor'} config.role
  * @param {string} config.msgDir        usually /logs/messages
- * @param {string} [config.instance]    required for agent role
+ * @param {string} [config.instance]    required for agent/advisor roles
  * @param {string} [config.eventLogRoot] usually /logs/events
+ * @param {string[]} [config.advisorNames] enum source for advisor recipient name params
  * @returns {{ server: object, toolNames: string[] }}
  */
 export function buildMessengerMcpServer({ role, msgDir, instance, eventLogRoot, advisorNames }) {

--- a/lib/agent-supervisor/sdk-mcp-tools.test.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.test.mjs
@@ -1,0 +1,88 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import net from 'node:net'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  sendAndFetchStatus,
+  buildDeliveredEnvelope,
+  buildErrorEnvelope,
+} from './sdk-mcp-tools.mjs'
+
+function startFakeSupervisor(sockPath, statusReply) {
+  const srv = net.createServer((conn) => {
+    let buf = ''
+    conn.on('data', (chunk) => {
+      buf += chunk.toString('utf-8')
+      while (true) {
+        const idx = buf.indexOf('\n')
+        if (idx < 0) break
+        const line = buf.slice(0, idx)
+        buf = buf.slice(idx + 1)
+        const req = JSON.parse(line)
+        if (req.cmd === 'send_user_message') {
+          conn.write(JSON.stringify({ ok: true }) + '\n')
+        } else if (req.cmd === 'status') {
+          conn.write(JSON.stringify({ ok: true, status: statusReply }) + '\n')
+        }
+      }
+    })
+  })
+  return new Promise((resolve) => srv.listen(sockPath, () => resolve(srv)))
+}
+
+test('sendAndFetchStatus delivers message and returns status', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sup-'))
+  const sockPath = path.join(tmp, 'supervisor.sock')
+  const statusReply = {
+    role: 'agent',
+    instance: 'decision-maker',
+    sessionId: 'abc',
+    turns: 7,
+    lastActivityMs: 10_000,
+    queue_depth: 1,
+    git_branch: 'main',
+  }
+  const srv = await startFakeSupervisor(sockPath, statusReply)
+  try {
+    const r = await sendAndFetchStatus(sockPath, 'hello')
+    assert.equal(r.delivered, true)
+    assert.equal(r.status.instance, 'decision-maker')
+    assert.equal(r.status.git_branch, 'main')
+  } finally {
+    srv.close()
+  }
+})
+
+test('sendAndFetchStatus returns delivered:false for missing socket', async () => {
+  const r = await sendAndFetchStatus('/tmp/does-not-exist-xyzzy.sock', 'hello')
+  assert.equal(r.delivered, false)
+  assert.match(r.error, /not present|connect|ENOENT/)
+})
+
+test('buildDeliveredEnvelope shape', () => {
+  const env = buildDeliveredEnvelope({
+    recipient: 'decision-maker',
+    status: { git_branch: 'main', turns: 5, lastActivityMs: 1000, queue_depth: 0, sessionId: 's' },
+    expectedReplyWindow: '~2-10 min',
+    guidance: 'Continue your current task.',
+  })
+  assert.equal(env.delivered, true)
+  assert.equal(env.recipient, 'decision-maker')
+  assert.equal(env.recipient_status.git_branch, 'main')
+  assert.equal(env.recipient_status.idle_for_seconds, 1)
+  assert.equal(env.expected_reply_window, '~2-10 min')
+})
+
+test('buildErrorEnvelope shape', () => {
+  const env = buildErrorEnvelope({
+    recipient: 'gone',
+    sockPath: '/tmp/gone.sock',
+    reason: 'socket not present',
+  })
+  assert.equal(env.delivered, false)
+  assert.equal(env.recipient, 'gone')
+  assert.match(env.error, /not reachable/)
+  assert.match(env.suggestion, /restart/)
+})

--- a/lib/agent-supervisor/sdk-mcp-tools.test.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.test.mjs
@@ -138,3 +138,14 @@ test('advisor tools are omitted when no advisors configured', async () => {
   assert.ok(!toolNames.includes('mcp__agent-messenger__handshake_advisor'))
   assert.ok(!toolNames.includes('mcp__agent-messenger__ask_advisor'))
 })
+
+test('coordinator role exposes send_to_worker', async () => {
+  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'coordinator',
+    msgDir: '/tmp',
+    eventLogRoot: '/tmp',
+    advisorNames: [],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__send_to_worker'))
+})

--- a/lib/agent-supervisor/sdk-mcp-tools.test.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.test.mjs
@@ -86,3 +86,17 @@ test('buildErrorEnvelope shape', () => {
   assert.match(env.error, /not reachable/)
   assert.match(env.suggestion, /restart/)
 })
+
+test('worker role exposes notify_coordinator, ask_coordinator, shutdown_self', async () => {
+  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'agent',
+    msgDir: '/tmp',
+    instance: 'issue-42',
+    eventLogRoot: '/tmp',
+    advisorNames: [],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__notify_coordinator'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__ask_coordinator'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__shutdown_self'))
+})

--- a/lib/agent-supervisor/sdk-mcp-tools.test.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.test.mjs
@@ -1,4 +1,4 @@
-import { test } from 'node:test'
+import { test, before } from 'node:test'
 import assert from 'node:assert/strict'
 import net from 'node:net'
 import fs from 'node:fs'
@@ -8,7 +8,7 @@ import {
   sendAndFetchStatus,
   buildDeliveredEnvelope,
   buildErrorEnvelope,
-} from './sdk-mcp-tools.mjs'
+} from './socket-protocol.mjs'
 
 function startFakeSupervisor(sockPath, statusReply) {
   const srv = net.createServer((conn) => {
@@ -87,8 +87,20 @@ test('buildErrorEnvelope shape', () => {
   assert.match(env.suggestion, /restart/)
 })
 
-test('worker role exposes notify_coordinator, ask_coordinator, shutdown_self', async () => {
-  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+let buildMessengerMcpServer = null
+let sdkAvailable = false
+
+before(async () => {
+  try {
+    ({ buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs'))
+    sdkAvailable = true
+  } catch (e) {
+    if (!e.message.includes('@anthropic-ai/claude-agent-sdk')) throw e
+    console.error('[sdk-mcp-tools.test.mjs] SDK not installed; skipping SDK-dependent tests')
+  }
+})
+
+test('worker role exposes notify_coordinator, ask_coordinator, shutdown_self', { skip: !sdkAvailable }, () => {
   const { toolNames } = buildMessengerMcpServer({
     role: 'agent',
     msgDir: '/tmp',
@@ -101,8 +113,7 @@ test('worker role exposes notify_coordinator, ask_coordinator, shutdown_self', a
   assert.ok(toolNames.includes('mcp__agent-messenger__shutdown_self'))
 })
 
-test('worker role exposes handshake_advisor and ask_advisor when advisors are configured', async () => {
-  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+test('worker role exposes handshake_advisor and ask_advisor when advisors are configured', { skip: !sdkAvailable }, () => {
   const { toolNames } = buildMessengerMcpServer({
     role: 'agent',
     msgDir: '/tmp',
@@ -114,8 +125,7 @@ test('worker role exposes handshake_advisor and ask_advisor when advisors are co
   assert.ok(toolNames.includes('mcp__agent-messenger__ask_advisor'))
 })
 
-test('coordinator role exposes ask_advisor and send_to_advisor when advisors are configured', async () => {
-  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+test('coordinator role exposes ask_advisor and send_to_advisor when advisors are configured', { skip: !sdkAvailable }, () => {
   const { toolNames } = buildMessengerMcpServer({
     role: 'coordinator',
     msgDir: '/tmp',
@@ -126,8 +136,7 @@ test('coordinator role exposes ask_advisor and send_to_advisor when advisors are
   assert.ok(toolNames.includes('mcp__agent-messenger__send_to_advisor'))
 })
 
-test('advisor tools are omitted when no advisors configured', async () => {
-  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+test('advisor tools are omitted when no advisors configured', { skip: !sdkAvailable }, () => {
   const { toolNames } = buildMessengerMcpServer({
     role: 'agent',
     msgDir: '/tmp',
@@ -139,8 +148,7 @@ test('advisor tools are omitted when no advisors configured', async () => {
   assert.ok(!toolNames.includes('mcp__agent-messenger__ask_advisor'))
 })
 
-test('coordinator role exposes send_to_worker', async () => {
-  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+test('coordinator role exposes send_to_worker', { skip: !sdkAvailable }, () => {
   const { toolNames } = buildMessengerMcpServer({
     role: 'coordinator',
     msgDir: '/tmp',
@@ -150,8 +158,7 @@ test('coordinator role exposes send_to_worker', async () => {
   assert.ok(toolNames.includes('mcp__agent-messenger__send_to_worker'))
 })
 
-test('advisor role exposes reply and note tools', async () => {
-  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+test('advisor role exposes reply and note tools', { skip: !sdkAvailable }, () => {
   const { toolNames } = buildMessengerMcpServer({
     role: 'advisor',
     msgDir: '/tmp',

--- a/lib/agent-supervisor/sdk-mcp-tools.test.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.test.mjs
@@ -100,3 +100,41 @@ test('worker role exposes notify_coordinator, ask_coordinator, shutdown_self', a
   assert.ok(toolNames.includes('mcp__agent-messenger__ask_coordinator'))
   assert.ok(toolNames.includes('mcp__agent-messenger__shutdown_self'))
 })
+
+test('worker role exposes handshake_advisor and ask_advisor when advisors are configured', async () => {
+  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'agent',
+    msgDir: '/tmp',
+    instance: 'issue-42',
+    eventLogRoot: '/tmp',
+    advisorNames: ['decision-maker'],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__handshake_advisor'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__ask_advisor'))
+})
+
+test('coordinator role exposes ask_advisor and send_to_advisor when advisors are configured', async () => {
+  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'coordinator',
+    msgDir: '/tmp',
+    eventLogRoot: '/tmp',
+    advisorNames: ['decision-maker'],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__ask_advisor'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__send_to_advisor'))
+})
+
+test('advisor tools are omitted when no advisors configured', async () => {
+  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'agent',
+    msgDir: '/tmp',
+    instance: 'issue-42',
+    eventLogRoot: '/tmp',
+    advisorNames: [],
+  })
+  assert.ok(!toolNames.includes('mcp__agent-messenger__handshake_advisor'))
+  assert.ok(!toolNames.includes('mcp__agent-messenger__ask_advisor'))
+})

--- a/lib/agent-supervisor/sdk-mcp-tools.test.mjs
+++ b/lib/agent-supervisor/sdk-mcp-tools.test.mjs
@@ -149,3 +149,17 @@ test('coordinator role exposes send_to_worker', async () => {
   })
   assert.ok(toolNames.includes('mcp__agent-messenger__send_to_worker'))
 })
+
+test('advisor role exposes reply and note tools', async () => {
+  const { buildMessengerMcpServer } = await import('./sdk-mcp-tools.mjs')
+  const { toolNames } = buildMessengerMcpServer({
+    role: 'advisor',
+    msgDir: '/tmp',
+    instance: 'decision-maker',
+    eventLogRoot: '/tmp',
+    advisorNames: ['decision-maker'],
+  })
+  assert.ok(toolNames.includes('mcp__agent-messenger__reply_to_coordinator'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__reply_to_worker'))
+  assert.ok(toolNames.includes('mcp__agent-messenger__note_to_coordinator'))
+})

--- a/lib/agent-supervisor/socket-protocol.mjs
+++ b/lib/agent-supervisor/socket-protocol.mjs
@@ -1,0 +1,126 @@
+/**
+ * Socket-based protocol helpers extracted from sdk-mcp-tools.mjs.
+ * These have no SDK dependencies, so they can be imported in tests
+ * without requiring node_modules/ to be installed.
+ */
+
+import fs from 'node:fs'
+import net from 'node:net'
+import path from 'node:path'
+
+/**
+ * Send a request to a supervisor's Unix socket and return the reply.
+ * Used for status probes and live message injection.
+ */
+export function trySocketRequest(sockPath, request, timeoutMs = 2000) {
+  return new Promise((resolve) => {
+    if (!fs.existsSync(sockPath)) {
+      resolve({ ok: false, error: 'socket not present' })
+      return
+    }
+    const conn = net.createConnection(sockPath)
+    let settled = false
+    const finish = (value) => {
+      if (settled) return
+      settled = true
+      try {
+        conn.end()
+      } catch {}
+      clearTimeout(timer)
+      resolve(value)
+    }
+    const timer = setTimeout(
+      () => finish({ ok: false, error: 'timeout' }),
+      timeoutMs,
+    )
+    let buf = ''
+    conn.on('connect', () =>
+      conn.write(JSON.stringify(request) + '\n'),
+    )
+    conn.on('data', (chunk) => {
+      buf += chunk.toString('utf-8')
+      const idx = buf.indexOf('\n')
+      if (idx >= 0) {
+        try {
+          finish(JSON.parse(buf.slice(0, idx)))
+        } catch (e) {
+          finish({ ok: false, error: `parse error: ${e.message}` })
+        }
+      }
+    })
+    conn.on('error', (e) =>
+      finish({ ok: false, error: e.message }),
+    )
+    conn.on('end', () =>
+      finish({ ok: false, error: 'connection closed' }),
+    )
+  })
+}
+
+/**
+ * Compute the socket path for a supervisor instance.
+ */
+export function sockPathFor(msgDir, instance) {
+  return path.join(msgDir, instance, 'supervisor.sock')
+}
+
+/**
+ * Send a user message to a supervisor's socket and then probe its status.
+ * Returns `{delivered, status, error?}`. On delivery failure (no socket,
+ * bad reply), returns `{delivered: false, error: <reason>}`.
+ */
+export async function sendAndFetchStatus(sockPath, text) {
+  const sendReply = await trySocketRequest(sockPath, { cmd: 'send_user_message', text })
+  if (!sendReply.ok) {
+    return { delivered: false, error: sendReply.error || 'send failed' }
+  }
+  const statusReply = await trySocketRequest(sockPath, { cmd: 'status' })
+  if (!statusReply.ok || !statusReply.status) {
+    return { delivered: true, status: null, error: statusReply.error || 'status unavailable' }
+  }
+  return { delivered: true, status: statusReply.status }
+}
+
+/**
+ * Build the standard send-tool return envelope for a successful delivery.
+ */
+export function buildDeliveredEnvelope({ recipient, status, expectedReplyWindow, guidance }) {
+  const recipientStatus = status
+    ? {
+        git_branch: status.git_branch || 'unknown',
+        turns_completed: status.turns ?? 0,
+        idle_for_seconds: Math.round((status.lastActivityMs ?? 0) / 1000),
+        queue_depth: status.queue_depth ?? 0,
+        session_id: status.sessionId || null,
+      }
+    : null
+  return {
+    delivered: true,
+    recipient,
+    recipient_status: recipientStatus,
+    expected_reply_window: expectedReplyWindow,
+    guidance,
+  }
+}
+
+/**
+ * Build the standard send-tool return envelope for a delivery failure.
+ */
+export function buildErrorEnvelope({ recipient, sockPath, reason }) {
+  return {
+    delivered: false,
+    recipient,
+    error: `recipient's supervisor not reachable at ${sockPath} (${reason})`,
+    suggestion: `restart the recipient (e.g. \`cspace advisor restart ${recipient}\` for advisors, or \`cspace restart-supervisor ${recipient}\` for workers)`,
+  }
+}
+
+/**
+ * Wrap the envelope in the { content: [{type: 'text', text: ...}] }
+ * shape that MCP tools return.
+ */
+export function toolResult(envelope) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(envelope, null, 2) }],
+  }
+}

--- a/lib/agent-supervisor/supervisor-helpers.mjs
+++ b/lib/agent-supervisor/supervisor-helpers.mjs
@@ -1,0 +1,109 @@
+/**
+ * Pure helpers extracted from supervisor.mjs so tests can run without the SDK.
+ * These functions have no external dependencies (only node:child_process).
+ */
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const GIT_BRANCH_TTL_MS = 2000
+
+/**
+ * Derive role-dependent behavior. Pure function for testability.
+ */
+export function deriveRoleBehavior({ role, instance, persistent }) {
+  const isMultiTurn = role === 'coordinator' || role === 'advisor' || persistent === true
+  const socketInstance = role === 'coordinator' ? '_coordinator' : instance
+  const eventSubdir = role === 'coordinator' ? '_coordinator' : instance
+  return { isMultiTurn, socketInstance, eventSubdir }
+}
+
+/**
+ * Build the extra fields to merge into the supervisor's status reply.
+ * `cache` is a mutable object ({lastBranch, lastBranchTs}) used to cache
+ * the git branch result across rapid-fire calls. `now` is injectable for tests.
+ */
+export async function computeStatusExtras({ queueLength, cwd, cache, now }) {
+  cache = cache || computeStatusExtras.defaultCache
+  now = now || Date.now
+
+  const extras = { queue_depth: queueLength }
+
+  const t = now()
+  if (cache.lastBranch !== null && t - cache.lastBranchTs < GIT_BRANCH_TTL_MS) {
+    extras.git_branch = cache.lastBranch
+  } else {
+    let branch = 'unknown'
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD'], {
+        timeout: 1000,
+      })
+      branch = stdout.trim() || 'unknown'
+    } catch {
+      branch = 'unknown'
+    }
+    cache.lastBranch = branch
+    cache.lastBranchTs = t
+    extras.git_branch = branch
+  }
+
+  return extras
+}
+computeStatusExtras.defaultCache = { lastBranch: null, lastBranchTs: 0 }
+
+/**
+ * Construct a user message in SDK format.
+ */
+export function makeUserMessage(text, sessionId = '') {
+  return {
+    type: 'user',
+    session_id: sessionId,
+    parent_tool_use_id: null,
+    message: {
+      role: 'user',
+      content: [{ type: 'text', text }],
+    },
+  }
+}
+
+/**
+ * Handle a single supervisor socket request. Exported for tests.
+ * `state` = { promptQueue, cwd, getQuery, getStatus, onShutdown }
+ */
+export async function handleSupervisorRequest(req, state) {
+  switch (req.cmd) {
+    case 'send_user_message': {
+      if (typeof req.text !== 'string' || !req.text) {
+        return { ok: false, error: 'text required' }
+      }
+      state.promptQueue.push(makeUserMessage(req.text))
+      return { ok: true }
+    }
+    case 'interrupt': {
+      const q = state.getQuery()
+      if (!q) return { ok: false, error: 'query not yet started' }
+      try {
+        await q.interrupt()
+        return { ok: true }
+      } catch (e) {
+        return { ok: false, error: e.message }
+      }
+    }
+    case 'status': {
+      const base = state.getStatus()
+      const extras = await computeStatusExtras({
+        queueLength: state.promptQueue._queue.length,
+        cwd: state.cwd,
+      })
+      return { ok: true, status: { ...base, ...extras } }
+    }
+    case 'shutdown':
+    case 'shutdown_self':
+      state.onShutdown()
+      return { ok: true }
+    default:
+      return { ok: false, error: `unknown cmd: ${req.cmd}` }
+  }
+}

--- a/lib/agent-supervisor/supervisor.integration.test.mjs
+++ b/lib/agent-supervisor/supervisor.integration.test.mjs
@@ -6,7 +6,7 @@ import path from 'node:path'
 import os from 'node:os'
 import {
   sendAndFetchStatus,
-} from './sdk-mcp-tools.mjs'
+} from './socket-protocol.mjs'
 
 const enabled = process.env.RUN_INTEGRATION === '1'
 

--- a/lib/agent-supervisor/supervisor.integration.test.mjs
+++ b/lib/agent-supervisor/supervisor.integration.test.mjs
@@ -1,0 +1,68 @@
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import net from 'node:net'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  sendAndFetchStatus,
+} from './sdk-mcp-tools.mjs'
+
+const enabled = process.env.RUN_INTEGRATION === '1'
+
+function makeFakeSupervisor(sockPath, statusReply) {
+  const received = []
+  const srv = net.createServer((conn) => {
+    let buf = ''
+    conn.on('data', (chunk) => {
+      buf += chunk.toString('utf-8')
+      while (true) {
+        const idx = buf.indexOf('\n')
+        if (idx < 0) break
+        const line = buf.slice(0, idx)
+        buf = buf.slice(idx + 1)
+        try {
+          const req = JSON.parse(line)
+          received.push(req)
+          if (req.cmd === 'send_user_message') {
+            conn.write(JSON.stringify({ ok: true }) + '\n')
+          } else if (req.cmd === 'status') {
+            conn.write(JSON.stringify({ ok: true, status: statusReply }) + '\n')
+          }
+        } catch (e) {
+          conn.write(JSON.stringify({ ok: false, error: e.message }) + '\n')
+        }
+      }
+    })
+  })
+  return new Promise((resolve) =>
+    srv.listen(sockPath, () => resolve({ srv, received })),
+  )
+}
+
+test('send_to_advisor round-trip delivers and reports status', { skip: !enabled }, async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'advisor-int-'))
+  const sockPath = path.join(tmp, 'supervisor.sock')
+  const { srv, received } = await makeFakeSupervisor(sockPath, {
+    role: 'advisor',
+    instance: 'decision-maker',
+    sessionId: 'session-1',
+    turns: 3,
+    lastActivityMs: 0,
+    queue_depth: 0,
+    git_branch: 'main',
+  })
+  try {
+    const r = await sendAndFetchStatus(sockPath, 'test message')
+    assert.equal(r.delivered, true)
+    assert.equal(r.status.instance, 'decision-maker')
+    assert.equal(r.status.git_branch, 'main')
+    assert.deepEqual(
+      received.map((req) => req.cmd),
+      ['send_user_message', 'status'],
+    )
+  } finally {
+    srv.close()
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})

--- a/lib/agent-supervisor/supervisor.mjs
+++ b/lib/agent-supervisor/supervisor.mjs
@@ -33,6 +33,12 @@ import { query } from '@anthropic-ai/claude-agent-sdk'
 import { parseArgsForTest, buildQueryOptions } from './args.mjs'
 import { buildMessengerMcpServer } from './sdk-mcp-tools.mjs'
 import { normalizeSdkMessage, shim } from './stream-shim.mjs'
+import {
+  deriveRoleBehavior,
+  computeStatusExtras,
+  makeUserMessage,
+  handleSupervisorRequest,
+} from './supervisor-helpers.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -51,7 +57,14 @@ process.stdout.on('error', (err) => {
 // would eagerly load the Claude Agent SDK.
 //
 // Re-exported here for backward-compatibility with existing callers.
-export { parseArgsForTest, buildQueryOptions }
+export {
+  parseArgsForTest,
+  buildQueryOptions,
+  deriveRoleBehavior,
+  computeStatusExtras,
+  makeUserMessage,
+  handleSupervisorRequest,
+}
 
 function parseArgs(argv) {
   try {
@@ -134,18 +147,6 @@ class PromptQueue {
   }
 }
 
-function makeUserMessage(text, sessionId = '') {
-  return {
-    type: 'user',
-    session_id: sessionId,
-    parent_tool_use_id: null,
-    message: {
-      role: 'user',
-      content: [{ type: 'text', text }],
-    },
-  }
-}
-
 // --- Socket server for host-side injection ---
 
 function socketPathFor(role, msgDir, instance) {
@@ -157,91 +158,6 @@ function socketPathFor(role, msgDir, instance) {
 }
 
 const execFileAsync = promisify(execFile)
-
-const GIT_BRANCH_TTL_MS = 2000
-
-/**
- * Derive role-dependent behavior. Pure function for testability.
- */
-export function deriveRoleBehavior({ role, instance, persistent }) {
-  const isMultiTurn = role === 'coordinator' || role === 'advisor' || persistent === true
-  const socketInstance = role === 'coordinator' ? '_coordinator' : instance
-  const eventSubdir = role === 'coordinator' ? '_coordinator' : instance
-  return { isMultiTurn, socketInstance, eventSubdir }
-}
-
-/**
- * Build the extra fields to merge into the supervisor's status reply.
- * `cache` is a mutable object ({lastBranch, lastBranchTs}) used to cache
- * the git branch result across rapid-fire calls. `now` is injectable for tests.
- */
-export async function computeStatusExtras({ queueLength, cwd, cache, now }) {
-  cache = cache || computeStatusExtras.defaultCache
-  now = now || Date.now
-
-  const extras = { queue_depth: queueLength }
-
-  const t = now()
-  if (cache.lastBranch !== null && t - cache.lastBranchTs < GIT_BRANCH_TTL_MS) {
-    extras.git_branch = cache.lastBranch
-  } else {
-    let branch = 'unknown'
-    try {
-      const { stdout } = await execFileAsync('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD'], {
-        timeout: 1000,
-      })
-      branch = stdout.trim() || 'unknown'
-    } catch {
-      branch = 'unknown'
-    }
-    cache.lastBranch = branch
-    cache.lastBranchTs = t
-    extras.git_branch = branch
-  }
-
-  return extras
-}
-computeStatusExtras.defaultCache = { lastBranch: null, lastBranchTs: 0 }
-
-/**
- * Handle a single supervisor socket request. Exported for tests.
- * `state` = { promptQueue, cwd, getQuery, getStatus, onShutdown }
- */
-export async function handleSupervisorRequest(req, state) {
-  switch (req.cmd) {
-    case 'send_user_message': {
-      if (typeof req.text !== 'string' || !req.text) {
-        return { ok: false, error: 'text required' }
-      }
-      state.promptQueue.push(makeUserMessage(req.text))
-      return { ok: true }
-    }
-    case 'interrupt': {
-      const q = state.getQuery()
-      if (!q) return { ok: false, error: 'query not yet started' }
-      try {
-        await q.interrupt()
-        return { ok: true }
-      } catch (e) {
-        return { ok: false, error: e.message }
-      }
-    }
-    case 'status': {
-      const base = state.getStatus()
-      const extras = await computeStatusExtras({
-        queueLength: state.promptQueue._queue.length,
-        cwd: state.cwd,
-      })
-      return { ok: true, status: { ...base, ...extras } }
-    }
-    case 'shutdown':
-    case 'shutdown_self':
-      state.onShutdown()
-      return { ok: true }
-    default:
-      return { ok: false, error: `unknown cmd: ${req.cmd}` }
-  }
-}
 
 /**
  * Start the control socket. Commands are NDJSON-framed; each connection

--- a/lib/agent-supervisor/supervisor.mjs
+++ b/lib/agent-supervisor/supervisor.mjs
@@ -14,13 +14,17 @@
  *   4. persists all SDK events to an NDJSON event log on disk
  *
  * Roles:
- *   agent       — one-shot: exits after the first result
+ *   agent       — one-shot: exits after the first result (or multi-turn with --persistent)
  *   coordinator — multi-turn: stays alive between results, waiting for
  *                 worker completions via `cspace send _coordinator`
+ *   advisor     — multi-turn persistent: stays alive to handle consultations
+ *                 from coordinator and workers; session continuity preserved
+ *                 across cspace coordinate invocations
  *
  * Invocation:
  *   node supervisor.mjs --role agent --instance venus --prompt-file /tmp/claude-prompt.txt
  *   node supervisor.mjs --role coordinator --prompt-file /tmp/coordinator-prompt.txt
+ *   node supervisor.mjs --role advisor --instance decision-maker --prompt-file /tmp/p --system-prompt-file /tmp/sys
  */
 
 import fs from 'node:fs'
@@ -73,7 +77,7 @@ function parseArgs(argv) {
     if (e.message === '__help__') {
       console.error(`Usage: supervisor.mjs --role agent|coordinator [--instance NAME] [--prompt-file PATH | --resume-session ID]
 Options:
-  --role <agent|coordinator>    Default: agent
+  --role <agent|coordinator|advisor>  Default: agent
   --instance <name>             Required for agent role
   --prompt-file <path>          Initial user prompt (required unless --resume-session)
   --resume-session <id>         Resume an existing Claude session by id.
@@ -91,7 +95,7 @@ Options:
                                 Overrides the CLAUDE_CODE_EFFORT_LEVEL env var for this query.
   --persistent                  Agent role only: keep the prompt queue open between
                                 results so \`cspace send <instance> ...\` can drive
-                                multi-turn conversations. Coordinator is always persistent.
+                                multi-turn conversations. Coordinator and advisor are always persistent.
   --event-log-dir <path>        Directory root for NDJSON event log.
                                 Default /logs/events. Empty string disables.
   --advisors <csv>              Comma-separated advisor names (populates MCP tool enums).`)

--- a/lib/agent-supervisor/supervisor.mjs
+++ b/lib/agent-supervisor/supervisor.mjs
@@ -80,7 +80,8 @@ Options:
                                 results so \`cspace send <instance> ...\` can drive
                                 multi-turn conversations. Coordinator is always persistent.
   --event-log-dir <path>        Directory root for NDJSON event log.
-                                Default /logs/events. Empty string disables.`)
+                                Default /logs/events. Empty string disables.
+  --advisors <csv>              Comma-separated advisor names (populates MCP tool enums).`)
       process.exit(0)
     }
     console.error(`supervisor: ${e.message}`)
@@ -352,6 +353,7 @@ async function main() {
     msgDir,
     instance: args.instance,
     eventLogRoot: args.eventLogDir || '/logs/events',
+    advisorNames: args.advisors,
   })
 
   // Merge in external MCP servers from a --mcp-config file (same shape

--- a/lib/agent-supervisor/supervisor.mjs
+++ b/lib/agent-supervisor/supervisor.mjs
@@ -193,6 +193,46 @@ export async function computeStatusExtras({ queueLength, cwd, cache, now }) {
 computeStatusExtras.defaultCache = { lastBranch: null, lastBranchTs: 0 }
 
 /**
+ * Handle a single supervisor socket request. Exported for tests.
+ * `state` = { promptQueue, cwd, getQuery, getStatus, onShutdown }
+ */
+export async function handleSupervisorRequest(req, state) {
+  switch (req.cmd) {
+    case 'send_user_message': {
+      if (typeof req.text !== 'string' || !req.text) {
+        return { ok: false, error: 'text required' }
+      }
+      state.promptQueue.push(makeUserMessage(req.text))
+      return { ok: true }
+    }
+    case 'interrupt': {
+      const q = state.getQuery()
+      if (!q) return { ok: false, error: 'query not yet started' }
+      try {
+        await q.interrupt()
+        return { ok: true }
+      } catch (e) {
+        return { ok: false, error: e.message }
+      }
+    }
+    case 'status': {
+      const base = state.getStatus()
+      const extras = await computeStatusExtras({
+        queueLength: state.promptQueue._queue.length,
+        cwd: state.cwd,
+      })
+      return { ok: true, status: { ...base, ...extras } }
+    }
+    case 'shutdown':
+    case 'shutdown_self':
+      state.onShutdown()
+      return { ok: true }
+    default:
+      return { ok: false, error: `unknown cmd: ${req.cmd}` }
+  }
+}
+
+/**
  * Start the control socket. Commands are NDJSON-framed; each connection
  * handles one or more newline-delimited requests and sends JSON replies.
  *
@@ -201,6 +241,7 @@ computeStatusExtras.defaultCache = { lastBranch: null, lastBranchTs: 0 }
  *   { cmd: "interrupt" }
  *   { cmd: "status" }
  *   { cmd: "shutdown" }
+ *   { cmd: "shutdown_self" }
  */
 function startSocket({ sockPath, promptQueue, cwd, getQuery, getStatus, onShutdown }) {
   fs.mkdirSync(path.dirname(sockPath), { recursive: true })
@@ -234,38 +275,13 @@ function startSocket({ sockPath, promptQueue, cwd, getQuery, getStatus, onShutdo
   })
 
   async function handleRequest(req) {
-    switch (req.cmd) {
-      case 'send_user_message': {
-        if (typeof req.text !== 'string' || !req.text) {
-          return { ok: false, error: 'text required' }
-        }
-        promptQueue.push(makeUserMessage(req.text))
-        return { ok: true }
-      }
-      case 'interrupt': {
-        const q = getQuery()
-        if (!q) return { ok: false, error: 'query not yet started' }
-        try {
-          await q.interrupt()
-          return { ok: true }
-        } catch (e) {
-          return { ok: false, error: e.message }
-        }
-      }
-      case 'status': {
-        const base = getStatus()
-        const extras = await computeStatusExtras({
-          queueLength: promptQueue._queue.length,
-          cwd: cwd,
-        })
-        return { ok: true, status: { ...base, ...extras } }
-      }
-      case 'shutdown':
-        onShutdown()
-        return { ok: true }
-      default:
-        return { ok: false, error: `unknown cmd: ${req.cmd}` }
-    }
+    return handleSupervisorRequest(req, {
+      promptQueue,
+      cwd,
+      getQuery,
+      getStatus,
+      onShutdown,
+    })
   }
 
   server.listen(sockPath, () => {

--- a/lib/agent-supervisor/supervisor.mjs
+++ b/lib/agent-supervisor/supervisor.mjs
@@ -27,6 +27,8 @@ import fs from 'node:fs'
 import net from 'node:net'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import { query } from '@anthropic-ai/claude-agent-sdk'
 import { parseArgsForTest, buildQueryOptions } from './args.mjs'
 import { buildMessengerMcpServer } from './sdk-mcp-tools.mjs'
@@ -153,6 +155,43 @@ function socketPathFor(role, msgDir, instance) {
   return path.join(msgDir, instance, 'supervisor.sock')
 }
 
+const execFileAsync = promisify(execFile)
+
+const GIT_BRANCH_TTL_MS = 2000
+
+/**
+ * Build the extra fields to merge into the supervisor's status reply.
+ * `cache` is a mutable object ({lastBranch, lastBranchTs}) used to cache
+ * the git branch result across rapid-fire calls. `now` is injectable for tests.
+ */
+export async function computeStatusExtras({ queueLength, cwd, cache, now }) {
+  cache = cache || computeStatusExtras.defaultCache
+  now = now || Date.now
+
+  const extras = { queue_depth: queueLength }
+
+  const t = now()
+  if (cache.lastBranch !== null && t - cache.lastBranchTs < GIT_BRANCH_TTL_MS) {
+    extras.git_branch = cache.lastBranch
+  } else {
+    let branch = 'unknown'
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD'], {
+        timeout: 1000,
+      })
+      branch = stdout.trim() || 'unknown'
+    } catch {
+      branch = 'unknown'
+    }
+    cache.lastBranch = branch
+    cache.lastBranchTs = t
+    extras.git_branch = branch
+  }
+
+  return extras
+}
+computeStatusExtras.defaultCache = { lastBranch: null, lastBranchTs: 0 }
+
 /**
  * Start the control socket. Commands are NDJSON-framed; each connection
  * handles one or more newline-delimited requests and sends JSON replies.
@@ -163,7 +202,7 @@ function socketPathFor(role, msgDir, instance) {
  *   { cmd: "status" }
  *   { cmd: "shutdown" }
  */
-function startSocket({ sockPath, promptQueue, getQuery, getStatus, onShutdown }) {
+function startSocket({ sockPath, promptQueue, cwd, getQuery, getStatus, onShutdown }) {
   fs.mkdirSync(path.dirname(sockPath), { recursive: true })
   try {
     fs.unlinkSync(sockPath)
@@ -213,8 +252,14 @@ function startSocket({ sockPath, promptQueue, getQuery, getStatus, onShutdown })
           return { ok: false, error: e.message }
         }
       }
-      case 'status':
-        return { ok: true, status: getStatus() }
+      case 'status': {
+        const base = getStatus()
+        const extras = await computeStatusExtras({
+          queueLength: promptQueue._queue.length,
+          cwd: cwd,
+        })
+        return { ok: true, status: { ...base, ...extras } }
+      }
       case 'shutdown':
         onShutdown()
         return { ok: true }
@@ -329,6 +374,7 @@ async function main() {
   const sockServer = startSocket({
     sockPath,
     promptQueue,
+    cwd,
     getQuery: () => queryHandle,
     getStatus: () => ({
       role: args.role,

--- a/lib/agent-supervisor/supervisor.mjs
+++ b/lib/agent-supervisor/supervisor.mjs
@@ -161,6 +161,16 @@ const execFileAsync = promisify(execFile)
 const GIT_BRANCH_TTL_MS = 2000
 
 /**
+ * Derive role-dependent behavior. Pure function for testability.
+ */
+export function deriveRoleBehavior({ role, instance, persistent }) {
+  const isMultiTurn = role === 'coordinator' || role === 'advisor' || persistent === true
+  const socketInstance = role === 'coordinator' ? '_coordinator' : instance
+  const eventSubdir = role === 'coordinator' ? '_coordinator' : instance
+  return { isMultiTurn, socketInstance, eventSubdir }
+}
+
+/**
  * Build the extra fields to merge into the supervisor's status reply.
  * `cache` is a mutable object ({lastBranch, lastBranchTs}) used to cache
  * the git branch result across rapid-fire calls. `now` is injectable for tests.
@@ -314,14 +324,20 @@ async function main() {
   const cwd = args.cwd || '/workspace'
 
   // Coordinator is always multi-turn (stays alive for worker completions).
+  // Advisor is always multi-turn (stays alive between turns).
   // Agents go multi-turn only when `--persistent` is passed, letting
   // `cspace send <instance> ...` drive follow-up turns on their own
   // instance-scoped socket.
-  const isMultiTurn = args.role === 'coordinator' || args.persistent === true
+  const behavior = deriveRoleBehavior({
+    role: args.role,
+    instance: args.instance,
+    persistent: args.persistent,
+  })
+  const isMultiTurn = behavior.isMultiTurn
 
   // Event log directory — one subdir per instance (or _coordinator), mirroring
   // the socketPathFor convention. Empty-string disables persistence entirely.
-  const eventSubdir = args.role === 'coordinator' ? '_coordinator' : args.instance
+  const eventSubdir = behavior.eventSubdir
   const eventLogDir =
     args.eventLogDir === '' || !eventSubdir ? null : path.join(args.eventLogDir, eventSubdir)
   const startTs = new Date().toISOString().replace(/[:.]/g, '-')
@@ -388,7 +404,7 @@ async function main() {
   let idleInterrupted = false
   let lastResult = null
 
-  const sockPath = socketPathFor(args.role, msgDir, args.instance)
+  const sockPath = path.join(msgDir, behavior.socketInstance, 'supervisor.sock')
   const sockServer = startSocket({
     sockPath,
     promptQueue,
@@ -506,7 +522,7 @@ async function main() {
       if (idle < args.idleTimeoutMs) return
       idleInterrupted = true
       if (isMultiTurn) {
-        const label = args.role === 'coordinator' ? 'coordinator' : 'persistent agent'
+        const label = args.role === 'coordinator' ? 'coordinator' : args.role === 'advisor' ? 'advisor' : 'persistent agent'
         console.error(
           `[supervisor] ${label} idle for ${Math.round(idle / 1000)}s — no messages received, shutting down`,
         )
@@ -594,7 +610,7 @@ async function main() {
           // The session exits when the idle timer fires (no messages for
           // idleTimeoutMs) or on SIGTERM/SIGINT.
           lastActivity = Date.now()
-          const label = args.role === 'coordinator' ? 'coordinator' : 'persistent agent'
+          const label = args.role === 'coordinator' ? 'coordinator' : args.role === 'advisor' ? 'advisor' : 'persistent agent'
           console.error(
             `[supervisor] ${label} turn complete (${turnCount} turns) — waiting for next message`,
           )

--- a/lib/agent-supervisor/supervisor.test.mjs
+++ b/lib/agent-supervisor/supervisor.test.mjs
@@ -151,3 +151,18 @@ test('computeStatusExtras caches git_branch within TTL', async () => {
   })
   assert.equal(second.git_branch, first.git_branch, 'should reuse cached branch')
 })
+
+test('shutdown_self closes the prompt queue', async () => {
+  const { handleSupervisorRequest } = await import('./supervisor.mjs')
+  let shutdownCalled = false
+  const state = {
+    promptQueue: { push: () => {}, close: () => {}, _queue: [] },
+    cwd: process.cwd(),
+    onShutdown: () => { shutdownCalled = true },
+    getQuery: () => null,
+    getStatus: () => ({ role: 'agent', instance: 'test', sessionId: '', turns: 0, lastActivityMs: 0 }),
+  }
+  const reply = await handleSupervisorRequest({ cmd: 'shutdown_self' }, state)
+  assert.equal(reply.ok, true)
+  assert.equal(shutdownCalled, true)
+})

--- a/lib/agent-supervisor/supervisor.test.mjs
+++ b/lib/agent-supervisor/supervisor.test.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 // without node_modules/ installed. supervisor.mjs re-exports the same
 // names for runtime callers.
 import { parseArgsForTest, buildQueryOptions } from './args.mjs'
-import { computeStatusExtras } from './supervisor.mjs'
+import { computeStatusExtras, deriveRoleBehavior } from './supervisor.mjs'
 
 test('parses --resume-session', () => {
   const args = parseArgsForTest(['node', 'supervisor.mjs',
@@ -165,4 +165,29 @@ test('shutdown_self closes the prompt queue', async () => {
   const reply = await handleSupervisorRequest({ cmd: 'shutdown_self' }, state)
   assert.equal(reply.ok, true)
   assert.equal(shutdownCalled, true)
+})
+
+test('role=advisor is multi-turn and uses instance subdir', () => {
+  const b = deriveRoleBehavior({ role: 'advisor', instance: 'decision-maker' })
+  assert.equal(b.isMultiTurn, true)
+  assert.equal(b.socketInstance, 'decision-maker')
+  assert.equal(b.eventSubdir, 'decision-maker')
+})
+
+test('role=coordinator is multi-turn and uses _coordinator subdir', () => {
+  const b = deriveRoleBehavior({ role: 'coordinator' })
+  assert.equal(b.isMultiTurn, true)
+  assert.equal(b.socketInstance, '_coordinator')
+  assert.equal(b.eventSubdir, '_coordinator')
+})
+
+test('role=agent is one-shot by default', () => {
+  const b = deriveRoleBehavior({ role: 'agent', instance: 'issue-42', persistent: false })
+  assert.equal(b.isMultiTurn, false)
+  assert.equal(b.socketInstance, 'issue-42')
+})
+
+test('role=agent with --persistent is multi-turn', () => {
+  const b = deriveRoleBehavior({ role: 'agent', instance: 'issue-42', persistent: true })
+  assert.equal(b.isMultiTurn, true)
 })

--- a/lib/agent-supervisor/supervisor.test.mjs
+++ b/lib/agent-supervisor/supervisor.test.mjs
@@ -1,10 +1,9 @@
-import { test } from 'node:test'
+import { test, before } from 'node:test'
 import assert from 'node:assert/strict'
-// Import from args.mjs (the SDK-free module) so these tests can run
-// without node_modules/ installed. supervisor.mjs re-exports the same
-// names for runtime callers.
+// Import from SDK-free modules so these tests can run without node_modules/
+// installed. supervisor.mjs re-exports these for runtime callers.
 import { parseArgsForTest, buildQueryOptions } from './args.mjs'
-import { computeStatusExtras, deriveRoleBehavior } from './supervisor.mjs'
+import { computeStatusExtras, deriveRoleBehavior, handleSupervisorRequest } from './supervisor-helpers.mjs'
 
 test('parses --resume-session', () => {
   const args = parseArgsForTest(['node', 'supervisor.mjs',
@@ -153,7 +152,6 @@ test('computeStatusExtras caches git_branch within TTL', async () => {
 })
 
 test('shutdown_self closes the prompt queue', async () => {
-  const { handleSupervisorRequest } = await import('./supervisor.mjs')
   let shutdownCalled = false
   const state = {
     promptQueue: { push: () => {}, close: () => {}, _queue: [] },

--- a/lib/agent-supervisor/supervisor.test.mjs
+++ b/lib/agent-supervisor/supervisor.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 // without node_modules/ installed. supervisor.mjs re-exports the same
 // names for runtime callers.
 import { parseArgsForTest, buildQueryOptions } from './args.mjs'
+import { computeStatusExtras } from './supervisor.mjs'
 
 test('parses --resume-session', () => {
   const args = parseArgsForTest(['node', 'supervisor.mjs',
@@ -122,4 +123,31 @@ test('buildQueryOptions omits effort when undefined', () => {
     allowedTools: [],
   })
   assert.equal('effort' in opts, false)
+})
+
+test('computeStatusExtras returns queue_depth and git_branch', async () => {
+  const extras = await computeStatusExtras({
+    queueLength: 3,
+    cwd: process.cwd(),
+  })
+  assert.equal(extras.queue_depth, 3)
+  assert.equal(typeof extras.git_branch, 'string')
+})
+
+test('computeStatusExtras caches git_branch within TTL', async () => {
+  const state = { lastBranch: null, lastBranchTs: 0 }
+  const first = await computeStatusExtras({
+    queueLength: 0,
+    cwd: process.cwd(),
+    cache: state,
+    now: () => 1000,
+  })
+  assert.ok(state.lastBranchTs === 1000)
+  const second = await computeStatusExtras({
+    queueLength: 0,
+    cwd: '/does/not/exist',
+    cache: state,
+    now: () => 1500, // within 2s TTL
+  })
+  assert.equal(second.git_branch, first.git_branch, 'should reuse cached branch')
 })

--- a/lib/agents/coordinator.md
+++ b/lib/agents/coordinator.md
@@ -46,6 +46,35 @@ Track the graph in your status table:
 
 Update this table as PRs merge and new agents become launchable.
 
+## Phase 0.5 — Advisors
+
+You have a bench of advisors available — long-running specialists you can consult. The advisor roster is rendered into this prompt by `cspace coordinate` at launch (see above).
+
+**Consulting an advisor:** use the `ask_advisor(name, question, kind)` MCP tool. The reply arrives later as a new user turn on your session, not as a tool result. This means:
+
+- Your current turn ends after the tool returns (the tool only delivers the question).
+- You keep your full session context; the reply, when it arrives, has access to everything you were thinking about.
+- You can process other events (worker completions, directives) while waiting.
+
+**Consult the decision-maker when:**
+- Picking a base branch or merge ordering when dependencies are ambiguous.
+- Dispatching an implementer for an underspecified issue (multiple valid interpretations).
+- A worker reports a design-level blocker (e.g. "need to introduce abstraction X — proceed?").
+- A PR's diff doesn't cleanly match its acceptance criteria.
+- A prior decision or finding seems to conflict with the current work.
+- Any choice you judge architecturally significant.
+
+**Do NOT consult for:**
+- Routine orchestration (which port, which file, which commit message).
+- Choices the existing playbook already prescribes.
+- Questions that don't touch principles.md or direction.md.
+
+If you're unsure whether a choice qualifies, ask. A tight question is cheaper than the wrong call.
+
+For fire-and-forget notes (e.g. "issue-42 merged, decisions log updated"), use `send_to_advisor(name, message)`.
+
+---
+
 ## Phase 1 — Setup
 
 Run `cspace warm` with all container names to prepare them sequentially:
@@ -140,7 +169,7 @@ If `read_context` is unavailable (tool not registered), substitute `${STRATEGIC_
 ### Launch
 
 ```bash
-cspace up issue-$N --base $BASE --prompt-file /tmp/implementer-$N.txt
+cspace up issue-$N --base $BASE --prompt-file /tmp/implementer-$N.txt --persistent
 ```
 
 Use `run_in_background: true` with a 60-minute timeout. Launch all ready agents in a **single message** with multiple Bash tool calls.
@@ -217,7 +246,7 @@ For agents that **failed** (non-zero exit, no PR, or "FAILED" in output):
    ```
 3. If the agent's session is dead, re-render the prompt and re-launch:
    ```
-   cspace up issue-<N> --base <branch> --prompt-file /tmp/implementer-<N>.txt
+   cspace up issue-<N> --base <branch> --prompt-file /tmp/implementer-<N>.txt --persistent
    ```
 
 Repeat until all issues have accepted PRs or the user says stop.
@@ -278,3 +307,4 @@ Suggest `cspace down <name>` to clean up containers, or note they can be reused.
 - **Report each completion immediately** — don't batch notifications
 - **Do not fabricate PR URLs** — only report URLs found in the output
 - **Always recompute base branches** after each merge — the graph changes
+- **Prefer MCP tools over `cspace send`** for inter-agent messaging: `send_to_worker`, `ask_advisor`, `send_to_advisor` give you typed recipient names and structured return values. `cspace send` still works as the underlying transport and is fine for humans/scripts/debugging.

--- a/lib/agents/implementer.md
+++ b/lib/agents/implementer.md
@@ -23,6 +23,22 @@ If the `cspace-context` MCP server is available (you'll see `mcp__cspace_context
 - Before designing (Phase 3), if the task touches architecture, existing abstractions, or prior design choices, call `read_context` with `sections: ["decisions", "discoveries"]` to avoid re-litigating settled questions.
 - If the task touches an area that might have open bugs or pending refactor proposals, call `list_findings` with `status: ["open", "acknowledged"]` and any relevant `tags` or `category` filter. Read any matches with `read_finding` and surface them as context — you may end up closing one as part of this task, or deliberately deferring it.
 
+### Advisor handshake
+
+After reading your task prompt and initial `read_context`, call:
+
+```
+handshake_advisor(
+  name="decision-maker",
+  summary="<one-line summary of your task>",
+  hints=["path/to/file1", "module/name", "..."]
+)
+```
+
+This warms the decision-maker's context so it's ready for any consultations later in the task. Do not wait for a reply (the advisor will not reply to a handshake). Continue to Explore.
+
+You may receive mid-task messages from the advisor if it finds something urgent (e.g. a conflicting prior decision). Treat these the way you'd treat a new directive from the coordinator: read, adjust, continue.
+
 ## Phase 2 — Codebase Exploration
 
 **Goal**: Understand relevant existing code and patterns at both high and low levels.
@@ -44,6 +60,22 @@ If the `cspace-context` MCP server is available (you'll see `mcp__cspace_context
    - **Pragmatic balance** — speed + quality
 
 6. Review all approaches and form your opinion on which fits best for this specific task.
+
+### When to ask the decision-maker
+
+If you hit an architectural choice you can't confidently resolve against `principles.md` and prior decisions in the context server, call:
+
+```
+ask_advisor(
+  name="decision-maker",
+  question="<specific question with context>",
+  kind="question"
+)
+```
+
+The reply arrives later as a new user turn on your session, not as a tool result. Continue working on parts of the task that don't depend on the answer. When the reply lands, integrate it and proceed.
+
+Don't ask for: trivial naming, formatting, or which file to edit. Do ask for: cross-cutting design decisions that affect other agents' work or conflict with existing decisions.
 
 ## Phase 4 — Implement
 
@@ -68,6 +100,16 @@ If the `cspace-context` MCP server is available (you'll see `mcp__cspace_context
 
 17b. **Report bugs / observations / refactor opportunities you encounter outside this task's scope.** Call `log_finding` with `category` ∈ {bug, observation, refactor}, a title, summary, and details. Do NOT fix them inline — that expands the PR. A finding is a commitment to remember, not to do right now. If your commit happens to resolve an existing finding, append `(cs-finding:<slug>)` to the commit message and call `append_to_finding(slug, note, status="resolved")` so the Updates log reflects the fix.
 
+### Release your supervisor
+
+After the coordinator-notification message has been delivered, call:
+
+```
+shutdown_self()
+```
+
+This closes your supervisor cleanly so the coordinator isn't left tracking an idle persistent agent. Your container stays up; the coordinator can reclaim it with `cspace down` or reuse it with `cspace up`.
+
 ## Phase 7 — Review
 
 18. Take screenshots of the new/changed features using Playwright MCP browser tools against the running preview server, then post them as a comment on the PR using gh cli.
@@ -77,4 +119,6 @@ If the `cspace-context` MCP server is available (you'll see `mcp__cspace_context
     ```bash
     cspace send _coordinator "Worker issue-${NUMBER} complete. Status: <success|failed>. PR: <url or 'none'>. Summary: <one-line description of what was done>" 2>/dev/null || true
     ```
+    (Equivalent MCP tool: `notify_coordinator(message="...")`. Preferred for structured return values.)
+    
     If you failed and could not produce a PR, still send the message with `Status: failed` and a brief explanation. If the send fails (no coordinator running), that's fine — it means you were launched standalone.

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -14,7 +14,7 @@
     "domains": []
   },
   "claude": {
-    "model": "",
+    "model": "opus[1m]",
     "effort": ""
   },
   "mcpServers": {},

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -14,7 +14,7 @@
     "domains": []
   },
   "claude": {
-    "model": "opus[1m]",
+    "model": "",
     "effort": ""
   },
   "mcpServers": {},

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -42,7 +42,13 @@
       "plugin-dev"
     ]
   },
-  "advisors": {},
+  "advisors": {
+    "decision-maker": {
+      "model": "claude-opus-4-7",
+      "effort": "max",
+      "baseBranch": "main"
+    }
+  },
   "services": "",
   "post_setup": ""
 }

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -42,6 +42,7 @@
       "plugin-dev"
     ]
   },
+  "advisors": {},
   "services": "",
   "post_setup": ""
 }


### PR DESCRIPTION
## Summary

Adds a pluggable long-running advisor-agent class to cspace. The decision-maker (Opus, max effort) is the first shipped advisor; the mechanism is generic for future advisors (critic, historian, security-reviewer, etc.). Inter-agent messaging moves from bash `cspace send` to typed role-scoped MCP tools on the existing `agent-messenger` server.

- **Session continuity**: advisor supervisors stay alive across `cspace coordinate` invocations so their SDK sessions accumulate project understanding.
- **Pluggable via config**: `advisors` block in `.cspace.json`. Adding a new advisor is config + optional system-prompt file, no Go changes.
- **Typed messaging**: role-scoped MCP tools (`ask_advisor`, `handshake_advisor`, `notify_coordinator`, `reply_to_coordinator`, `shutdown_self`, etc.) with recipient-name enum validation and structured return envelopes (git_branch, queue_depth, expected_reply_window).
- **Coordinator defaults to Sonnet** via new `claude.coordinatorModel` config field, independent of `claude.model` (which continues to default workers and advisor fallbacks to `opus[1m]`). Deep reasoning is concentrated in the advisor, not spent on orchestration.
- **`cspace advisor list|down|restart`**: explicit lifecycle management.

## Design & plan

- Spec: [`docs/superpowers/specs/2026-04-18-advisor-agents-design.md`](docs/superpowers/specs/2026-04-18-advisor-agents-design.md)
- Plan: [`docs/superpowers/plans/2026-04-18-advisor-agents.md`](docs/superpowers/plans/2026-04-18-advisor-agents.md)

## Verification

- `make vet` clean, `make test` passes (45/46 — 1 integration test skipped, gated on `RUN_INTEGRATION=1`), `make build` clean.
- CI: `check` + `lint` both green on latest commit.
- **End-to-end POC executed** (see `experiments/advisor-poc/REPORT.md`):
  - Run 1 surfaced two issues (worker MCP tools missing advisor entries; `.cspace/context/` bind-mount path mismatch under DooD). First was fixed in `5dbb839`; second documented as pre-existing infra limit.
  - Run 4 verified end-to-end: advisor auto-launch, `ask_advisor` with reply-as-new-user-turn, worker `handshake_advisor` + `notify_coordinator` + `shutdown_self`, session continuity across two invocations (same advisor session_id), advisor cited seeded `principles.md` verbatim in its reasoning.
- Code review on the PR surfaced 10 findings; 1 high-confidence finding (stale `--role` help text) fixed in `0671666`, all others either fixed or documented as out of scope.

## Known limits

- **End users invoking `cspace up` directly** (without `--persistent`) receive `ask_advisor` in their MCP surface but can't receive the reply, since replies arrive as new user turns on the supervisor's prompt queue and a one-shot worker has already exited. `handshake_advisor` (fire-and-forget) works fine. Coordinator-dispatched workers are always `--persistent`, so this is only a sharp edge for ad-hoc `cspace up` usage.
- **`.cspace/context/` bind-mount breaks under Docker-in-Docker.** Running `cspace coordinate` from *inside* another cspace container (the POC's setup) causes the `${PROJECT_ROOT}/.cspace/context` bind source to resolve to the in-container `/workspace` path on the real Docker host, where it doesn't exist, so Docker creates an empty directory and the advisor sees no principles/direction/roadmap. Pre-existing bug, out of scope for this PR. On a real host invocation it works as designed. Workaround for DooD runs: `docker cp` the files into the advisor container after provisioning (documented in the POC report).
- **Idle timeout shared with workers.** Advisors use the default 10-minute idle-timer. In a low-consultation project, an advisor may be reaped between requests; session continuity is then lost until the next `cspace coordinate` re-provisions. Auto-expiry was explicitly marked out of scope in the spec.
- **Test coverage gap**: `handleSupervisorRequest` has direct unit test coverage only for `shutdown_self`; the other four commands (`send_user_message`, `interrupt`, `status`, `shutdown`) are exercised only through socket integration. Worth widening in a follow-up.

## Test plan

- [x] `make vet` clean
- [x] `make test` — 45/46 tests pass (1 intentional skip)
- [x] `make build` clean
- [x] `cspace advisor --help` renders list/down/restart subcommands
- [x] `cspace advisor list` shows decision-maker with configured model/effort
- [x] **End-to-end POC in a real cspace container**: `cspace coordinate` launches the decision-maker advisor, coordinator `ask_advisor` round-trip works, worker `handshake_advisor` + `notify_coordinator` + `shutdown_self` all succeed, advisor cites seeded context files
- [x] **Advisor persistence across two `cspace coordinate` invocations** — same session_id, advisor cites prior reasoning
- [x] `cspace advisor restart decision-maker` (via the restart subcommand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)