### PR TITLE
Add issues corpus (GitHub issues + PRs with comments)

### DIFF
--- a/cmd/cspace-search/main.go
+++ b/cmd/cspace-search/main.go
@@ -74,7 +74,7 @@ func indexCmd() *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits|context)")
+	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits|context|issues)")
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress progress output")
 	return cmd
 }
@@ -122,7 +122,7 @@ func queryCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits|context)")
+	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits|context|issues)")
 	cmd.Flags().IntVar(&topK, "top", 10, "top K hits")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "emit JSON envelope")
 	cmd.Flags().BoolVar(&withCluster, "with-cluster", false, "include cluster_id per hit")
@@ -165,7 +165,7 @@ func clustersCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits|context)")
+	cmd.Flags().StringVar(&corpusID, "corpus", "code", "corpus id (code|commits|context|issues)")
 	cmd.Flags().StringVar(&coordsOut, "coords-out", "", "write TSV of coords+labels")
 	cmd.Flags().IntVar(&minPts, "min-pts", 3, "HDBSCAN min_cluster_size (min points per cluster)")
 	cmd.Flags().IntVar(&minSamples, "min-samples", 1, "HDBSCAN min_samples (cluster conservatism; higher → more noise, tighter clusters)")

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -38,7 +38,13 @@ func newSearchCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&topK, "top", 10, "Number of results to show (back-compat flag)")
-	cmd.AddCommand(newSearchSubcmd("code"), newSearchSubcmd("commits"), newSearchSubcmd("context"), newSearchMCPCmd())
+	cmd.AddCommand(
+		newSearchSubcmd("code"),
+		newSearchSubcmd("commits"),
+		newSearchSubcmd("context"),
+		newSearchSubcmd("issues"),
+		newSearchMCPCmd(),
+	)
 	return cmd
 }
 

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -49,18 +49,19 @@ func newSearchCmd() *cobra.Command {
 }
 
 // newSearchMCPCmd builds `cspace search mcp`, a stdio MCP server exposing
-// search tools (search_code, search_context, list_clusters). Registered per
-// agent container via init-claude-plugins.sh so advisors/coordinators/
-// implementers can consult the indexes mid-session. Parallels `cspace
-// context-server`.
+// the search tools (search_code, search_context, search_issues,
+// list_clusters). Registered per agent container via init-claude-plugins.sh
+// so advisors/coordinators/implementers can consult the indexes mid-session.
+// Parallels `cspace context-server`.
 func newSearchMCPCmd() *cobra.Command {
 	var root string
 	cmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Run the search MCP server over stdio",
-		Long: `Expose the code, commits, and context search indexes as MCP tools
-(search_code, search_context, list_clusters). Invoked by Claude Code via
-.mcp.json or a container's Claude MCP config, not by humans directly.`,
+		Long: `Expose the code, commits, context, and issues search indexes as MCP
+tools (search_code, search_context, search_issues, list_clusters). Invoked
+by Claude Code via .mcp.json or a container's Claude MCP config, not by
+humans directly.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if root == "" {
 				root = searchProjectRoot()

--- a/search/config/default.yaml
+++ b/search/config/default.yaml
@@ -31,6 +31,9 @@ corpora:
     # No max_bytes / excludes: ContextCorpus has no config fields. Indexes
     # the fixed set of .cspace/context/ artifacts unconditionally.
     enabled: true
+  issues:
+    enabled: true
+    limit: 500
 sidecars:
   llama_retrieval_url: "http://llama-server:8080"
   llama_clustering_url: "http://llama-clustering:8080"

--- a/search/config/runtime.go
+++ b/search/config/runtime.go
@@ -45,7 +45,9 @@ func buildCorpus(id string, cfg *Config) (corpus.Corpus, error) {
 		return &corpus.CommitCorpus{Limit: cfg.Corpora["commits"].Limit}, nil
 	case "context":
 		return &corpus.ContextCorpus{}, nil
+	case "issues":
+		return &corpus.IssuesCorpus{Limit: cfg.Corpora["issues"].Limit}, nil
 	default:
-		return nil, fmt.Errorf("unknown corpus %q (known: code, commits, context)", id)
+		return nil, fmt.Errorf("unknown corpus %q (known: code, commits, context, issues)", id)
 	}
 }

--- a/search/corpus/issues.go
+++ b/search/corpus/issues.go
@@ -1,0 +1,304 @@
+package corpus
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// ghIssue holds the extracted data for a single GitHub issue or PR.
+type ghIssue struct {
+	Number    int      `json:"number"`
+	Title     string   `json:"title"`
+	Body      string   `json:"body"`
+	State     string   `json:"state"`
+	Author    string   `json:"user"`
+	Labels    []string `json:"labels"`
+	CreatedAt string   `json:"created_at"`
+	UpdatedAt string   `json:"updated_at"`
+	HTMLURL   string   `json:"html_url"`
+	PRURL     string   `json:"pull_request"`
+}
+
+// ghComment holds a single issue comment.
+type ghComment struct {
+	Author    string `json:"user"`
+	CreatedAt string `json:"created_at"`
+	Body      string `json:"body"`
+}
+
+// ghFetcher abstracts the GitHub API calls so tests can inject a fake.
+type ghFetcher interface {
+	ListIssues(owner, repo string, limit int) ([]ghIssue, error)
+	ListComments(owner, repo string, number int) ([]ghComment, error)
+}
+
+// ghCLIFetcher is the production implementation that shells out to `gh api`.
+type ghCLIFetcher struct{}
+
+func (f *ghCLIFetcher) ListIssues(owner, repo string, limit int) ([]ghIssue, error) {
+	var all []ghIssue
+	perPage := 100
+	for page := 1; len(all) < limit; page++ {
+		jqExpr := `.[] | {number, title, body, state, user: .user.login, labels: [.labels[].name], created_at, updated_at, html_url, pull_request: (.pull_request.html_url // null)}`
+		endpoint := fmt.Sprintf("repos/%s/%s/issues?state=all&sort=updated&direction=desc&per_page=%d&page=%d", owner, repo, perPage, page)
+		out, err := ghAPI(endpoint, jqExpr)
+		if err != nil {
+			return nil, fmt.Errorf("gh api issues page %d: %w", page, err)
+		}
+		out = strings.TrimSpace(out)
+		if out == "" {
+			break
+		}
+		// gh --jq emits one JSON object per line (NDJSON).
+		var batch []ghIssue
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			var issue ghIssue
+			if err := json.Unmarshal([]byte(line), &issue); err != nil {
+				return nil, fmt.Errorf("parse issue JSON: %w\nline: %s", err, line)
+			}
+			batch = append(batch, issue)
+		}
+		if len(batch) == 0 {
+			break
+		}
+		all = append(all, batch...)
+		if len(batch) < perPage {
+			break // last page
+		}
+	}
+	if len(all) > limit {
+		all = all[:limit]
+	}
+	return all, nil
+}
+
+func (f *ghCLIFetcher) ListComments(owner, repo string, number int) ([]ghComment, error) {
+	jqExpr := `.[] | {user: .user.login, created_at, body}`
+	endpoint := fmt.Sprintf("repos/%s/%s/issues/%d/comments?per_page=100", owner, repo, number)
+	out, err := ghAPI(endpoint, jqExpr)
+	if err != nil {
+		return nil, fmt.Errorf("gh api comments for #%d: %w", number, err)
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil, nil
+	}
+	var comments []ghComment
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var c ghComment
+		if err := json.Unmarshal([]byte(line), &c); err != nil {
+			return nil, fmt.Errorf("parse comment JSON: %w", err)
+		}
+		comments = append(comments, c)
+	}
+	return comments, nil
+}
+
+// ghAPI executes `gh api <endpoint> --jq <jq>` and returns stdout.
+func ghAPI(endpoint, jqExpr string) (string, error) {
+	cmd := exec.Command("gh", "api", endpoint, "--jq", jqExpr)
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%w: %s", err, errBuf.String())
+	}
+	return out.String(), nil
+}
+
+// parseOwnerRepo extracts (owner, repo) from a git remote URL.
+// Supports both HTTPS and SSH forms:
+//
+//	https://github.com/foo/bar.git -> (foo, bar)
+//	git@github.com:foo/bar.git    -> (foo, bar)
+func parseOwnerRepo(remoteURL string) (string, string, error) {
+	u := strings.TrimSpace(remoteURL)
+	u = strings.TrimSuffix(u, ".git")
+
+	// SSH: git@github.com:owner/repo
+	if strings.Contains(u, ":") && strings.HasPrefix(u, "git@") {
+		parts := strings.SplitN(u, ":", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("cannot parse SSH remote: %s", remoteURL)
+		}
+		ownerRepo := strings.Split(parts[1], "/")
+		if len(ownerRepo) != 2 {
+			return "", "", fmt.Errorf("cannot parse owner/repo from SSH remote: %s", remoteURL)
+		}
+		return ownerRepo[0], ownerRepo[1], nil
+	}
+
+	// HTTPS: https://github.com/owner/repo
+	if strings.Contains(u, "://") {
+		parts := strings.Split(u, "/")
+		if len(parts) < 5 {
+			return "", "", fmt.Errorf("cannot parse HTTPS remote: %s", remoteURL)
+		}
+		return parts[len(parts)-2], parts[len(parts)-1], nil
+	}
+
+	return "", "", fmt.Errorf("unrecognized remote URL format: %s", remoteURL)
+}
+
+// getRemoteURL reads the origin remote URL from a git repo.
+func getRemoteURL(repoPath string) (string, error) {
+	out, err := gitCmd(repoPath, "config", "--get", "remote.origin.url")
+	if err != nil {
+		return "", fmt.Errorf("git config remote.origin.url: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// formatIssueEmbedText produces the text to embed for an issue, following the
+// format specified in the corpus design:
+//
+//	Issue #{number}: {title}
+//	State: {state}  Author: {author}  Labels: {labels}
+//
+//	{body}
+//
+//	--- Comment by {author}, {created_at} ---
+//	{body}
+//
+// Truncated to maxEmbedChars.
+func formatIssueEmbedText(issue ghIssue, comments []ghComment) string {
+	var b strings.Builder
+
+	// Header
+	fmt.Fprintf(&b, "Issue #%d: %s\n", issue.Number, issue.Title)
+	fmt.Fprintf(&b, "State: %s  Author: %s", issue.State, issue.Author)
+	if len(issue.Labels) > 0 {
+		fmt.Fprintf(&b, "  Labels: %s", strings.Join(issue.Labels, ", "))
+	}
+	b.WriteString("\n")
+
+	// Body
+	if issue.Body != "" {
+		b.WriteString("\n")
+		b.WriteString(issue.Body)
+		b.WriteString("\n")
+	}
+
+	// Comments
+	for _, c := range comments {
+		fmt.Fprintf(&b, "\n--- Comment by %s, %s ---\n", c.Author, c.CreatedAt)
+		b.WriteString(c.Body)
+		b.WriteString("\n")
+	}
+
+	text := b.String()
+	if len(text) > maxEmbedChars {
+		text = text[:maxEmbedChars]
+	}
+	return text
+}
+
+// IssuesCorpus indexes GitHub issues and PRs for the current repo.
+type IssuesCorpus struct {
+	// Limit caps the number of issues fetched; 0 means use a default.
+	Limit int
+
+	// fetcher is the GitHub API abstraction. Nil means use the real gh CLI.
+	fetcher ghFetcher
+
+	// remoteURL overrides the git remote URL for testing. Empty means read
+	// from git config.
+	remoteURL string
+}
+
+// ID returns the stable corpus identifier.
+func (c *IssuesCorpus) ID() string { return "issues" }
+
+// Collection returns the Qdrant collection name for this corpus + project.
+func (c *IssuesCorpus) Collection(projectRoot string) string {
+	return "issues-" + ProjectHash(projectRoot)
+}
+
+// Enumerate emits Records for each issue/PR. The channel is closed when
+// enumeration completes. Errors are reported via the errs channel.
+func (c *IssuesCorpus) Enumerate(projectRoot string) (<-chan Record, <-chan error) {
+	out := make(chan Record)
+	errs := make(chan error, 4)
+	go func() {
+		defer close(out)
+		defer close(errs)
+
+		// Resolve owner/repo.
+		remoteURL := c.remoteURL
+		if remoteURL == "" {
+			var err error
+			remoteURL, err = getRemoteURL(projectRoot)
+			if err != nil {
+				errs <- err
+				return
+			}
+		}
+		owner, repo, err := parseOwnerRepo(remoteURL)
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		limit := c.Limit
+		if limit <= 0 {
+			limit = 500
+		}
+
+		fetcher := c.fetcher
+		if fetcher == nil {
+			fetcher = &ghCLIFetcher{}
+		}
+
+		issues, err := fetcher.ListIssues(owner, repo, limit)
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		for _, issue := range issues {
+			// Fetch comments; log and continue on failure.
+			comments, err := fetcher.ListComments(owner, repo, issue.Number)
+			if err != nil {
+				log.Printf("warn: failed to fetch comments for #%d: %v", issue.Number, err)
+				comments = nil
+			}
+
+			embedText := formatIssueEmbedText(issue, comments)
+			hash := sha256.Sum256([]byte(embedText))
+
+			isPR := issue.PRURL != ""
+
+			out <- Record{
+				Path:        fmt.Sprintf("issue#%d", issue.Number),
+				Kind:        "issue",
+				ContentHash: fmt.Sprintf("%x", hash),
+				EmbedText:   embedText,
+				Extra: map[string]any{
+					"number":     issue.Number,
+					"title":      issue.Title,
+					"state":      issue.State,
+					"author":     issue.Author,
+					"labels":     issue.Labels,
+					"created_at": issue.CreatedAt,
+					"updated_at": issue.UpdatedAt,
+					"url":        issue.HTMLURL,
+					"is_pr":      isPR,
+				},
+			}
+		}
+	}()
+	return out, errs
+}

--- a/search/corpus/issues.go
+++ b/search/corpus/issues.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os/exec"
 	"strings"
 )
@@ -45,7 +46,7 @@ func (f *ghCLIFetcher) ListIssues(owner, repo string, limit int) ([]ghIssue, err
 	perPage := 100
 	for page := 1; len(all) < limit; page++ {
 		jqExpr := `.[] | {number, title, body, state, user: .user.login, labels: [.labels[].name], created_at, updated_at, html_url, pull_request: (.pull_request.html_url // null)}`
-		endpoint := fmt.Sprintf("repos/%s/%s/issues?state=all&sort=updated&direction=desc&per_page=%d&page=%d", owner, repo, perPage, page)
+		endpoint := fmt.Sprintf("repos/%s/%s/issues?state=all&sort=updated&direction=desc&per_page=%d&page=%d", url.PathEscape(owner), url.PathEscape(repo), perPage, page)
 		out, err := ghAPI(endpoint, jqExpr)
 		if err != nil {
 			return nil, fmt.Errorf("gh api issues page %d: %w", page, err)
@@ -83,7 +84,7 @@ func (f *ghCLIFetcher) ListIssues(owner, repo string, limit int) ([]ghIssue, err
 
 func (f *ghCLIFetcher) ListComments(owner, repo string, number int) ([]ghComment, error) {
 	jqExpr := `.[] | {user: .user.login, created_at, body}`
-	endpoint := fmt.Sprintf("repos/%s/%s/issues/%d/comments?per_page=100", owner, repo, number)
+	endpoint := fmt.Sprintf("repos/%s/%s/issues/%d/comments?per_page=100", url.PathEscape(owner), url.PathEscape(repo), number)
 	out, err := ghAPI(endpoint, jqExpr)
 	if err != nil {
 		return nil, fmt.Errorf("gh api comments for #%d: %w", number, err)

--- a/search/corpus/issues_test.go
+++ b/search/corpus/issues_test.go
@@ -1,7 +1,6 @@
 package corpus
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -284,7 +283,7 @@ func TestFormatIssueEmbedText_WithLabels(t *testing.T) {
 	}
 }
 
-func TestFormatIssueEmbedText_ContentHash(t *testing.T) {
+func TestFormatIssueEmbedText_Deterministic(t *testing.T) {
 	issue := ghIssue{
 		Number: 1, Title: "test", Body: "body",
 		State: "open", Author: "a", Labels: nil,
@@ -370,6 +369,4 @@ func TestIssuesCorpus_RecordContentHash(t *testing.T) {
 	if rec.Extra["author"] != "a" {
 		t.Errorf("Extra[author] = %v, want %q", rec.Extra["author"], "a")
 	}
-
-	fmt.Println("ContentHash:", rec.ContentHash)
 }

--- a/search/corpus/issues_test.go
+++ b/search/corpus/issues_test.go
@@ -1,0 +1,375 @@
+package corpus
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// --- parseOwnerRepo tests ---
+
+func TestParseOwnerRepo_HTTPS(t *testing.T) {
+	owner, repo, err := parseOwnerRepo("https://github.com/foo/bar.git")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != "foo" || repo != "bar" {
+		t.Errorf("got (%q, %q), want (foo, bar)", owner, repo)
+	}
+}
+
+func TestParseOwnerRepo_HTTPSNoGitSuffix(t *testing.T) {
+	owner, repo, err := parseOwnerRepo("https://github.com/foo/bar")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != "foo" || repo != "bar" {
+		t.Errorf("got (%q, %q), want (foo, bar)", owner, repo)
+	}
+}
+
+func TestParseOwnerRepo_SSH(t *testing.T) {
+	owner, repo, err := parseOwnerRepo("git@github.com:foo/bar.git")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != "foo" || repo != "bar" {
+		t.Errorf("got (%q, %q), want (foo, bar)", owner, repo)
+	}
+}
+
+func TestParseOwnerRepo_SSHNoGitSuffix(t *testing.T) {
+	owner, repo, err := parseOwnerRepo("git@github.com:foo/bar")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != "foo" || repo != "bar" {
+		t.Errorf("got (%q, %q), want (foo, bar)", owner, repo)
+	}
+}
+
+func TestParseOwnerRepo_Invalid(t *testing.T) {
+	_, _, err := parseOwnerRepo("not-a-url")
+	if err == nil {
+		t.Error("expected error for invalid URL")
+	}
+}
+
+// --- IssuesCorpus basic tests ---
+
+func TestIssuesCorpus_ID(t *testing.T) {
+	c := &IssuesCorpus{}
+	if got := c.ID(); got != "issues" {
+		t.Errorf("ID() = %q, want %q", got, "issues")
+	}
+}
+
+func TestIssuesCorpus_Collection(t *testing.T) {
+	c := &IssuesCorpus{}
+	got := c.Collection(".")
+	if !strings.HasPrefix(got, "issues-") {
+		t.Errorf("Collection(.) = %q, want prefix %q", got, "issues-")
+	}
+}
+
+// --- Fake ghFetcher for Enumerate tests ---
+
+type fakeGHFetcher struct {
+	issues   []ghIssue
+	comments map[int][]ghComment
+}
+
+func (f *fakeGHFetcher) ListIssues(owner, repo string, limit int) ([]ghIssue, error) {
+	if limit > 0 && limit < len(f.issues) {
+		return f.issues[:limit], nil
+	}
+	return f.issues, nil
+}
+
+func (f *fakeGHFetcher) ListComments(owner, repo string, number int) ([]ghComment, error) {
+	if c, ok := f.comments[number]; ok {
+		return c, nil
+	}
+	return nil, nil
+}
+
+// --- Enumerate tests ---
+
+func TestIssuesCorpus_Enumerate_ThreeIssues(t *testing.T) {
+	fake := &fakeGHFetcher{
+		issues: []ghIssue{
+			{
+				Number:    1,
+				Title:     "Bug: crash on startup",
+				Body:      "The app crashes when you open it.",
+				State:     "open",
+				Author:    "alice",
+				Labels:    []string{"bug"},
+				CreatedAt: "2026-01-01T00:00:00Z",
+				UpdatedAt: "2026-01-02T00:00:00Z",
+				HTMLURL:   "https://github.com/foo/bar/issues/1",
+				PRURL:     "",
+			},
+			{
+				Number:    2,
+				Title:     "Add dark mode",
+				Body:      "Please add dark mode support.",
+				State:     "closed",
+				Author:    "bob",
+				Labels:    []string{"enhancement", "ui"},
+				CreatedAt: "2026-02-01T00:00:00Z",
+				UpdatedAt: "2026-02-15T00:00:00Z",
+				HTMLURL:   "https://github.com/foo/bar/issues/2",
+				PRURL:     "",
+			},
+			{
+				Number:    3,
+				Title:     "Fix dark mode contrast",
+				Body:      "The contrast ratio is too low.",
+				State:     "open",
+				Author:    "charlie",
+				Labels:    nil,
+				CreatedAt: "2026-03-01T00:00:00Z",
+				UpdatedAt: "2026-03-02T00:00:00Z",
+				HTMLURL:   "https://github.com/foo/bar/pull/3",
+				PRURL:     "https://github.com/foo/bar/pull/3",
+			},
+		},
+		comments: map[int][]ghComment{
+			2: {
+				{Author: "alice", CreatedAt: "2026-02-02T00:00:00Z", Body: "Good idea, +1"},
+				{Author: "bob", CreatedAt: "2026-02-03T00:00:00Z", Body: "Thanks!"},
+			},
+		},
+	}
+
+	c := &IssuesCorpus{Limit: 10, fetcher: fake, remoteURL: "https://github.com/foo/bar.git"}
+	records, errs := c.Enumerate(".")
+
+	go func() {
+		for range errs {
+		}
+	}()
+
+	var recs []Record
+	for rec := range records {
+		recs = append(recs, rec)
+	}
+
+	if len(recs) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(recs))
+	}
+
+	// Issue #1: plain issue, no comments
+	r1 := recs[0]
+	if r1.Path != "issue#1" {
+		t.Errorf("rec[0].Path = %q, want %q", r1.Path, "issue#1")
+	}
+	if r1.Kind != "issue" {
+		t.Errorf("rec[0].Kind = %q, want %q", r1.Kind, "issue")
+	}
+	if !strings.Contains(r1.EmbedText, "Issue #1: Bug: crash on startup") {
+		t.Errorf("rec[0].EmbedText missing header, got:\n%s", r1.EmbedText)
+	}
+	if r1.Extra["is_pr"] != false {
+		t.Errorf("rec[0].Extra[is_pr] = %v, want false", r1.Extra["is_pr"])
+	}
+
+	// Issue #2: closed issue with comments
+	r2 := recs[1]
+	if r2.Path != "issue#2" {
+		t.Errorf("rec[1].Path = %q, want %q", r2.Path, "issue#2")
+	}
+	if r2.Extra["state"] != "closed" {
+		t.Errorf("rec[1].Extra[state] = %v, want %q", r2.Extra["state"], "closed")
+	}
+	if !strings.Contains(r2.EmbedText, "--- Comment by alice") {
+		t.Errorf("rec[1].EmbedText missing comment by alice, got:\n%s", r2.EmbedText)
+	}
+	if !strings.Contains(r2.EmbedText, "Good idea, +1") {
+		t.Errorf("rec[1].EmbedText missing comment body, got:\n%s", r2.EmbedText)
+	}
+	labels, ok := r2.Extra["labels"].([]string)
+	if !ok || len(labels) != 2 || labels[0] != "enhancement" {
+		t.Errorf("rec[1].Extra[labels] = %v, want [enhancement ui]", r2.Extra["labels"])
+	}
+
+	// Issue #3: PR (has PRURL set)
+	r3 := recs[2]
+	if r3.Path != "issue#3" {
+		t.Errorf("rec[2].Path = %q, want %q", r3.Path, "issue#3")
+	}
+	if r3.Extra["is_pr"] != true {
+		t.Errorf("rec[2].Extra[is_pr] = %v, want true", r3.Extra["is_pr"])
+	}
+}
+
+func TestIssuesCorpus_Enumerate_NoBodyNoComments(t *testing.T) {
+	fake := &fakeGHFetcher{
+		issues: []ghIssue{
+			{
+				Number:    42,
+				Title:     "Empty issue",
+				Body:      "",
+				State:     "open",
+				Author:    "dev",
+				Labels:    nil,
+				CreatedAt: "2026-04-01T00:00:00Z",
+				UpdatedAt: "2026-04-01T00:00:00Z",
+				HTMLURL:   "https://github.com/foo/bar/issues/42",
+				PRURL:     "",
+			},
+		},
+		comments: map[int][]ghComment{},
+	}
+
+	c := &IssuesCorpus{Limit: 10, fetcher: fake, remoteURL: "https://github.com/foo/bar.git"}
+	records, errs := c.Enumerate(".")
+
+	go func() {
+		for range errs {
+		}
+	}()
+
+	var recs []Record
+	for rec := range records {
+		recs = append(recs, rec)
+	}
+
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+
+	r := recs[0]
+	if r.EmbedText == "" {
+		t.Error("expected non-empty EmbedText for issue with no body and no comments")
+	}
+	if !strings.Contains(r.EmbedText, "Issue #42: Empty issue") {
+		t.Errorf("EmbedText missing header, got:\n%s", r.EmbedText)
+	}
+	if !strings.Contains(r.EmbedText, "State: open") {
+		t.Errorf("EmbedText missing state, got:\n%s", r.EmbedText)
+	}
+}
+
+// --- formatIssueEmbedText tests ---
+
+func TestFormatIssueEmbedText_Truncation(t *testing.T) {
+	// Create an issue with a very long body to test truncation.
+	longBody := strings.Repeat("x", 20000)
+	text := formatIssueEmbedText(
+		ghIssue{
+			Number: 1, Title: "test", Body: longBody,
+			State: "open", Author: "a", Labels: nil,
+			CreatedAt: "2026-01-01T00:00:00Z",
+		},
+		nil,
+	)
+	if len(text) > maxEmbedChars {
+		t.Errorf("EmbedText length %d exceeds maxEmbedChars %d", len(text), maxEmbedChars)
+	}
+}
+
+func TestFormatIssueEmbedText_WithLabels(t *testing.T) {
+	text := formatIssueEmbedText(
+		ghIssue{
+			Number: 5, Title: "feature", Body: "details",
+			State: "open", Author: "dev", Labels: []string{"bug", "p1"},
+			CreatedAt: "2026-01-01T00:00:00Z",
+		},
+		nil,
+	)
+	if !strings.Contains(text, "Labels: bug, p1") {
+		t.Errorf("expected labels in embed text, got:\n%s", text)
+	}
+}
+
+func TestFormatIssueEmbedText_ContentHash(t *testing.T) {
+	issue := ghIssue{
+		Number: 1, Title: "test", Body: "body",
+		State: "open", Author: "a", Labels: nil,
+		CreatedAt: "2026-01-01T00:00:00Z",
+	}
+	text1 := formatIssueEmbedText(issue, nil)
+	text2 := formatIssueEmbedText(issue, nil)
+	// Same input produces same output (deterministic).
+	if text1 != text2 {
+		t.Error("formatIssueEmbedText is not deterministic")
+	}
+	// Different input produces different output.
+	issue.Title = "different"
+	text3 := formatIssueEmbedText(issue, nil)
+	if text1 == text3 {
+		t.Error("different titles should produce different embed text")
+	}
+}
+
+func TestFormatIssueEmbedText_Comments(t *testing.T) {
+	text := formatIssueEmbedText(
+		ghIssue{
+			Number: 10, Title: "with comments", Body: "main body",
+			State: "closed", Author: "dev", Labels: nil,
+			CreatedAt: "2026-01-01T00:00:00Z",
+		},
+		[]ghComment{
+			{Author: "reviewer", CreatedAt: "2026-01-02T00:00:00Z", Body: "Looks good"},
+		},
+	)
+	if !strings.Contains(text, "--- Comment by reviewer") {
+		t.Errorf("missing comment header in embed text:\n%s", text)
+	}
+	if !strings.Contains(text, "Looks good") {
+		t.Errorf("missing comment body in embed text:\n%s", text)
+	}
+}
+
+// --- Record shape validation ---
+
+func TestIssuesCorpus_RecordContentHash(t *testing.T) {
+	fake := &fakeGHFetcher{
+		issues: []ghIssue{
+			{
+				Number: 1, Title: "test", Body: "body",
+				State: "open", Author: "a", Labels: nil,
+				CreatedAt: "2026-01-01T00:00:00Z",
+				UpdatedAt: "2026-01-01T00:00:00Z",
+				HTMLURL:   "https://github.com/foo/bar/issues/1",
+				PRURL:     "",
+			},
+		},
+		comments: map[int][]ghComment{},
+	}
+
+	c := &IssuesCorpus{Limit: 10, fetcher: fake, remoteURL: "https://github.com/foo/bar.git"}
+	records, errs := c.Enumerate(".")
+
+	go func() {
+		for range errs {
+		}
+	}()
+
+	rec := <-records
+	if rec.ContentHash == "" {
+		t.Error("expected non-empty ContentHash")
+	}
+	// ContentHash should be a hex sha256 (64 chars).
+	if len(rec.ContentHash) != 64 {
+		t.Errorf("ContentHash length = %d, want 64 hex chars", len(rec.ContentHash))
+	}
+
+	// Verify Extra fields.
+	if rec.Extra["number"] != 1 {
+		t.Errorf("Extra[number] = %v, want 1", rec.Extra["number"])
+	}
+	if rec.Extra["title"] != "test" {
+		t.Errorf("Extra[title] = %v, want %q", rec.Extra["title"], "test")
+	}
+	if rec.Extra["url"] != "https://github.com/foo/bar/issues/1" {
+		t.Errorf("Extra[url] = %v, want the html url", rec.Extra["url"])
+	}
+	if rec.Extra["author"] != "a" {
+		t.Errorf("Extra[author] = %v, want %q", rec.Extra["author"], "a")
+	}
+
+	fmt.Println("ContentHash:", rec.ContentHash)
+}

--- a/search/mcp/server.go
+++ b/search/mcp/server.go
@@ -14,13 +14,13 @@ import (
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// Server holds runtime dependencies for search_code / list_clusters tools.
+// Server holds runtime dependencies for the MCP tool handlers.
 type Server struct {
 	ProjectRoot string
 	Config      *config.Config
 }
 
-// Register attaches both tools to the provided MCP server.
+// Register attaches all search tools to the provided MCP server.
 func (s *Server) Register(srv *mcpSDK.Server) {
 	mcpSDK.AddTool[searchCodeInput, searchCodeOutput](srv, &mcpSDK.Tool{
 		Name:        "search_code",
@@ -36,6 +36,13 @@ func (s *Server) Register(srv *mcpSDK.Server) {
 		return s.handleSearchContext(ctx, in)
 	})
 
+	mcpSDK.AddTool[searchIssuesInput, searchIssuesOutput](srv, &mcpSDK.Tool{
+		Name:        "search_issues",
+		Description: "Semantic search over the repo's GitHub issues and PRs. Use to find prior discussion of a bug, feature request, or decision before proposing new work.",
+	}, func(ctx context.Context, req *mcpSDK.CallToolRequest, in searchIssuesInput) (*mcpSDK.CallToolResult, searchIssuesOutput, error) {
+		return s.handleSearchIssues(ctx, in)
+	})
+
 	mcpSDK.AddTool[listClustersInput, listClustersOutput](srv, &mcpSDK.Tool{
 		Name:        "list_clusters",
 		Description: "List the thematic clusters discovered in the code index. Returns cluster IDs, sizes, and representative file paths.",
@@ -47,8 +54,8 @@ func (s *Server) Register(srv *mcpSDK.Server) {
 // --- Input / output types ---
 
 type searchCodeInput struct {
-	Query       string `json:"query"        jsonschema:"the natural language query to embed and search"`
-	TopK        int    `json:"top_k,omitempty" jsonschema:"max results to return (default 10, max 50)"`
+	Query       string `json:"query"                  jsonschema:"the natural language query to embed and search"`
+	TopK        int    `json:"top_k,omitempty"        jsonschema:"max results to return (default 10, max 50)"`
 	WithCluster bool   `json:"with_cluster,omitempty" jsonschema:"include cluster_id per hit"`
 }
 
@@ -57,12 +64,22 @@ type searchCodeOutput struct {
 }
 
 type searchContextInput struct {
-	Query       string `json:"query"        jsonschema:"the natural language query to embed and search against context artifacts"`
-	TopK        int    `json:"top_k,omitempty" jsonschema:"max results to return (default 10, max 50)"`
+	Query       string `json:"query"                  jsonschema:"the natural language query to embed and search against context artifacts"`
+	TopK        int    `json:"top_k,omitempty"        jsonschema:"max results to return (default 10, max 50)"`
 	WithCluster bool   `json:"with_cluster,omitempty" jsonschema:"include cluster_id per hit"`
 }
 
 type searchContextOutput struct {
+	Results json.RawMessage `json:"results"`
+}
+
+type searchIssuesInput struct {
+	Query       string `json:"query"                  jsonschema:"the natural language query to embed and search against issues and PRs"`
+	TopK        int    `json:"top_k,omitempty"        jsonschema:"max results to return (default 10, max 50)"`
+	WithCluster bool   `json:"with_cluster,omitempty" jsonschema:"include cluster_id per hit"`
+}
+
+type searchIssuesOutput struct {
 	Results json.RawMessage `json:"results"`
 }
 
@@ -74,15 +91,17 @@ type listClustersOutput struct {
 
 // --- Handlers ---
 
-func (s *Server) handleSearchCode(ctx context.Context, in searchCodeInput) (*mcpSDK.CallToolResult, searchCodeOutput, error) {
-	rt, err := config.BuildWithConfig(s.ProjectRoot, "code", s.Config)
+// runCorpusQuery is a small helper that drives query.Run for a given corpus
+// and returns the envelope JSON both as a CallToolResult text content and
+// as a raw message embedded in the typed output.
+func (s *Server) runCorpusQuery(ctx context.Context, corpusID, q string, topK int, withCluster bool) (*mcpSDK.CallToolResult, json.RawMessage, error) {
+	rt, err := config.BuildWithConfig(s.ProjectRoot, corpusID, s.Config)
 	if err != nil {
-		return nil, searchCodeOutput{}, err
+		return nil, nil, err
 	}
 	qc := qdrant.NewQdrantClient(s.Config.Sidecars.QdrantURL)
 	ec := embed.NewClient(s.Config.Sidecars.LlamaRetrievalURL)
 
-	topK := in.TopK
 	if topK <= 0 {
 		topK = 10
 	}
@@ -92,58 +111,44 @@ func (s *Server) handleSearchCode(ctx context.Context, in searchCodeInput) (*mcp
 		Embedder:    &embed.QueryAdapter{Client: ec},
 		Searcher:    &qdrant.Adapter{QdrantClient: qc},
 		ProjectRoot: s.ProjectRoot,
-		Query:       in.Query,
+		Query:       q,
 		TopK:        topK,
-		WithCluster: in.WithCluster,
+		WithCluster: withCluster,
 	})
 	if err != nil {
-		return nil, searchCodeOutput{}, err
+		return nil, nil, err
 	}
-
 	buf, err := json.Marshal(env)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &mcpSDK.CallToolResult{
+		Content: []mcpSDK.Content{&mcpSDK.TextContent{Text: string(buf)}},
+	}, json.RawMessage(buf), nil
+}
+
+func (s *Server) handleSearchCode(ctx context.Context, in searchCodeInput) (*mcpSDK.CallToolResult, searchCodeOutput, error) {
+	res, raw, err := s.runCorpusQuery(ctx, "code", in.Query, in.TopK, in.WithCluster)
 	if err != nil {
 		return nil, searchCodeOutput{}, err
 	}
-	out := searchCodeOutput{Results: json.RawMessage(buf)}
-	return &mcpSDK.CallToolResult{
-		Content: []mcpSDK.Content{&mcpSDK.TextContent{Text: string(buf)}},
-	}, out, nil
+	return res, searchCodeOutput{Results: raw}, nil
 }
 
 func (s *Server) handleSearchContext(ctx context.Context, in searchContextInput) (*mcpSDK.CallToolResult, searchContextOutput, error) {
-	rt, err := config.BuildWithConfig(s.ProjectRoot, "context", s.Config)
+	res, raw, err := s.runCorpusQuery(ctx, "context", in.Query, in.TopK, in.WithCluster)
 	if err != nil {
 		return nil, searchContextOutput{}, err
 	}
-	qc := qdrant.NewQdrantClient(s.Config.Sidecars.QdrantURL)
-	ec := embed.NewClient(s.Config.Sidecars.LlamaRetrievalURL)
+	return res, searchContextOutput{Results: raw}, nil
+}
 
-	topK := in.TopK
-	if topK <= 0 {
-		topK = 10
-	}
-
-	env, err := query.Run(ctx, query.Config{
-		Corpus:      rt.Corpus,
-		Embedder:    &embed.QueryAdapter{Client: ec},
-		Searcher:    &qdrant.Adapter{QdrantClient: qc},
-		ProjectRoot: s.ProjectRoot,
-		Query:       in.Query,
-		TopK:        topK,
-		WithCluster: in.WithCluster,
-	})
+func (s *Server) handleSearchIssues(ctx context.Context, in searchIssuesInput) (*mcpSDK.CallToolResult, searchIssuesOutput, error) {
+	res, raw, err := s.runCorpusQuery(ctx, "issues", in.Query, in.TopK, in.WithCluster)
 	if err != nil {
-		return nil, searchContextOutput{}, err
+		return nil, searchIssuesOutput{}, err
 	}
-
-	buf, err := json.Marshal(env)
-	if err != nil {
-		return nil, searchContextOutput{}, err
-	}
-	out := searchContextOutput{Results: json.RawMessage(buf)}
-	return &mcpSDK.CallToolResult{
-		Content: []mcpSDK.Content{&mcpSDK.TextContent{Text: string(buf)}},
-	}, out, nil
+	return res, searchIssuesOutput{Results: raw}, nil
 }
 
 func (s *Server) handleListClusters(ctx context.Context) (*mcpSDK.CallToolResult, listClustersOutput, error) {


### PR DESCRIPTION
## Summary
- New `IssuesCorpus` fetching the current repo's issues and PRs via the `gh` CLI (open + closed, up to configured limit).
- Title + body + comments are embedded together, so discussion signal is searchable — not just issue titles.
- Exposed via `cspace search issues "<query>"` and the `search_issues` MCP tool.

## Design decisions
- **`ghFetcher` interface** decouples the `gh api` shellout from the corpus logic, making all unit tests run without network.
- **`parseOwnerRepo`** handles both HTTPS and SSH git remote URL formats.
- **Record shape:** all issues and PRs use `Kind: "issue"` with `Extra["is_pr"]` differentiating — keeps the index uniform for queries that span both.
- **Comment fetch:** per-issue; failure is logged and skipped, not fatal.

## Validation
- 14 unit tests covering: ID, Collection, Enumerate (3 issues incl. PR + comments + plain), parseOwnerRepo (HTTPS/SSH/invalid), formatIssueEmbedText (truncation, labels, comments, determinism), Record shape (ContentHash, Extra fields), empty body/comments.
- `go build ./...` — clean
- `go test ./search/...` — all pass
- `bash scripts/check-search-imports.sh` — clean
- `gofmt` — clean
- Live `gh api` fetch validated: 47 issues/PRs visible, comments fetch works.
- Full `Enumerate` pipeline tested against live repo: 5 issues returned with correct metadata.
- `cspace-search index --corpus=issues` fails at Qdrant upsert (search compose stack not running in devcontainer) — data fetch + record generation confirmed working.

## Test plan
- [x] Unit tests pass (`go test ./search/corpus/...`)
- [x] `go build ./...` succeeds
- [x] Import check passes
- [x] `gofmt` clean
- [ ] `cspace-search index --corpus=issues` succeeds against this repo (needs search compose stack)
- [ ] Query for a known issue's concept returns it in top 5
- [ ] MCP `search_issues` tool returns same envelope shape as `search_code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)