### PR TITLE
Fix qdrant/hdbscan healthchecks failing on missing curl/wget

### DIFF
--- a/lib/templates/docker-compose.core.yml
+++ b/lib/templates/docker-compose.core.yml
@@ -205,7 +205,8 @@ services:
     build:
       context: ${CSPACE_HOME}/lib/hdbscan-api
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O- http://localhost:8090/health || exit 1"]
+      # hdbscan-api image has python but no wget/curl; match reduce-api's probe.
+      test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8090/health\")' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -222,7 +223,8 @@ services:
     volumes:
       - qdrant-storage:/qdrant/storage
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:6333/healthz || exit 1"]
+      # qdrant/qdrant image ships without curl/wget; probe TCP via bash builtin.
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/6333'"]
       interval: 5s
       timeout: 3s
       retries: 30


### PR DESCRIPTION
## Summary
- `qdrant/qdrant` ships without `curl` and `cspace-hdbscan-api` ships without `wget`, so the healthchecks in `docker-compose.core.yml` fail every interval (`/bin/sh: 1: curl: not found`, 76-deep failing streak observed).
- `cspace-search-mcp` declares `depends_on: qdrant: service_healthy`, so it never starts and `cspace up` hangs until compose's retry window expires, then fails with `dependency failed to start: container <inst>.qdrant is unhealthy`.
- Swap to probes that use tools already present in each image: bash `/dev/tcp` for qdrant, python `urllib.request` for hdbscan (matches the already-healthy `reduce-api` probe one service above).

## Test plan
- [x] Verified `bash -c 'exec 3<>/dev/tcp/127.0.0.1/6333'` succeeds inside a live `qdrant/qdrant` container.
- [x] Verified `python -c 'import urllib.request; urllib.request.urlopen("http://localhost:8090/health")'` returns 200 inside a live `cspace-hdbscan-api` container.
- [ ] `cspace up <planet>` reaches `[15/15]` without a healthcheck-blocked `search-mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)