### PR TITLE
Add context corpus (findings, decisions, discoveries, direction/principles/roadmap)

### DIFF
--- a/cmd/cspace-search/main.go
+++ b/cmd/cspace-search/main.go
@@ -122,7 +122,7 @@ func queryCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id")
+	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits|context)")
 	cmd.Flags().IntVar(&topK, "top", 10, "top K hits")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "emit JSON envelope")
 	cmd.Flags().BoolVar(&withCluster, "with-cluster", false, "include cluster_id per hit")
@@ -165,7 +165,7 @@ func clustersCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id")
+	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits|context)")
 	cmd.Flags().StringVar(&coordsOut, "coords-out", "", "write TSV of coords+labels")
 	cmd.Flags().IntVar(&minPts, "min-pts", 3, "HDBSCAN min_cluster_size (min points per cluster)")
 	cmd.Flags().IntVar(&minSamples, "min-samples", 1, "HDBSCAN min_samples (cluster conservatism; higher → more noise, tighter clusters)")

--- a/cmd/cspace-search/main.go
+++ b/cmd/cspace-search/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 func main() {
-	root := &cobra.Command{Use: "cspace-search", Short: "Semantic search over commits and code"}
+	root := &cobra.Command{Use: "cspace-search", Short: "Semantic search over commits, code, and context"}
 	root.AddCommand(indexCmd(), queryCmd(), clustersCmd())
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -74,7 +74,7 @@ func indexCmd() *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits)")
+	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits|context)")
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress progress output")
 	return cmd
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -26,7 +26,7 @@ func newSearchCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "search",
 		Short:   "Semantic search over commits and code",
-		Long:    "Subcommands: code, commits. Back-compat: `cspace search \"<query>\"` runs a commits query.",
+		Long:    "Subcommands: code, commits, context. Back-compat: `cspace search \"<query>\"` runs a commits query.",
 		GroupID: "other",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -38,7 +38,7 @@ func newSearchCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&topK, "top", 10, "Number of results to show (back-compat flag)")
-	cmd.AddCommand(newSearchSubcmd("code"), newSearchSubcmd("commits"), newSearchMCPCmd())
+	cmd.AddCommand(newSearchSubcmd("code"), newSearchSubcmd("commits"), newSearchSubcmd("context"), newSearchMCPCmd())
 	return cmd
 }
 

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -43,17 +43,18 @@ func newSearchCmd() *cobra.Command {
 }
 
 // newSearchMCPCmd builds `cspace search mcp`, a stdio MCP server exposing
-// search_code + list_clusters. Registered per agent container via
-// init-claude-plugins.sh so advisors/coordinators/implementers can consult
-// the index mid-session. Parallels `cspace context-server`.
+// search tools (search_code, search_context, list_clusters). Registered per
+// agent container via init-claude-plugins.sh so advisors/coordinators/
+// implementers can consult the indexes mid-session. Parallels `cspace
+// context-server`.
 func newSearchMCPCmd() *cobra.Command {
 	var root string
 	cmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Run the search MCP server over stdio",
-		Long: `Expose the code + commits search indexes as MCP tools (search_code,
-list_clusters). Invoked by Claude Code via .mcp.json or a container's Claude
-MCP config, not by humans directly.`,
+		Long: `Expose the code, commits, and context search indexes as MCP tools
+(search_code, search_context, list_clusters). Invoked by Claude Code via
+.mcp.json or a container's Claude MCP config, not by humans directly.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if root == "" {
 				root = searchProjectRoot()

--- a/search/config/default.yaml
+++ b/search/config/default.yaml
@@ -27,6 +27,8 @@ corpora:
   commits:
     enabled: true
     limit: 500
+  context:
+    enabled: true
 sidecars:
   llama_retrieval_url: "http://llama-server:8080"
   llama_clustering_url: "http://llama-clustering:8080"

--- a/search/config/default.yaml
+++ b/search/config/default.yaml
@@ -28,6 +28,8 @@ corpora:
     enabled: true
     limit: 500
   context:
+    # No max_bytes / excludes: ContextCorpus has no config fields. Indexes
+    # the fixed set of .cspace/context/ artifacts unconditionally.
     enabled: true
 sidecars:
   llama_retrieval_url: "http://llama-server:8080"

--- a/search/config/runtime.go
+++ b/search/config/runtime.go
@@ -43,7 +43,9 @@ func buildCorpus(id string, cfg *Config) (corpus.Corpus, error) {
 		}, nil
 	case "commits":
 		return &corpus.CommitCorpus{Limit: cfg.Corpora["commits"].Limit}, nil
+	case "context":
+		return &corpus.ContextCorpus{}, nil
 	default:
-		return nil, fmt.Errorf("unknown corpus %q (known: code, commits)", id)
+		return nil, fmt.Errorf("unknown corpus %q (known: code, commits, context)", id)
 	}
 }

--- a/search/corpus/context.go
+++ b/search/corpus/context.go
@@ -1,0 +1,113 @@
+package corpus
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ContextCorpus indexes the layered planning artifacts under .cspace/context/:
+// direction.md, principles.md, roadmap.md, and the findings/, decisions/,
+// discoveries/ subdirectories.
+type ContextCorpus struct{}
+
+// ID returns the stable corpus identifier.
+func (c *ContextCorpus) ID() string { return "context" }
+
+// Collection returns the Qdrant collection name for this corpus + project.
+func (c *ContextCorpus) Collection(projectRoot string) string {
+	return "context-" + ProjectHash(projectRoot)
+}
+
+// Enumerate emits one Record per context artifact. Missing subdirectories are
+// silently skipped. Files are not chunked — just truncated to ~12000 chars.
+func (c *ContextCorpus) Enumerate(projectRoot string) (<-chan Record, <-chan error) {
+	out := make(chan Record)
+	errs := make(chan error, 8)
+	go func() {
+		defer close(out)
+		defer close(errs)
+
+		ctxDir := filepath.Join(projectRoot, ".cspace", "context")
+
+		// Top-level context files: each is one record with kind="context".
+		for _, name := range []string{"direction.md", "principles.md", "roadmap.md"} {
+			abs := filepath.Join(ctxDir, name)
+			data, err := os.ReadFile(abs)
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				errs <- fmt.Errorf("read %s: %w", name, err)
+				continue
+			}
+			subkind := strings.TrimSuffix(name, ".md")
+			rel := filepath.ToSlash(filepath.Join(".cspace", "context", name))
+			out <- contextRecord(rel, subkind, "context", data)
+		}
+
+		// Subdirectories: findings, decisions, discoveries.
+		subdirs := []struct {
+			dir  string
+			kind string
+		}{
+			{"findings", "finding"},
+			{"decisions", "decision"},
+			{"discoveries", "discovery"},
+		}
+		for _, sub := range subdirs {
+			subDir := filepath.Join(ctxDir, sub.dir)
+			entries, err := os.ReadDir(subDir)
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				errs <- fmt.Errorf("readdir %s: %w", sub.dir, err)
+				continue
+			}
+			for _, entry := range entries {
+				if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+					continue
+				}
+				abs := filepath.Join(subDir, entry.Name())
+				data, err := os.ReadFile(abs)
+				if err != nil {
+					errs <- fmt.Errorf("read %s/%s: %w", sub.dir, entry.Name(), err)
+					continue
+				}
+				rel := filepath.ToSlash(filepath.Join(".cspace", "context", sub.dir, entry.Name()))
+				out <- contextRecord(rel, sub.kind, sub.kind, data)
+			}
+		}
+	}()
+	return out, errs
+}
+
+// contextRecord builds a Record for a context artifact.
+func contextRecord(relPath, labelForHeader, kind string, data []byte) Record {
+	hash := fmt.Sprintf("%x", sha256.Sum256(data))
+	extra := map[string]any{}
+	if kind == "context" {
+		// Top-level files carry a subkind for disambiguation.
+		extra["subkind"] = labelForHeader
+	}
+	return Record{
+		Path:        relPath,
+		Kind:        kind,
+		ContentHash: hash,
+		EmbedText:   formatContextEmbedText(labelForHeader, relPath, string(data)),
+		Extra:       extra,
+	}
+}
+
+// formatContextEmbedText prepends a small header and truncates to ~12000 chars.
+func formatContextEmbedText(label, path, body string) string {
+	const max = 12000
+	header := "Context (" + label + "): " + path + "\n\n"
+	if len(body)+len(header) > max {
+		body = body[:max-len(header)]
+	}
+	return header + body
+}

--- a/search/corpus/context_test.go
+++ b/search/corpus/context_test.go
@@ -1,0 +1,245 @@
+package corpus
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeContextDir creates a .cspace/context/ tree under dir with the given
+// files. Each key is a relative path from .cspace/context/ (e.g.
+// "findings/2026-04-13-some-finding.md"), each value is the file content.
+func makeContextDir(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	ctxDir := filepath.Join(dir, ".cspace", "context")
+	if err := os.MkdirAll(ctxDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for rel, content := range files {
+		abs := filepath.Join(ctxDir, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// drainRecords collects all records and errors from a ContextCorpus enumeration.
+func drainRecords(t *testing.T, recs <-chan Record, errs <-chan error) []Record {
+	t.Helper()
+	var out []Record
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for e := range errs {
+			t.Errorf("unexpected error: %v", e)
+		}
+	}()
+	for r := range recs {
+		out = append(out, r)
+	}
+	<-done
+	return out
+}
+
+func TestContextCorpus_EnumeratesAllArtifactTypes(t *testing.T) {
+	dir := t.TempDir()
+	makeContextDir(t, dir, map[string]string{
+		"principles.md":                          "# Principles\nKeep it simple.",
+		"findings/2026-04-13-some-finding.md":    "# Finding\nSomething was found.",
+		"decisions/2026-04-10-use-go.md":         "# Decision\nUse Go for the CLI.",
+		"discoveries/2026-04-12-perf-insight.md": "# Discovery\nPerf insight here.",
+	})
+
+	cc := &ContextCorpus{}
+	recs, errs := cc.Enumerate(dir)
+	records := drainRecords(t, recs, errs)
+
+	if len(records) != 4 {
+		t.Fatalf("expected 4 records, got %d", len(records))
+	}
+
+	// Build a map of path -> record for assertion.
+	byPath := map[string]Record{}
+	for _, r := range records {
+		byPath[r.Path] = r
+	}
+
+	// Check principles.md
+	r, ok := byPath[".cspace/context/principles.md"]
+	if !ok {
+		t.Fatal("missing record for principles.md")
+	}
+	if r.Kind != "context" {
+		t.Errorf("principles.md: expected Kind=context, got %q", r.Kind)
+	}
+	if r.Extra["subkind"] != "principles" {
+		t.Errorf("principles.md: expected subkind=principles, got %v", r.Extra["subkind"])
+	}
+
+	// Check finding
+	r, ok = byPath[".cspace/context/findings/2026-04-13-some-finding.md"]
+	if !ok {
+		t.Fatal("missing record for finding")
+	}
+	if r.Kind != "finding" {
+		t.Errorf("finding: expected Kind=finding, got %q", r.Kind)
+	}
+
+	// Check decision
+	r, ok = byPath[".cspace/context/decisions/2026-04-10-use-go.md"]
+	if !ok {
+		t.Fatal("missing record for decision")
+	}
+	if r.Kind != "decision" {
+		t.Errorf("decision: expected Kind=decision, got %q", r.Kind)
+	}
+
+	// Check discovery
+	r, ok = byPath[".cspace/context/discoveries/2026-04-12-perf-insight.md"]
+	if !ok {
+		t.Fatal("missing record for discovery")
+	}
+	if r.Kind != "discovery" {
+		t.Errorf("discovery: expected Kind=discovery, got %q", r.Kind)
+	}
+
+	// All records should have ContentHash and EmbedText.
+	for _, r := range records {
+		if r.ContentHash == "" {
+			t.Errorf("record %s missing ContentHash", r.Path)
+		}
+		if r.EmbedText == "" {
+			t.Errorf("record %s missing EmbedText", r.Path)
+		}
+	}
+}
+
+func TestContextCorpus_MissingSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	// Only create principles.md — no findings/, decisions/, discoveries/.
+	makeContextDir(t, dir, map[string]string{
+		"principles.md": "# Principles\nKeep it simple.",
+	})
+
+	cc := &ContextCorpus{}
+	recs, errs := cc.Enumerate(dir)
+	records := drainRecords(t, recs, errs)
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record (only principles.md), got %d", len(records))
+	}
+	if records[0].Kind != "context" {
+		t.Errorf("expected Kind=context, got %q", records[0].Kind)
+	}
+	if records[0].Path != ".cspace/context/principles.md" {
+		t.Errorf("expected path .cspace/context/principles.md, got %q", records[0].Path)
+	}
+}
+
+func TestContextCorpus_EmptyContextDir(t *testing.T) {
+	dir := t.TempDir()
+	// Create the context dir but put nothing in it.
+	if err := os.MkdirAll(filepath.Join(dir, ".cspace", "context"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cc := &ContextCorpus{}
+	recs, errs := cc.Enumerate(dir)
+	records := drainRecords(t, recs, errs)
+
+	if len(records) != 0 {
+		t.Fatalf("expected 0 records for empty context dir, got %d", len(records))
+	}
+}
+
+func TestContextCorpus_NoContextDirAtAll(t *testing.T) {
+	dir := t.TempDir()
+	// Don't even create .cspace/context/.
+
+	cc := &ContextCorpus{}
+	recs, errs := cc.Enumerate(dir)
+	records := drainRecords(t, recs, errs)
+
+	if len(records) != 0 {
+		t.Fatalf("expected 0 records when .cspace/context/ does not exist, got %d", len(records))
+	}
+}
+
+func TestContextCorpus_ID(t *testing.T) {
+	cc := &ContextCorpus{}
+	if cc.ID() != "context" {
+		t.Errorf("expected ID=context, got %q", cc.ID())
+	}
+}
+
+func TestContextCorpus_CollectionName(t *testing.T) {
+	cc := &ContextCorpus{}
+	got := cc.Collection(".")
+	if !strings.HasPrefix(got, "context-") {
+		t.Errorf("expected context- prefix, got %q", got)
+	}
+}
+
+func TestContextCorpus_EmbedTextFormat(t *testing.T) {
+	dir := t.TempDir()
+	makeContextDir(t, dir, map[string]string{
+		"direction.md": "We are heading north.",
+	})
+
+	cc := &ContextCorpus{}
+	recs, errs := cc.Enumerate(dir)
+	records := drainRecords(t, recs, errs)
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	r := records[0]
+	// EmbedText should start with the header.
+	if !strings.HasPrefix(r.EmbedText, "Context (direction): .cspace/context/direction.md\n\n") {
+		t.Errorf("unexpected EmbedText prefix: %q", r.EmbedText[:80])
+	}
+	if !strings.Contains(r.EmbedText, "We are heading north.") {
+		t.Error("EmbedText should contain file content")
+	}
+}
+
+func TestContextCorpus_RoadmapAndDirection(t *testing.T) {
+	dir := t.TempDir()
+	makeContextDir(t, dir, map[string]string{
+		"direction.md": "# Direction\nGo north.",
+		"roadmap.md":   "# Roadmap\nPhase 1.",
+	})
+
+	cc := &ContextCorpus{}
+	recs, errs := cc.Enumerate(dir)
+	records := drainRecords(t, recs, errs)
+
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+
+	byPath := map[string]Record{}
+	for _, r := range records {
+		byPath[r.Path] = r
+	}
+
+	r, ok := byPath[".cspace/context/direction.md"]
+	if !ok {
+		t.Fatal("missing direction.md record")
+	}
+	if r.Kind != "context" || r.Extra["subkind"] != "direction" {
+		t.Errorf("direction.md: expected Kind=context subkind=direction, got Kind=%q subkind=%v", r.Kind, r.Extra["subkind"])
+	}
+
+	r, ok = byPath[".cspace/context/roadmap.md"]
+	if !ok {
+		t.Fatal("missing roadmap.md record")
+	}
+	if r.Kind != "context" || r.Extra["subkind"] != "roadmap" {
+		t.Errorf("roadmap.md: expected Kind=context subkind=roadmap, got Kind=%q subkind=%v", r.Kind, r.Extra["subkind"])
+	}
+}

--- a/search/mcp/server.go
+++ b/search/mcp/server.go
@@ -29,6 +29,13 @@ func (s *Server) Register(srv *mcpSDK.Server) {
 		return s.handleSearchCode(ctx, in)
 	})
 
+	mcpSDK.AddTool[searchContextInput, searchContextOutput](srv, &mcpSDK.Tool{
+		Name:        "search_context",
+		Description: "Semantic search over the project's context artifacts (direction, principles, roadmap, findings, decisions, discoveries). Use when you need to check prior decisions, open findings, or stated architectural principles before acting.",
+	}, func(ctx context.Context, req *mcpSDK.CallToolRequest, in searchContextInput) (*mcpSDK.CallToolResult, searchContextOutput, error) {
+		return s.handleSearchContext(ctx, in)
+	})
+
 	mcpSDK.AddTool[listClustersInput, listClustersOutput](srv, &mcpSDK.Tool{
 		Name:        "list_clusters",
 		Description: "List the thematic clusters discovered in the code index. Returns cluster IDs, sizes, and representative file paths.",
@@ -46,6 +53,16 @@ type searchCodeInput struct {
 }
 
 type searchCodeOutput struct {
+	Results json.RawMessage `json:"results"`
+}
+
+type searchContextInput struct {
+	Query       string `json:"query"        jsonschema:"the natural language query to embed and search against context artifacts"`
+	TopK        int    `json:"top_k,omitempty" jsonschema:"max results to return (default 10, max 50)"`
+	WithCluster bool   `json:"with_cluster,omitempty" jsonschema:"include cluster_id per hit"`
+}
+
+type searchContextOutput struct {
 	Results json.RawMessage `json:"results"`
 }
 
@@ -88,6 +105,42 @@ func (s *Server) handleSearchCode(ctx context.Context, in searchCodeInput) (*mcp
 		return nil, searchCodeOutput{}, err
 	}
 	out := searchCodeOutput{Results: json.RawMessage(buf)}
+	return &mcpSDK.CallToolResult{
+		Content: []mcpSDK.Content{&mcpSDK.TextContent{Text: string(buf)}},
+	}, out, nil
+}
+
+func (s *Server) handleSearchContext(ctx context.Context, in searchContextInput) (*mcpSDK.CallToolResult, searchContextOutput, error) {
+	rt, err := config.BuildWithConfig(s.ProjectRoot, "context", s.Config)
+	if err != nil {
+		return nil, searchContextOutput{}, err
+	}
+	qc := qdrant.NewQdrantClient(s.Config.Sidecars.QdrantURL)
+	ec := embed.NewClient(s.Config.Sidecars.LlamaRetrievalURL)
+
+	topK := in.TopK
+	if topK <= 0 {
+		topK = 10
+	}
+
+	env, err := query.Run(ctx, query.Config{
+		Corpus:      rt.Corpus,
+		Embedder:    &embed.QueryAdapter{Client: ec},
+		Searcher:    &qdrant.Adapter{QdrantClient: qc},
+		ProjectRoot: s.ProjectRoot,
+		Query:       in.Query,
+		TopK:        topK,
+		WithCluster: in.WithCluster,
+	})
+	if err != nil {
+		return nil, searchContextOutput{}, err
+	}
+
+	buf, err := json.Marshal(env)
+	if err != nil {
+		return nil, searchContextOutput{}, err
+	}
+	out := searchContextOutput{Results: json.RawMessage(buf)}
 	return &mcpSDK.CallToolResult{
 		Content: []mcpSDK.Content{&mcpSDK.TextContent{Text: string(buf)}},
 	}, out, nil


### PR DESCRIPTION
## Summary
- New `ContextCorpus` indexing the layered planning artifacts under `.cspace/context/` as a fourth corpus alongside code, commits, and (future) docs.
- Each file becomes one record; kind disambiguates direction/principles/roadmap/finding/decision/discovery.
- Exposed via `cspace search context "<query>"` and the `search_context` MCP tool.

## Test plan
- [x] `go test ./search/corpus/...` passes with the new context_test.go (8 new tests)
- [ ] `cspace search context --help` shows query/index/clusters subcommands
- [ ] On a repo with `.cspace/context/findings/*.md`, `cspace search context index` + query returns the expected findings
- [ ] MCP `search_context` tool returns the same envelope shape as `search_code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)