### PR TITLE
Replace auto-reindex hooks with staleness signals + background-bootstrap status

### DIFF
--- a/.cspace/context/decisions/2026-04-22-bootstrap-search-indexing-is-opt-in-advisors-and-coordinator.md
+++ b/.cspace/context/decisions/2026-04-22-bootstrap-search-indexing-is-opt-in-advisors-and-coordinator.md
@@ -1,0 +1,17 @@
+---
+title: Bootstrap search indexing is opt-in; advisors and coordinators get it by default
+date: 2026-04-22
+kind: decision
+---
+
+## Context
+Auto-indexing at container boot blocks provisioning by minutes and wastes resources in the common case where search isn't queried that session. Advisors and coordinators are search-heavy and session-continuous, so the cost amortizes. Everyone else pays only when they explicitly opt in.
+
+## Alternatives
+(a) always bootstrap in background (current) — rejected: still CPU-intensive, races with agent startup; (b) never bootstrap at boot — rejected: advisors would hit cold indexes every consultation; (c) role-aware default with opt-in flag — chosen.
+
+## Decision
+Search indexing at provision time is opt-in via BootstrapSearch on provision.Params. Advisors (advisor.Launch) and coordinators (runCoordinateWithArgs) set it true. Interactive cspace up defaults to false; users pass --index to enable. TUI flows skip it.
+
+## Consequences
+Interactive cspace up returns faster; autonomous agents do not pay an indexing tax they may not need; advisors/coordinators retain the warm-start behavior they depend on.

--- a/.cspace/context/decisions/2026-04-22-delta-detection-needs-symmetric-difference-not-one-sided-mem.md
+++ b/.cspace/context/decisions/2026-04-22-delta-detection-needs-symmetric-difference-not-one-sided-mem.md
@@ -1,0 +1,17 @@
+---
+title: Delta detection needs symmetric difference, not one-sided membership
+date: 2026-04-22
+kind: decision
+---
+
+## Context
+CodeStaleness counted tracked files whose hash was absent from the index — but never counted indexed entries whose path/hash was no longer tracked. Deleted-but-still-indexed ghosts made results stale in a way the signal couldn't surface.
+
+## Alternatives
+One-sided check with documented known-unknowns (rejected: erodes trust).
+
+## Decision
+Any "is A in sync with B" check computes A - B and B - A and reports both sides. One-sided checks are a code smell for sync logic.
+
+## Consequences
+Slightly more code per check; better signal fidelity.

--- a/.cspace/context/decisions/2026-04-22-don-t-compare-counts-when-limits-are-in-play-compare-identit.md
+++ b/.cspace/context/decisions/2026-04-22-don-t-compare-counts-when-limits-are-in-play-compare-identit.md
@@ -1,0 +1,17 @@
+---
+title: Don't compare counts when limits are in play — compare identities or timestamps
+date: 2026-04-22
+kind: decision
+---
+
+## Context
+CommitsStaleness compared rev-list --count to len(indexed). With commits.limit: 500 and a 1000-commit repo, the difference is always 500, so the staleness signal was permanently stuck at "500 new commits".
+
+## Alternatives
+Clamp the rev-list count to the limit (rejected: doesn't answer "is HEAD newer than last indexed?"); treat indexed == limit as special (rejected: fragile).
+
+## Decision
+When detecting "X is newer than Y" across a bounded window, compare the identity of the newest element (timestamp, hash, sequence id) — never raw size. Applies to any staleness/change-detection check going forward.
+
+## Consequences
+Change-detection logic needs to surface timestamps/hashes in payloads; slightly richer qdrant payload schema.

--- a/.cspace/context/decisions/2026-04-22-don-t-use-planet-names-for-agent-spawned-cspace-instances.md
+++ b/.cspace/context/decisions/2026-04-22-don-t-use-planet-names-for-agent-spawned-cspace-instances.md
@@ -1,0 +1,17 @@
+---
+title: Don't use planet names for agent-spawned cspace instances
+date: 2026-04-22
+kind: decision
+---
+
+## Context
+cspace reserves planet names (mercury, venus, earth, …) for the human-facing TUI which auto-assigns them via port-range heuristics in internal/ports. Agents manually spawning sub-instances with planet names collide with what the TUI would otherwise pick, and make human vs agent traffic indistinguishable in docker ps.
+
+## Alternatives
+Allow but warn (rejected: too easy to ignore); reserve the names in config (rejected: changes a live user-facing behavior).
+
+## Decision
+Agents spawning cspace instances use descriptive or numbered names (issue-<n>, short task labels like review-fixes, search-bootstrap, or cs-agent-<n>). Planet names are reserved for TUI-auto-assigned instances.
+
+## Consequences
+Predictable separation of human vs agent instances in cspace list / docker ps; fewer port collisions; agents must pick names explicitly.

--- a/.cspace/context/decisions/2026-04-22-secondary-work-injected-into-query-paths-needs-a-latency-bud.md
+++ b/.cspace/context/decisions/2026-04-22-secondary-work-injected-into-query-paths-needs-a-latency-bud.md
@@ -1,0 +1,17 @@
+---
+title: Secondary work injected into query paths needs a latency budget
+date: 2026-04-22
+kind: decision
+---
+
+## Context
+mcpAppendStalenessWarning added 100-500ms of git I/O + SHA256 to every MCP search call. Agents doing 5+ queries mid-turn paid seconds of invisible overhead.
+
+## Alternatives
+Do the check async (rejected: result not available when query returns); move the check entirely off-path (rejected: agents forget to call it); cache the result (accepted).
+
+## Decision
+Any synchronous check bolted onto a user-facing command must either (a) be cached with a TTL appropriate to the volatility of the input, (b) be timeboxed to <50ms with graceful fall-through, or (c) be opt-in via a flag. Default to caching when the input is slow-changing.
+
+## Consequences
+First query in a session is slightly slower; subsequent queries are fast; staleness signals may lag by up to the TTL.

--- a/.cspace/context/decisions/2026-04-22-writer-instances-must-refresh-state-before-writing-or-be-sin.md
+++ b/.cspace/context/decisions/2026-04-22-writer-instances-must-refresh-state-before-writing-or-be-sin.md
@@ -1,0 +1,17 @@
+---
+title: Writer instances must refresh state before writing OR be single-use
+date: 2026-04-22
+kind: decision
+---
+
+## Context
+PR #61's runSearchInit held a long-lived status.Writer whose in-memory snapshot was wiped by concurrent inner writers; the next mutation clobbered everything. Single-use writers (created at call-site, flushed once, discarded) or read-modify-write semantics avoid the footgun.
+
+## Alternatives
+A singleton writer with inner locks (rejected: locks don't solve cross-process or re-entrant reads); read-before-every-write (rejected: slower, harder to reason about).
+
+## Decision
+For status/context-like writers where multiple callers in a process may mutate the same file, callers construct the writer at the narrowest useful scope and discard after flushing. Long-lived writers must re-read on each mutation or be explicitly documented as single-writer-per-process.
+
+## Consequences
+Fewer surprising clobbers; some redundant reads.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Format check
+        run: make fmt-check
+
       - name: Vet
         run: make vet
 
@@ -23,7 +26,6 @@ jobs:
         run: make test
 
   lint:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ lib/agent-supervisor/node_modules/
 # sidecar URL overrides; embedded default.yaml holds the real defaults.
 /search.yaml
 
+# Runtime index status file — written by cspace search index, not source.
+.cspace/search-index-status.json
+
 # Go build artifacts
 bin/cspace-go
 bin/cspace-go-linux-amd64

--- a/.lefthookrc
+++ b/.lefthookrc
@@ -1,0 +1,1 @@
+export PATH="$HOME/go/bin:$PATH"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Shell scripts fired by Claude Code's hook system: progress logging on `PostToolU
 
 **Template overrides**: Users place files in `.cspace/` to override built-in templates (Dockerfile, compose files, agent playbooks). Resolution checks project dir first, falls back to `$ASSETS_DIR/templates/` or `$ASSETS_DIR/agents/`.
 
-**Instance naming**: Auto-assigned from planet names with deterministic port ranges. Custom names get random port assignment.
+**Instance naming**: Auto-assigned from planet names with deterministic port ranges. Custom names get random port assignment. When spawning a cspace instance from an agent, use a descriptive or numbered name (`issue-<n>`, `cs-agent-<n>`, or a short task label). Planet names (`mercury`, `venus`, …) are reserved for the human-facing TUI.
 
 **Exit code handling**: Exit codes 0 and 2 (stream pipe closed) are success; 141 (SIGPIPE) is expected.
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LDFLAGS         := -ldflags "-X github.com/elliottregan/cspace/internal/cli.Vers
 LDFLAGS_RELEASE := -ldflags "-s -w -X github.com/elliottregan/cspace/internal/cli.Version=$(VERSION)"
 GOBIN           := ./bin/cspace-go
 
-.PHONY: build build-linux clean test test-node vet sync-embedded overlay-demo overlay-web fmt fmt-check lint check install-tools setup-hooks
+.PHONY: build build-linux clean test test-node vet sync-embedded overlay-demo overlay-web fmt fmt-check lint check install-tools setup-hooks check-hooks
 
 # Sync lib/ contents into internal/assets/embedded/ for go:embed
 sync-embedded:
@@ -22,7 +22,7 @@ sync-embedded:
 	@cp lib/defaults.json internal/assets/embedded/
 	@cp lib/planets.json internal/assets/embedded/
 
-build: sync-embedded bin/cspace-go bin/cspace-search bin/cspace-search-mcp
+build: check-hooks sync-embedded bin/cspace-go bin/cspace-search bin/cspace-search-mcp
 
 bin/cspace-go: $(shell find cmd/cspace internal -name '*.go') sync-embedded
 	go build $(LDFLAGS) -o $@ ./cmd/cspace
@@ -89,4 +89,14 @@ install-tools:
 	@echo "Install shellcheck via your package manager (brew install shellcheck / apt install shellcheck)."
 
 setup-hooks:
+	@command -v lefthook >/dev/null 2>&1 || { echo "ERROR: lefthook not found in PATH. Run 'make install-tools' first." >&2; exit 1; }
 	lefthook install
+
+# Emit a warning if git hooks are not installed. Called by build so
+# contributors notice early without blocking the build itself.
+check-hooks:
+	@if [ -d .git ] && [ ! -f .git/hooks/pre-commit ]; then \
+		echo "" >&2; \
+		echo "⚠  Git hooks are not installed. Run 'make setup-hooks' to enable pre-commit and pre-push checks." >&2; \
+		echo "" >&2; \
+	fi

--- a/README.md
+++ b/README.md
@@ -87,17 +87,25 @@ Full reference: [configuration](https://cspace-cli.netlify.app/configuration/con
 The CLI is written in Go with Cobra. The agent supervisor is Node.js (ESM).
 
 ```bash
+# First-time setup: install tools and git hooks
+make install-tools
+make setup-hooks
+
 # Build
 make build
 ./bin/cspace-go --help
 
 # Test and lint
 make test
-make vet
+make check   # fmt-check + vet + lint + test
 
 # Rebuild the container image after Dockerfile/template changes
 cspace rebuild
 ```
+
+### Git Hooks
+
+[Lefthook](https://github.com/evilmartians/lefthook) runs pre-commit (format, lint, vet) and pre-push (lint, test) checks automatically. Run `make setup-hooks` after cloning to activate them. The `make build` target will warn if hooks are not installed.
 
 ### Project Structure
 

--- a/cmd/cspace-search/main.go
+++ b/cmd/cspace-search/main.go
@@ -228,6 +228,11 @@ func initCmd() *cobra.Command {
 			}
 
 			if !skipIndex {
+				// Short-circuit when the project hasn't opted in.
+				if cfg, err := config.Load(root); err == nil && !cfg.Enabled {
+					report("search not configured (set `enabled: true` in %s/search.yaml to activate)", root)
+					return nil
+				}
 				for _, corpusID := range []string{"code", "commits", "context", "issues"} {
 					err := runIndexCorpus(cmd.Context(), root, corpusID)
 					switch {
@@ -304,7 +309,7 @@ func statusCmd() *cobra.Command {
 				}
 			}
 
-			cs, err := status.Compute(root, disabled, func(corpusID string) (bool, string) {
+			cs, err := status.Compute(root, cfg.Enabled, disabled, func(corpusID string) (bool, string) {
 				qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
 				adapter := &qdrant.Adapter{QdrantClient: qc}
 				collection := corpusCollection(corpusID, root)
@@ -325,6 +330,12 @@ func statusCmd() *cobra.Command {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
 				return enc.Encode(cs)
+			}
+
+			if !cs.Enabled {
+				fmt.Printf("search not configured for this project.\n")
+				fmt.Printf("To activate, set `enabled: true` in %s/search.yaml.\n", root)
+				return nil
 			}
 
 			allCorpora := []string{"code", "commits", "context", "issues"}

--- a/cmd/cspace-search/main.go
+++ b/cmd/cspace-search/main.go
@@ -12,20 +12,23 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/elliottregan/cspace/search/cluster"
 	"github.com/elliottregan/cspace/search/config"
+	"github.com/elliottregan/cspace/search/corpus"
 	"github.com/elliottregan/cspace/search/embed"
 	"github.com/elliottregan/cspace/search/index"
 	"github.com/elliottregan/cspace/search/qdrant"
 	"github.com/elliottregan/cspace/search/query"
+	"github.com/elliottregan/cspace/search/status"
 
 	"github.com/spf13/cobra"
 )
 
 func main() {
 	root := &cobra.Command{Use: "cspace-search", Short: "Semantic search over commits, code, context, and issues"}
-	root.AddCommand(indexCmd(), queryCmd(), clustersCmd(), initCmd())
+	root.AddCommand(indexCmd(), queryCmd(), clustersCmd(), initCmd(), statusCmd())
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -61,13 +64,19 @@ func indexCmd() *cobra.Command {
 					fmt.Fprintf(os.Stderr, "\rindex: %d/%d", done, total)
 				}
 			}
+			sw, _ := status.NewWriter(root)
+			var statusWriter index.StatusWriter
+			if sw != nil {
+				statusWriter = sw
+			}
 			err = index.Run(context.Background(), index.Config{
-				Corpus:      rt.Corpus,
-				Embedder:    &embed.Adapter{Client: ec},
-				Upserter:    &qdrant.Adapter{QdrantClient: qc},
-				ProjectRoot: root,
-				LockPath:    filepath.Join(root, rt.Cfg.Index.LockPath),
-				Progress:    progress,
+				Corpus:       rt.Corpus,
+				Embedder:     &embed.Adapter{Client: ec},
+				Upserter:     &qdrant.Adapter{QdrantClient: qc},
+				ProjectRoot:  root,
+				LockPath:     filepath.Join(root, rt.Cfg.Index.LockPath),
+				Progress:     progress,
+				StatusWriter: statusWriter,
 			})
 			if !quiet {
 				fmt.Fprintln(os.Stderr)
@@ -109,6 +118,10 @@ func queryCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Check staleness and annotate the envelope.
+			appendStalenessWarning(env, corpusID, root, qc)
+
 			if asJSON {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
@@ -215,13 +228,17 @@ func initCmd() *cobra.Command {
 			}
 
 			if !skipIndex {
+				sw, _ := status.NewWriter(root)
 				for _, corpusID := range []string{"code", "commits", "context", "issues"} {
-					err := runIndexCorpus(cmd.Context(), root, corpusID)
+					err := runIndexCorpus(cmd.Context(), root, corpusID, sw)
 					switch {
 					case err == nil:
 						report("%s: indexed", corpusID)
 					case errors.Is(err, config.ErrCorpusDisabled):
 						report("%s: disabled in search.yaml (enable with corpora.%s.enabled=true)", corpusID, corpusID)
+						if sw != nil {
+							sw.DisableCorpus(corpusID)
+						}
 					default:
 						report("%s: skipped (%v)", corpusID, err)
 					}
@@ -240,18 +257,204 @@ func initCmd() *cobra.Command {
 // runIndexCorpus is a thin wrapper that runs index.Run for one corpus id,
 // used by initCmd to loop over corpora without rebuilding the cobra flag
 // plumbing that indexCmd exposes.
-func runIndexCorpus(ctx context.Context, root, corpusID string) error {
+func runIndexCorpus(ctx context.Context, root, corpusID string, sw *status.Writer) error {
 	rt, err := config.Build(root, corpusID)
 	if err != nil {
 		return err
 	}
 	qc := qdrant.NewQdrantClient(rt.Cfg.Sidecars.QdrantURL)
 	ec := embed.NewClient(rt.Cfg.Sidecars.LlamaRetrievalURL)
+	var statusWriter index.StatusWriter
+	if sw != nil {
+		statusWriter = sw
+	}
 	return index.Run(ctx, index.Config{
-		Corpus:      rt.Corpus,
-		Embedder:    &embed.Adapter{Client: ec},
-		Upserter:    &qdrant.Adapter{QdrantClient: qc},
-		ProjectRoot: root,
-		LockPath:    filepath.Join(root, rt.Cfg.Index.LockPath),
+		Corpus:       rt.Corpus,
+		Embedder:     &embed.Adapter{Client: ec},
+		Upserter:     &qdrant.Adapter{QdrantClient: qc},
+		ProjectRoot:  root,
+		LockPath:     filepath.Join(root, rt.Cfg.Index.LockPath),
+		StatusWriter: statusWriter,
 	})
+}
+
+func statusCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show index status and staleness for all corpora",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := projectRoot()
+			cfg, err := config.Load(root)
+			if err != nil {
+				return err
+			}
+			sf, err := status.Read(root)
+			if err != nil {
+				return fmt.Errorf("reading status file: %w", err)
+			}
+
+			type corpusStatusOutput struct {
+				State        string `json:"state"`
+				FinishedAt   string `json:"finished_at,omitempty"`
+				DurationMS   int64  `json:"duration_ms,omitempty"`
+				IndexedCount int    `json:"indexed_count,omitempty"`
+				Error        string `json:"error,omitempty"`
+				Stale        bool   `json:"stale,omitempty"`
+				StaleReason  string `json:"stale_reason,omitempty"`
+			}
+			type statusOutput struct {
+				Corpora map[string]corpusStatusOutput `json:"corpora"`
+				Current *status.RunningState          `json:"current"`
+			}
+
+			allCorpora := []string{"code", "commits", "context", "issues"}
+			out := statusOutput{Corpora: make(map[string]corpusStatusOutput)}
+			if sf != nil {
+				out.Current = sf.Current
+			}
+
+			for _, id := range allCorpora {
+				co := corpusStatusOutput{State: "unknown"}
+				if cc, ok := cfg.Corpora[id]; ok && !cc.Enabled {
+					co.State = "disabled"
+					out.Corpora[id] = co
+					continue
+				}
+				if sf != nil {
+					if cs, ok := sf.Last[id]; ok {
+						co.State = cs.State
+						if !cs.FinishedAt.IsZero() {
+							co.FinishedAt = cs.FinishedAt.Format(time.RFC3339)
+						}
+						co.DurationMS = cs.DurationMS
+						co.IndexedCount = cs.IndexedCount
+						co.Error = cs.Error
+					}
+				}
+				if co.State == "completed" && (id == "code" || id == "commits") {
+					qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
+					adapter := &qdrant.Adapter{QdrantClient: qc}
+					collection := corpusCollection(id, root)
+					var st corpus.Staleness
+					switch id {
+					case "code":
+						st, _ = corpus.CodeStaleness(root, collection, adapter)
+					case "commits":
+						st, _ = corpus.CommitsStaleness(root, collection, adapter)
+					}
+					if st.IsStale {
+						co.Stale = true
+						co.StaleReason = st.Reason
+					}
+				}
+				out.Corpora[id] = co
+			}
+
+			if asJSON {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(out)
+			}
+
+			for _, id := range allCorpora {
+				co := out.Corpora[id]
+				switch co.State {
+				case "disabled":
+					fmt.Printf("%-10s disabled (enable with corpora.%s.enabled=true in search.yaml)\n", id, id)
+				case "completed":
+					age := "unknown"
+					if co.FinishedAt != "" {
+						if t, err := time.Parse(time.RFC3339, co.FinishedAt); err == nil {
+							age = timeAgo(time.Since(t))
+						}
+					}
+					line := fmt.Sprintf("%-10s completed %s ago", id, age)
+					if co.IndexedCount > 0 {
+						line += fmt.Sprintf("   (%d chunks indexed)", co.IndexedCount)
+					}
+					if co.Stale {
+						line += fmt.Sprintf(" — STALE: %s", co.StaleReason)
+					} else {
+						line += " — up to date"
+					}
+					fmt.Println(line)
+				case "failed":
+					age := "unknown"
+					if co.FinishedAt != "" {
+						if t, err := time.Parse(time.RFC3339, co.FinishedAt); err == nil {
+							age = timeAgo(time.Since(t))
+						}
+					}
+					fmt.Printf("%-10s failed %s ago   error: %s\n", id, age, co.Error)
+				default:
+					fmt.Printf("%-10s never indexed\n", id)
+				}
+			}
+
+			if out.Current != nil {
+				age := timeAgo(time.Since(out.Current.StartedAt))
+				fmt.Printf("\nCurrently running: %s  started %s ago", out.Current.Corpus, age)
+				if out.Current.Progress.Total > 0 {
+					fmt.Printf("  (%d/%d)", out.Current.Progress.Done, out.Current.Progress.Total)
+				}
+				fmt.Println()
+			} else {
+				fmt.Println("\nCurrently running: none.")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit JSON output for programmatic consumers")
+	return cmd
+}
+
+// appendStalenessWarning checks corpus staleness and appends a warning to
+// the envelope if the index is out of date.
+func appendStalenessWarning(env *query.Envelope, corpusID, root string, qc *qdrant.QdrantClient) {
+	adapter := &qdrant.Adapter{QdrantClient: qc}
+	collection := corpusCollection(corpusID, root)
+	if collection == "" {
+		return
+	}
+	var st corpus.Staleness
+	var err error
+	switch corpusID {
+	case "code":
+		st, err = corpus.CodeStaleness(root, collection, adapter)
+	case "commits":
+		st, err = corpus.CommitsStaleness(root, collection, adapter)
+	default:
+		return
+	}
+	if err != nil || !st.IsStale {
+		return
+	}
+	warning := "index may be out of date: " + st.Reason +
+		" \u2014 run `cspace search " + corpusID + " index` to refresh"
+	env.Warning = strings.TrimSpace(env.Warning + "\n" + warning)
+}
+
+func corpusCollection(corpusID, projectRoot string) string {
+	switch corpusID {
+	case "code":
+		return "code-" + corpus.ProjectHash(projectRoot)
+	case "commits":
+		return "commits-" + corpus.ProjectHash(projectRoot)
+	default:
+		return ""
+	}
+}
+
+func timeAgo(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
 }

--- a/cmd/cspace-search/main.go
+++ b/cmd/cspace-search/main.go
@@ -228,17 +228,15 @@ func initCmd() *cobra.Command {
 			}
 
 			if !skipIndex {
-				sw, _ := status.NewWriter(root)
 				for _, corpusID := range []string{"code", "commits", "context", "issues"} {
-					err := runIndexCorpus(cmd.Context(), root, corpusID, sw)
+					err := runIndexCorpus(cmd.Context(), root, corpusID)
 					switch {
 					case err == nil:
 						report("%s: indexed", corpusID)
 					case errors.Is(err, config.ErrCorpusDisabled):
+						// runIndexCorpus already wrote the disabled state with
+						// a fresh single-use writer — no outer writer needed.
 						report("%s: disabled in search.yaml (enable with corpora.%s.enabled=true)", corpusID, corpusID)
-						if sw != nil {
-							sw.DisableCorpus(corpusID)
-						}
 					default:
 						report("%s: skipped (%v)", corpusID, err)
 					}
@@ -257,13 +255,22 @@ func initCmd() *cobra.Command {
 // runIndexCorpus is a thin wrapper that runs index.Run for one corpus id,
 // used by initCmd to loop over corpora without rebuilding the cobra flag
 // plumbing that indexCmd exposes.
-func runIndexCorpus(ctx context.Context, root, corpusID string, sw *status.Writer) error {
+func runIndexCorpus(ctx context.Context, root, corpusID string) error {
 	rt, err := config.Build(root, corpusID)
 	if err != nil {
+		// If the corpus is disabled, record that in the status file with a
+		// fresh single-use writer so we never clobber state written by prior
+		// iterations. Then return the sentinel so callers can report it.
+		if errors.Is(err, config.ErrCorpusDisabled) {
+			if sw, swErr := status.NewWriter(root); swErr == nil && sw != nil {
+				sw.DisableCorpus(corpusID)
+			}
+		}
 		return err
 	}
 	qc := qdrant.NewQdrantClient(rt.Cfg.Sidecars.QdrantURL)
 	ec := embed.NewClient(rt.Cfg.Sidecars.LlamaRetrievalURL)
+	sw, _ := status.NewWriter(root)
 	var statusWriter index.StatusWriter
 	if sw != nil {
 		statusWriter = sw

--- a/cmd/cspace-search/main.go
+++ b/cmd/cspace-search/main.go
@@ -346,9 +346,9 @@ func statusCmd() *cobra.Command {
 					var st corpus.Staleness
 					switch id {
 					case "code":
-						st, _ = corpus.CodeStaleness(root, collection, adapter)
+						st, _ = corpus.CodeStalenessCached(root, collection, adapter)
 					case "commits":
-						st, _ = corpus.CommitsStaleness(root, collection, adapter)
+						st, _ = corpus.CommitsStalenessCached(root, collection, adapter)
 					}
 					if st.IsStale {
 						co.Stale = true
@@ -428,9 +428,9 @@ func appendStalenessWarning(env *query.Envelope, corpusID, root string, qc *qdra
 	var err error
 	switch corpusID {
 	case "code":
-		st, err = corpus.CodeStaleness(root, collection, adapter)
+		st, err = corpus.CodeStalenessCached(root, collection, adapter)
 	case "commits":
-		st, err = corpus.CommitsStaleness(root, collection, adapter)
+		st, err = corpus.CommitsStalenessCached(root, collection, adapter)
 	default:
 		return
 	}

--- a/cmd/cspace-search/main.go
+++ b/cmd/cspace-search/main.go
@@ -296,76 +296,40 @@ func statusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sf, err := status.Read(root)
+
+			disabled := make(map[string]bool)
+			for id, cc := range cfg.Corpora {
+				if !cc.Enabled {
+					disabled[id] = true
+				}
+			}
+
+			cs, err := status.Compute(root, disabled, func(corpusID string) (bool, string) {
+				qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
+				adapter := &qdrant.Adapter{QdrantClient: qc}
+				collection := corpusCollection(corpusID, root)
+				var st corpus.Staleness
+				switch corpusID {
+				case "code":
+					st, _ = corpus.CodeStalenessCached(root, collection, adapter)
+				case "commits":
+					st, _ = corpus.CommitsStalenessCached(root, collection, adapter)
+				}
+				return st.IsStale, st.Reason
+			})
 			if err != nil {
-				return fmt.Errorf("reading status file: %w", err)
-			}
-
-			type corpusStatusOutput struct {
-				State        string `json:"state"`
-				FinishedAt   string `json:"finished_at,omitempty"`
-				DurationMS   int64  `json:"duration_ms,omitempty"`
-				IndexedCount int    `json:"indexed_count,omitempty"`
-				Error        string `json:"error,omitempty"`
-				Stale        bool   `json:"stale,omitempty"`
-				StaleReason  string `json:"stale_reason,omitempty"`
-			}
-			type statusOutput struct {
-				Corpora map[string]corpusStatusOutput `json:"corpora"`
-				Current *status.RunningState          `json:"current"`
-			}
-
-			allCorpora := []string{"code", "commits", "context", "issues"}
-			out := statusOutput{Corpora: make(map[string]corpusStatusOutput)}
-			if sf != nil {
-				out.Current = sf.Current
-			}
-
-			for _, id := range allCorpora {
-				co := corpusStatusOutput{State: "unknown"}
-				if cc, ok := cfg.Corpora[id]; ok && !cc.Enabled {
-					co.State = "disabled"
-					out.Corpora[id] = co
-					continue
-				}
-				if sf != nil {
-					if cs, ok := sf.Last[id]; ok {
-						co.State = cs.State
-						if !cs.FinishedAt.IsZero() {
-							co.FinishedAt = cs.FinishedAt.Format(time.RFC3339)
-						}
-						co.DurationMS = cs.DurationMS
-						co.IndexedCount = cs.IndexedCount
-						co.Error = cs.Error
-					}
-				}
-				if co.State == "completed" && (id == "code" || id == "commits") {
-					qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
-					adapter := &qdrant.Adapter{QdrantClient: qc}
-					collection := corpusCollection(id, root)
-					var st corpus.Staleness
-					switch id {
-					case "code":
-						st, _ = corpus.CodeStalenessCached(root, collection, adapter)
-					case "commits":
-						st, _ = corpus.CommitsStalenessCached(root, collection, adapter)
-					}
-					if st.IsStale {
-						co.Stale = true
-						co.StaleReason = st.Reason
-					}
-				}
-				out.Corpora[id] = co
+				return fmt.Errorf("computing status: %w", err)
 			}
 
 			if asJSON {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
-				return enc.Encode(out)
+				return enc.Encode(cs)
 			}
 
+			allCorpora := []string{"code", "commits", "context", "issues"}
 			for _, id := range allCorpora {
-				co := out.Corpora[id]
+				co := cs.Corpora[id]
 				switch co.State {
 				case "disabled":
 					fmt.Printf("%-10s disabled (enable with corpora.%s.enabled=true in search.yaml)\n", id, id)
@@ -399,11 +363,11 @@ func statusCmd() *cobra.Command {
 				}
 			}
 
-			if out.Current != nil {
-				age := timeAgo(time.Since(out.Current.StartedAt))
-				fmt.Printf("\nCurrently running: %s  started %s ago", out.Current.Corpus, age)
-				if out.Current.Progress.Total > 0 {
-					fmt.Printf("  (%d/%d)", out.Current.Progress.Done, out.Current.Progress.Total)
+			if cs.Current != nil {
+				age := timeAgo(time.Since(cs.Current.StartedAt))
+				fmt.Printf("\nCurrently running: %s  started %s ago", cs.Current.Corpus, age)
+				if cs.Current.Progress.Total > 0 {
+					fmt.Printf("  (%d/%d)", cs.Current.Progress.Done, cs.Current.Progress.Total)
 				}
 				fmt.Println()
 			} else {

--- a/internal/advisor/advisor.go
+++ b/internal/advisor/advisor.go
@@ -100,7 +100,7 @@ func Launch(cfg *config.Config, name string) (reused bool, err error) {
 		return true, nil
 	}
 
-	if _, err := provision.Run(provision.Params{Name: name, Cfg: cfg}); err != nil {
+	if _, err := provision.Run(provision.Params{Name: name, Cfg: cfg, BootstrapSearch: true}); err != nil {
 		return false, fmt.Errorf("provisioning advisor %s: %w", name, err)
 	}
 

--- a/internal/cli/coordinate.go
+++ b/internal/cli/coordinate.go
@@ -137,8 +137,9 @@ func runCoordinateWithArgs(prompt, promptFile, name, systemPromptFile string) er
 	}
 
 	_, err := provision.Run(provision.Params{
-		Name: name,
-		Cfg:  cfg,
+		Name:            name,
+		Cfg:             cfg,
+		BootstrapSearch: true,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -352,7 +352,7 @@ func runSearchStatus(asJSON bool) error {
 		}
 	}
 
-	cs, err := status.Compute(root, disabled, func(corpusID string) (bool, string) {
+	cs, err := status.Compute(root, cfg.Enabled, disabled, func(corpusID string) (bool, string) {
 		qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
 		adapter := &qdrant.Adapter{QdrantClient: qc}
 		collection := corpusCollection(corpusID, root)
@@ -373,6 +373,14 @@ func runSearchStatus(asJSON bool) error {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(cs)
+	}
+
+	// When search is opted out project-wide, show a single clear message
+	// instead of iterating the corpus map (which is empty by contract).
+	if !cs.Enabled {
+		fmt.Printf("search not configured for this project.\n")
+		fmt.Printf("To activate, set `enabled: true` in %s/search.yaml.\n", root)
+		return nil
 	}
 
 	// Human-readable output.

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -338,22 +338,6 @@ index is out of date.`,
 	return cmd
 }
 
-// statusOutput is the JSON shape for `cspace search status --json`.
-type statusOutput struct {
-	Corpora map[string]corpusStatusOutput `json:"corpora"`
-	Current *status.RunningState          `json:"current"`
-}
-
-type corpusStatusOutput struct {
-	State        string `json:"state"` // completed, failed, disabled, unknown
-	FinishedAt   string `json:"finished_at,omitempty"`
-	DurationMS   int64  `json:"duration_ms,omitempty"`
-	IndexedCount int    `json:"indexed_count,omitempty"`
-	Error        string `json:"error,omitempty"`
-	Stale        bool   `json:"stale,omitempty"`
-	StaleReason  string `json:"stale_reason,omitempty"`
-}
-
 func runSearchStatus(asJSON bool) error {
 	root := searchProjectRoot()
 	cfg, err := config.Load(root)
@@ -361,72 +345,40 @@ func runSearchStatus(asJSON bool) error {
 		return err
 	}
 
-	sf, err := status.Read(root)
+	disabled := make(map[string]bool)
+	for id, cc := range cfg.Corpora {
+		if !cc.Enabled {
+			disabled[id] = true
+		}
+	}
+
+	cs, err := status.Compute(root, disabled, func(corpusID string) (bool, string) {
+		qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
+		adapter := &qdrant.Adapter{QdrantClient: qc}
+		collection := corpusCollection(corpusID, root)
+		var st corpus.Staleness
+		switch corpusID {
+		case "code":
+			st, _ = corpus.CodeStalenessCached(root, collection, adapter)
+		case "commits":
+			st, _ = corpus.CommitsStalenessCached(root, collection, adapter)
+		}
+		return st.IsStale, st.Reason
+	})
 	if err != nil {
-		return fmt.Errorf("reading status file: %w", err)
-	}
-
-	allCorpora := []string{"code", "commits", "context", "issues"}
-	out := statusOutput{
-		Corpora: make(map[string]corpusStatusOutput),
-	}
-	if sf != nil {
-		out.Current = sf.Current
-	}
-
-	for _, id := range allCorpora {
-		co := corpusStatusOutput{State: "unknown"}
-
-		// Check if disabled in config.
-		if cc, ok := cfg.Corpora[id]; ok && !cc.Enabled {
-			co.State = "disabled"
-			out.Corpora[id] = co
-			continue
-		}
-
-		// Pull state from status file if available.
-		if sf != nil {
-			if cs, ok := sf.Last[id]; ok {
-				co.State = cs.State
-				if !cs.FinishedAt.IsZero() {
-					co.FinishedAt = cs.FinishedAt.Format(time.RFC3339)
-				}
-				co.DurationMS = cs.DurationMS
-				co.IndexedCount = cs.IndexedCount
-				co.Error = cs.Error
-			}
-		}
-
-		// Check staleness for code and commits (cached to avoid per-query I/O).
-		if co.State == "completed" && (id == "code" || id == "commits") {
-			qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
-			adapter := &qdrant.Adapter{QdrantClient: qc}
-			collection := corpusCollection(id, root)
-			var st corpus.Staleness
-			switch id {
-			case "code":
-				st, _ = corpus.CodeStalenessCached(root, collection, adapter)
-			case "commits":
-				st, _ = corpus.CommitsStalenessCached(root, collection, adapter)
-			}
-			if st.IsStale {
-				co.Stale = true
-				co.StaleReason = st.Reason
-			}
-		}
-
-		out.Corpora[id] = co
+		return fmt.Errorf("computing status: %w", err)
 	}
 
 	if asJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(out)
+		return enc.Encode(cs)
 	}
 
 	// Human-readable output.
+	allCorpora := []string{"code", "commits", "context", "issues"}
 	for _, id := range allCorpora {
-		co := out.Corpora[id]
+		co := cs.Corpora[id]
 		switch co.State {
 		case "disabled":
 			fmt.Printf("%-10s disabled (enable with corpora.%s.enabled=true in search.yaml)\n", id, id)
@@ -461,11 +413,11 @@ func runSearchStatus(asJSON bool) error {
 	}
 
 	// Show current run.
-	if out.Current != nil {
-		age := timeAgo(time.Since(out.Current.StartedAt))
-		fmt.Printf("\nCurrently running: %s  started %s ago", out.Current.Corpus, age)
-		if out.Current.Progress.Total > 0 {
-			fmt.Printf("  (%d/%d)", out.Current.Progress.Done, out.Current.Progress.Total)
+	if cs.Current != nil {
+		age := timeAgo(time.Since(cs.Current.StartedAt))
+		fmt.Printf("\nCurrently running: %s  started %s ago", cs.Current.Corpus, age)
+		if cs.Current.Progress.Total > 0 {
+			fmt.Printf("  (%d/%d)", cs.Current.Progress.Done, cs.Current.Progress.Total)
 		}
 		fmt.Println()
 	} else {

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -8,14 +8,17 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/elliottregan/cspace/search/cluster"
 	"github.com/elliottregan/cspace/search/config"
+	"github.com/elliottregan/cspace/search/corpus"
 	"github.com/elliottregan/cspace/search/embed"
 	"github.com/elliottregan/cspace/search/index"
 	searchmcp "github.com/elliottregan/cspace/search/mcp"
 	"github.com/elliottregan/cspace/search/qdrant"
 	"github.com/elliottregan/cspace/search/query"
+	"github.com/elliottregan/cspace/search/status"
 
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
@@ -45,6 +48,7 @@ func newSearchCmd() *cobra.Command {
 		newSearchSubcmd("issues"),
 		newSearchMCPCmd(),
 		newSearchInitCmd(),
+		newSearchStatusCmd(),
 	)
 	return cmd
 }
@@ -173,6 +177,10 @@ func runSearchQuery(corpusID, q string, opts searchQueryOpts) error {
 	if err != nil {
 		return err
 	}
+
+	// Check staleness and annotate the envelope.
+	appendStalenessWarning(env, corpusID, root, qc)
+
 	if opts.JSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -191,6 +199,47 @@ func runSearchQuery(corpusID, q string, opts searchQueryOpts) error {
 	return nil
 }
 
+// appendStalenessWarning checks corpus staleness and appends a warning to
+// the envelope if the index is out of date. Best-effort: errors are silently
+// ignored so queries are never blocked by staleness checks.
+func appendStalenessWarning(env *query.Envelope, corpusID, root string, qc *qdrant.QdrantClient) {
+	adapter := &qdrant.Adapter{QdrantClient: qc}
+	collection := corpusCollection(corpusID, root)
+	if collection == "" {
+		return
+	}
+	var st corpus.Staleness
+	var err error
+	switch corpusID {
+	case "code":
+		st, err = corpus.CodeStaleness(root, collection, adapter)
+	case "commits":
+		st, err = corpus.CommitsStaleness(root, collection, adapter)
+	default:
+		return // staleness not implemented for context/issues
+	}
+	if err != nil || !st.IsStale {
+		return
+	}
+	warning := "index may be out of date: " + st.Reason +
+		" \u2014 run `cspace search " + corpusID + " index` to refresh"
+	env.Warning = strings.TrimSpace(env.Warning + "\n" + warning)
+}
+
+// corpusCollection returns the qdrant collection name for a corpus, or ""
+// if the corpus ID is unknown. Used to avoid importing config.Build again
+// just for the collection name.
+func corpusCollection(corpusID, projectRoot string) string {
+	switch corpusID {
+	case "code":
+		return "code-" + corpus.ProjectHash(projectRoot)
+	case "commits":
+		return "commits-" + corpus.ProjectHash(projectRoot)
+	default:
+		return ""
+	}
+}
+
 func runSearchIndex(corpusID string, quiet bool) error {
 	root := searchProjectRoot()
 	rt, err := config.Build(root, corpusID)
@@ -205,13 +254,19 @@ func runSearchIndex(corpusID string, quiet bool) error {
 			fmt.Fprintf(os.Stderr, "\rindex: %d/%d", done, total)
 		}
 	}
+	sw, _ := status.NewWriter(root)
+	var statusWriter index.StatusWriter
+	if sw != nil {
+		statusWriter = sw
+	}
 	err = index.Run(context.Background(), index.Config{
-		Corpus:      rt.Corpus,
-		Embedder:    &embed.Adapter{Client: ec},
-		Upserter:    &qdrant.Adapter{QdrantClient: qc},
-		ProjectRoot: root,
-		LockPath:    filepath.Join(root, rt.Cfg.Index.LockPath),
-		Progress:    progress,
+		Corpus:       rt.Corpus,
+		Embedder:     &embed.Adapter{Client: ec},
+		Upserter:     &qdrant.Adapter{QdrantClient: qc},
+		ProjectRoot:  root,
+		LockPath:     filepath.Join(root, rt.Cfg.Index.LockPath),
+		Progress:     progress,
+		StatusWriter: statusWriter,
 	})
 	if !quiet {
 		fmt.Fprintln(os.Stderr)
@@ -254,4 +309,173 @@ func searchProjectRoot() string {
 		return cwd
 	}
 	return filepath.Clean(strings.TrimSpace(string(out)))
+}
+
+// newSearchStatusCmd builds `cspace search status`.
+func newSearchStatusCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show index status and staleness for all corpora",
+		Long: `Reads .cspace/search-index-status.json and checks each corpus for
+staleness against the current git state. Shows whether each corpus is
+completed, failed, disabled, or currently running, plus whether the
+index is out of date.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSearchStatus(asJSON)
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit JSON output for programmatic consumers")
+	return cmd
+}
+
+// statusOutput is the JSON shape for `cspace search status --json`.
+type statusOutput struct {
+	Corpora  map[string]corpusStatusOutput `json:"corpora"`
+	Current  *status.RunningState          `json:"current"`
+}
+
+type corpusStatusOutput struct {
+	State        string `json:"state"`                     // completed, failed, disabled, unknown
+	FinishedAt   string `json:"finished_at,omitempty"`
+	DurationMS   int64  `json:"duration_ms,omitempty"`
+	IndexedCount int    `json:"indexed_count,omitempty"`
+	Error        string `json:"error,omitempty"`
+	Stale        bool   `json:"stale,omitempty"`
+	StaleReason  string `json:"stale_reason,omitempty"`
+}
+
+func runSearchStatus(asJSON bool) error {
+	root := searchProjectRoot()
+	cfg, err := config.Load(root)
+	if err != nil {
+		return err
+	}
+
+	sf, err := status.Read(root)
+	if err != nil {
+		return fmt.Errorf("reading status file: %w", err)
+	}
+
+	allCorpora := []string{"code", "commits", "context", "issues"}
+	out := statusOutput{
+		Corpora: make(map[string]corpusStatusOutput),
+	}
+	if sf != nil {
+		out.Current = sf.Current
+	}
+
+	for _, id := range allCorpora {
+		co := corpusStatusOutput{State: "unknown"}
+
+		// Check if disabled in config.
+		if cc, ok := cfg.Corpora[id]; ok && !cc.Enabled {
+			co.State = "disabled"
+			out.Corpora[id] = co
+			continue
+		}
+
+		// Pull state from status file if available.
+		if sf != nil {
+			if cs, ok := sf.Last[id]; ok {
+				co.State = cs.State
+				if !cs.FinishedAt.IsZero() {
+					co.FinishedAt = cs.FinishedAt.Format(time.RFC3339)
+				}
+				co.DurationMS = cs.DurationMS
+				co.IndexedCount = cs.IndexedCount
+				co.Error = cs.Error
+			}
+		}
+
+		// Check staleness for code and commits.
+		if co.State == "completed" && (id == "code" || id == "commits") {
+			qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
+			adapter := &qdrant.Adapter{QdrantClient: qc}
+			collection := corpusCollection(id, root)
+			var st corpus.Staleness
+			switch id {
+			case "code":
+				st, _ = corpus.CodeStaleness(root, collection, adapter)
+			case "commits":
+				st, _ = corpus.CommitsStaleness(root, collection, adapter)
+			}
+			if st.IsStale {
+				co.Stale = true
+				co.StaleReason = st.Reason
+			}
+		}
+
+		out.Corpora[id] = co
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+
+	// Human-readable output.
+	for _, id := range allCorpora {
+		co := out.Corpora[id]
+		switch co.State {
+		case "disabled":
+			fmt.Printf("%-10s disabled (enable with corpora.%s.enabled=true in search.yaml)\n", id, id)
+		case "completed":
+			age := "unknown"
+			if co.FinishedAt != "" {
+				if t, err := time.Parse(time.RFC3339, co.FinishedAt); err == nil {
+					age = timeAgo(time.Since(t))
+				}
+			}
+			line := fmt.Sprintf("%-10s completed %s ago", id, age)
+			if co.IndexedCount > 0 {
+				line += fmt.Sprintf("   (%d chunks indexed)", co.IndexedCount)
+			}
+			if co.Stale {
+				line += fmt.Sprintf(" — STALE: %s", co.StaleReason)
+			} else {
+				line += " — up to date"
+			}
+			fmt.Println(line)
+		case "failed":
+			age := "unknown"
+			if co.FinishedAt != "" {
+				if t, err := time.Parse(time.RFC3339, co.FinishedAt); err == nil {
+					age = timeAgo(time.Since(t))
+				}
+			}
+			fmt.Printf("%-10s failed %s ago   error: %s\n", id, age, co.Error)
+		default:
+			fmt.Printf("%-10s never indexed\n", id)
+		}
+	}
+
+	// Show current run.
+	if out.Current != nil {
+		age := timeAgo(time.Since(out.Current.StartedAt))
+		fmt.Printf("\nCurrently running: %s  started %s ago", out.Current.Corpus, age)
+		if out.Current.Progress.Total > 0 {
+			fmt.Printf("  (%d/%d)", out.Current.Progress.Done, out.Current.Progress.Total)
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("\nCurrently running: none.")
+	}
+
+	return nil
+}
+
+// timeAgo returns a human-friendly duration string.
+func timeAgo(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -331,12 +331,12 @@ index is out of date.`,
 
 // statusOutput is the JSON shape for `cspace search status --json`.
 type statusOutput struct {
-	Corpora  map[string]corpusStatusOutput `json:"corpora"`
-	Current  *status.RunningState          `json:"current"`
+	Corpora map[string]corpusStatusOutput `json:"corpora"`
+	Current *status.RunningState          `json:"current"`
 }
 
 type corpusStatusOutput struct {
-	State        string `json:"state"`                     // completed, failed, disabled, unknown
+	State        string `json:"state"` // completed, failed, disabled, unknown
 	FinishedAt   string `json:"finished_at,omitempty"`
 	DurationMS   int64  `json:"duration_ms,omitempty"`
 	IndexedCount int    `json:"indexed_count,omitempty"`

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -244,6 +245,14 @@ func runSearchIndex(corpusID string, quiet bool) error {
 	root := searchProjectRoot()
 	rt, err := config.Build(root, corpusID)
 	if err != nil {
+		// If the corpus is disabled, record that in the status file with a
+		// fresh single-use writer so we never clobber state written by prior
+		// iterations. Then return the sentinel so callers can report it.
+		if errors.Is(err, config.ErrCorpusDisabled) {
+			if sw, swErr := status.NewWriter(root); swErr == nil && sw != nil {
+				sw.DisableCorpus(corpusID)
+			}
+		}
 		return err
 	}
 	qc := qdrant.NewQdrantClient(rt.Cfg.Sidecars.QdrantURL)

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -213,9 +213,9 @@ func appendStalenessWarning(env *query.Envelope, corpusID, root string, qc *qdra
 	var err error
 	switch corpusID {
 	case "code":
-		st, err = corpus.CodeStaleness(root, collection, adapter)
+		st, err = corpus.CodeStalenessCached(root, collection, adapter)
 	case "commits":
-		st, err = corpus.CommitsStaleness(root, collection, adapter)
+		st, err = corpus.CommitsStalenessCached(root, collection, adapter)
 	default:
 		return // staleness not implemented for context/issues
 	}
@@ -397,7 +397,7 @@ func runSearchStatus(asJSON bool) error {
 			}
 		}
 
-		// Check staleness for code and commits.
+		// Check staleness for code and commits (cached to avoid per-query I/O).
 		if co.State == "completed" && (id == "code" || id == "commits") {
 			qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
 			adapter := &qdrant.Adapter{QdrantClient: qc}
@@ -405,9 +405,9 @@ func runSearchStatus(asJSON bool) error {
 			var st corpus.Staleness
 			switch id {
 			case "code":
-				st, _ = corpus.CodeStaleness(root, collection, adapter)
+				st, _ = corpus.CodeStalenessCached(root, collection, adapter)
 			case "commits":
-				st, _ = corpus.CommitsStaleness(root, collection, adapter)
+				st, _ = corpus.CommitsStalenessCached(root, collection, adapter)
 			}
 			if st.IsStale {
 				co.Stale = true

--- a/internal/cli/search_init.go
+++ b/internal/cli/search_init.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/elliottregan/cspace/search/config"
+	"github.com/elliottregan/cspace/search/status"
 	"github.com/spf13/cobra"
 )
 
@@ -82,6 +83,7 @@ func runSearchInit(opts searchInitOpts) error {
 	}
 
 	if !opts.SkipIndex {
+		sw, _ := status.NewWriter(root)
 		for _, corpusID := range []string{"code", "commits", "context", "issues"} {
 			err := runSearchIndex(corpusID, true)
 			switch {
@@ -89,6 +91,9 @@ func runSearchInit(opts searchInitOpts) error {
 				report("%s: indexed", corpusID)
 			case errors.Is(err, config.ErrCorpusDisabled):
 				report("%s: disabled in search.yaml (enable with corpora.%s.enabled=true)", corpusID, corpusID)
+				if sw != nil {
+					sw.DisableCorpus(corpusID)
+				}
 			default:
 				report("%s: skipped (%v)", corpusID, err)
 			}

--- a/internal/cli/search_init.go
+++ b/internal/cli/search_init.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 
 	"github.com/elliottregan/cspace/search/config"
-	"github.com/elliottregan/cspace/search/status"
 	"github.com/spf13/cobra"
 )
 
@@ -83,17 +82,15 @@ func runSearchInit(opts searchInitOpts) error {
 	}
 
 	if !opts.SkipIndex {
-		sw, _ := status.NewWriter(root)
 		for _, corpusID := range []string{"code", "commits", "context", "issues"} {
 			err := runSearchIndex(corpusID, true)
 			switch {
 			case err == nil:
 				report("%s: indexed", corpusID)
 			case errors.Is(err, config.ErrCorpusDisabled):
+				// runSearchIndex already wrote the disabled state with a
+				// fresh single-use writer — no outer writer needed.
 				report("%s: disabled in search.yaml (enable with corpora.%s.enabled=true)", corpusID, corpusID)
-				if sw != nil {
-					sw.DisableCorpus(corpusID)
-				}
 			default:
 				report("%s: skipped (%v)", corpusID, err)
 			}

--- a/internal/cli/search_init.go
+++ b/internal/cli/search_init.go
@@ -82,6 +82,13 @@ func runSearchInit(opts searchInitOpts) error {
 	}
 
 	if !opts.SkipIndex {
+		// Short-circuit the per-corpus loop when the project hasn't opted
+		// in — the first call into runSearchIndex would return
+		// ErrSearchDisabled four times otherwise. One clear message.
+		if cfg, err := config.Load(root); err == nil && !cfg.Enabled {
+			report("search not configured (set `enabled: true` in %s/search.yaml to activate)", root)
+			return nil
+		}
 		for _, corpusID := range []string{"code", "commits", "context", "issues"} {
 			err := runSearchIndex(corpusID, true)
 			switch {

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -155,7 +155,7 @@ func tuiNew() error {
 		fmt.Printf("Instance name: %s\n", name)
 	}
 
-	return runUpWithArgs(name, "", false, false, "", "", "", false)
+	return runUpWithArgs(name, "", false, false, "", "", "", false, false)
 }
 
 // tuiConnect shows a sub-menu for connecting to a running instance.
@@ -186,7 +186,7 @@ func tuiConnect(details []instance.Detail) error {
 	composeName := cfg.ComposeName(name)
 	switch action {
 	case tuiActionConnect:
-		return runUpWithArgs(name, "", false, false, "", "", "", false)
+		return runUpWithArgs(name, "", false, false, "", "", "", false, false)
 	case tuiActionSSH:
 		return instance.DcExecInteractive(composeName, "bash")
 	case tuiActionPorts:

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -44,6 +44,7 @@ Use --no-claude to provision the container without launching Claude.`,
 			"after its first result (the default one-shot behavior).")
 	cmd.Flags().String("base", "", "Override base branch")
 	cmd.Flags().String("teleport-from", "", "Seed the instance from a teleport session dir (internal; used by /cspace-teleport)")
+	cmd.Flags().Bool("index", false, "Bootstrap search indexes during provisioning (auto-enabled for advisors and coordinators)")
 
 	return cmd
 }
@@ -56,6 +57,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 	persistent, _ := cmd.Flags().GetBool("persistent")
 	baseOverride, _ := cmd.Flags().GetString("base")
 	teleportFrom, _ := cmd.Flags().GetString("teleport-from")
+	indexFlag, _ := cmd.Flags().GetBool("index")
 
 	// Validate flags
 	if prompt != "" && promptFile != "" {
@@ -109,12 +111,12 @@ func runUp(cmd *cobra.Command, args []string) error {
 		branch = baseOverride
 	}
 
-	return runUpWithArgs(name, branch, noClaude, verbose, prompt, promptFile, teleportFrom, persistent)
+	return runUpWithArgs(name, branch, noClaude, verbose, prompt, promptFile, teleportFrom, persistent, indexFlag)
 }
 
 // runUpWithArgs is the shared implementation for the up command, callable from
 // both the CLI handler and the TUI menu.
-func runUpWithArgs(name, branch string, noClaude, verbose bool, prompt, promptFile, teleportFrom string, persistent bool) error {
+func runUpWithArgs(name, branch string, noClaude, verbose bool, prompt, promptFile, teleportFrom string, persistent, bootstrapSearch bool) error {
 	if teleportFrom != "" {
 		return provision.TeleportRun(provision.TeleportParams{
 			Name:         name,
@@ -123,7 +125,7 @@ func runUpWithArgs(name, branch string, noClaude, verbose bool, prompt, promptFi
 		})
 	}
 
-	if err := provisionWithUI(name, branch, verbose); err != nil {
+	if err := provisionWithUI(name, branch, verbose, bootstrapSearch); err != nil {
 		return err
 	}
 
@@ -172,14 +174,15 @@ func runUpWithArgs(name, branch string, noClaude, verbose bool, prompt, promptFi
 // TTY, --verbose, and terminal size. The overlay path runs provision in a
 // goroutine while a bubbletea Program consumes a buffered event channel;
 // returns the provisioning error (if any) after the overlay exits.
-func provisionWithUI(name, branch string, verbose bool) error {
+func provisionWithUI(name, branch string, verbose, bootstrapSearch bool) error {
 	if shouldUseOverlay(verbose) {
-		return provisionWithOverlay(name, branch)
+		return provisionWithOverlay(name, branch, bootstrapSearch)
 	}
 	_, err := provision.Run(provision.Params{
-		Name:   name,
-		Branch: branch,
-		Cfg:    cfg,
+		Name:            name,
+		Branch:          branch,
+		Cfg:             cfg,
+		BootstrapSearch: bootstrapSearch,
 	})
 	return err
 }
@@ -201,7 +204,7 @@ func shouldUseOverlay(verbose bool) bool {
 	return true
 }
 
-func provisionWithOverlay(name, branch string) error {
+func provisionWithOverlay(name, branch string, bootstrapSearch bool) error {
 	events := make(chan overlay.ProvisionEvent, 16)
 	reporter := overlay.NewChannelReporter(events)
 
@@ -229,12 +232,13 @@ func provisionWithOverlay(name, branch string) error {
 	done := make(chan error, 1)
 	go func() {
 		_, err := provision.Run(provision.Params{
-			Name:     name,
-			Branch:   branch,
-			Cfg:      cfg,
-			Reporter: reporter,
-			Stdout:   io.Discard,
-			Stderr:   io.Discard,
+			Name:            name,
+			Branch:          branch,
+			Cfg:             cfg,
+			Reporter:        reporter,
+			Stdout:          io.Discard,
+			Stderr:          io.Discard,
+			BootstrapSearch: bootstrapSearch,
 		})
 		close(events)
 		done <- err

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -22,12 +22,13 @@ var nameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // Params holds everything needed to provision an instance.
 type Params struct {
-	Name     string         // Instance name (validated: alphanumeric + hyphens/underscores)
-	Branch   string         // Git branch to checkout (empty = host's current branch)
-	Cfg      *config.Config // Merged configuration
-	Reporter Reporter       // Progress reporter; nil → logReporter{}
-	Stdout   io.Writer      // Subprocess stdout; nil → os.Stdout
-	Stderr   io.Writer      // Subprocess stderr; nil → os.Stderr
+	Name            string         // Instance name (validated: alphanumeric + hyphens/underscores)
+	Branch          string         // Git branch to checkout (empty = host's current branch)
+	Cfg             *config.Config // Merged configuration
+	Reporter        Reporter       // Progress reporter; nil → logReporter{}
+	Stdout          io.Writer      // Subprocess stdout; nil → os.Stdout
+	Stderr          io.Writer      // Subprocess stderr; nil → os.Stderr
+	BootstrapSearch bool           // Run `cspace search init` during provisioning (opt-in)
 }
 
 func (p Params) reporter() Reporter {
@@ -281,18 +282,16 @@ func Run(p Params) (result Result, err error) {
 		_, _ = instance.DcExec(composeName, "git", "pull", "--ff-only", "--quiet")
 	}
 
-	// Phase 16: bootstrap semantic search. Fires `cspace search init` inside
-	// the container so the sidecars (llama-server, qdrant) are reachable on
-	// the compose network. Runs in the background — indexing all corpora
-	// can take minutes on a large repo and we don't want to block the Claude
-	// handoff. Output goes to /workspace/.cspace/search-index.log. The
-	// content-hash check in index.Run makes re-runs a near no-op when
-	// nothing has changed since the last index, so this is safe to fire on
-	// both new and reused containers.
-	reportPhase(16, Phases[15])
-	if _, err := instance.DcExec(composeName, "bash", "-c",
-		"mkdir -p /workspace/.cspace && nohup cspace search init --quiet >>/workspace/.cspace/search-index.log 2>&1 &"); err != nil {
-		reportWarn(fmt.Sprintf("search bootstrap: %v", err))
+	// Phase 16: bootstrap semantic search — opt-in. Fires only when
+	// BootstrapSearch is true (advisors, coordinators, or explicit --index).
+	// Runs `cspace search init` in the background so the Claude handoff
+	// isn't blocked. Content-hash check makes re-runs a near no-op.
+	if p.BootstrapSearch {
+		reportPhase(16, Phases[15])
+		if _, err := instance.DcExec(composeName, "bash", "-c",
+			"mkdir -p /workspace/.cspace && nohup cspace search init --quiet >>/workspace/.cspace/search-index.log 2>&1 &"); err != nil {
+			reportWarn(fmt.Sprintf("search bootstrap: %v", err))
+		}
 	}
 
 	return Result{Created: created, Name: name}, nil

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -61,6 +61,32 @@ func TestGitRemoteURL(t *testing.T) {
 	}
 }
 
+// TestBootstrapSearchParam verifies that the BootstrapSearch field controls
+// whether Phase 16 would fire. We can't run provision.Run in a unit test
+// (it needs Docker), but we can verify the Params field exists and the
+// Phases list still has the correct count.
+func TestBootstrapSearchParam(t *testing.T) {
+	// Verify Phases has 16 entries (search bootstrap is the last one).
+	if len(Phases) != 16 {
+		t.Errorf("expected 16 provision phases, got %d", len(Phases))
+	}
+	if Phases[15] != "Bootstrapping search" {
+		t.Errorf("expected phase 16 to be 'Bootstrapping search', got %q", Phases[15])
+	}
+
+	// Verify default Params has BootstrapSearch=false (opt-in).
+	p := Params{Name: "test"}
+	if p.BootstrapSearch {
+		t.Error("expected BootstrapSearch to default to false")
+	}
+
+	// Verify it can be set to true (advisors/coordinators).
+	p.BootstrapSearch = true
+	if !p.BootstrapSearch {
+		t.Error("expected BootstrapSearch=true after setting")
+	}
+}
+
 func TestEnsureTeleportDir(t *testing.T) {
 	tmp := t.TempDir()
 	dir := filepath.Join(tmp, "teleport")

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,27 +22,3 @@ pre-push:
       run: golangci-lint run ./...
     test:
       run: go test ./...
-
-post-commit:
-  commands:
-    search-index:
-      run: |
-        if [ -x ./bin/cspace-search ]; then
-          ( ./bin/cspace-search index --corpus=code --quiet >> .cspace/search-index.log 2>&1 & )
-        fi
-
-post-checkout:
-  commands:
-    search-index:
-      run: |
-        if [ -x ./bin/cspace-search ]; then
-          ( ./bin/cspace-search index --corpus=code --quiet >> .cspace/search-index.log 2>&1 & )
-        fi
-
-post-merge:
-  commands:
-    search-index:
-      run: |
-        if [ -x ./bin/cspace-search ]; then
-          ( ./bin/cspace-search index --corpus=code --quiet >> .cspace/search-index.log 2>&1 & )
-        fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,4 +1,4 @@
-rc: export PATH="$HOME/go/bin:$PATH"
+rc: .lefthookrc
 
 pre-commit:
   parallel: true
@@ -9,7 +9,10 @@ pre-commit:
       stage_fixed: true
     lint-go:
       glob: "*.go"
-      run: golangci-lint run --new-from-rev=HEAD~1 ./...
+      run: golangci-lint run ./...
+    vet-go:
+      glob: "*.go"
+      run: go vet ./...
     lint-shell:
       glob: "*.sh"
       exclude: "lib/scripts/statusline.sh"

--- a/lib/agents/coordinator.md
+++ b/lib/agents/coordinator.md
@@ -172,6 +172,8 @@ If `read_context` is unavailable (tool not registered), substitute `${STRATEGIC_
 cspace up issue-$N --base $BASE --prompt-file /tmp/implementer-$N.txt --persistent
 ```
 
+Use descriptive or numbered names (`issue-<n>`, `cs-agent-<n>`, or short task labels). Planet names (`mercury`, `venus`, …) are reserved for the human-facing TUI.
+
 Use `run_in_background: true` with a 60-minute timeout. Launch all ready agents in a **single message** with multiple Bash tool calls.
 
 **Each `cspace up` call is a blocking streaming command.** It does not return until the agent exits, and its combined stdout+stderr emits the agent's entire event stream as it happens (thinking, tool calls, tool results, final result). With `run_in_background: true`, that whole stream accumulates in the Bash call's BashOutput and is what you read to monitor the agent — exactly like watching a foreground `cspace up` in a terminal. Save the background task ID for each agent; you'll need it to read BashOutput in Phase 3.

--- a/lib/skills/delegating-container-agents/SKILL.md
+++ b/lib/skills/delegating-container-agents/SKILL.md
@@ -78,11 +78,12 @@ directly against the named instance.
 cat > /tmp/work-prompt.txt <<'EOF'
 Implement the change described above. Commit and push when done.
 EOF
-cspace up mars --prompt-file /tmp/work-prompt.txt
+cspace up session-validate --prompt-file /tmp/work-prompt.txt
 ```
 
-If you omit the name, the next free planet name is auto-assigned (`mercury`,
-`venus`, `earth`, `mars`, …).
+When spawning a cspace instance from an agent, use a descriptive or numbered
+name (`issue-<n>`, `cs-agent-<n>`, or a short task label like `review-fixes`).
+Planet names (`mercury`, `venus`, …) are reserved for the human-facing TUI.
 
 ### `cspace coordinate "<instructions>"` — multi-chunk coordinated work
 
@@ -139,7 +140,7 @@ The existing code is in $CONVEX_DIR — leave it alone and create a new
 helper. Add tests for the "empty token" and "wrong length" cases.
 PROMPT
 
-cspace up mars --prompt-file /tmp/delegate-prompt.txt
+cspace up token-validate --prompt-file /tmp/delegate-prompt.txt
 ```
 
 The `<<'PROMPT'` (single-quoted heredoc tag) prevents the shell from
@@ -176,8 +177,8 @@ All of these route through the supervisor sockets. Same quoting rules apply
 
 ## Cleanup
 
-Containers persist by design — you can reattach to the same `mars` later
-with `cspace up mars` (without `--prompt-file`) or `cspace ssh mars`. When
+Containers persist by design — you can reattach to the same instance later
+with `cspace up <name>` (without `--prompt-file`) or `cspace ssh <name>`. When
 a batch is genuinely done:
 
 ```bash

--- a/lib/skills/using-semantic-search/SKILL.md
+++ b/lib/skills/using-semantic-search/SKILL.md
@@ -137,10 +137,34 @@ When existing code surprises you:
 
 ## Index freshness
 
-Indexes auto-refresh on `post-commit`, `post-checkout`, and `post-merge`
-lefthook hooks (if lefthook is installed for the project). If you suspect
-the index is stale — e.g. you just pulled a large change and the tool
-surfaces gone files — run:
+Indexes do **not** auto-refresh. There are no post-commit hooks. The
+index is built once at provisioning time (`cspace search init`) and
+updated only when you explicitly run `cspace search <corpus> index`.
+
+### Before high-stakes queries
+
+Run `cspace search status` (CLI) or use the `search_status` MCP tool.
+It reports per-corpus state and whether the index is stale:
+
+```
+$ cspace search status
+code      completed 12m ago   (1043 chunks indexed) — STALE: 17 files changed since last index
+commits   completed 12m ago   (197 commits indexed) — up to date
+context   disabled (enable with corpora.context.enabled=true in search.yaml)
+issues    disabled (enable with corpora.issues.enabled=true in search.yaml)
+
+Currently running: none.
+```
+
+### Decision tree
+
+- **STALE** and your answer depends on current code state? Reindex first:
+  `cspace search code index` (or `commits`, etc.)
+- **running**? Proceed with awareness that results may be partial, or wait.
+- **failed**? Surface the error, reindex before trusting results.
+- **completed + up to date**? Query freely.
+
+### Reindex commands
 
 ```
 cspace search code index

--- a/lib/skills/using-semantic-search/SKILL.md
+++ b/lib/skills/using-semantic-search/SKILL.md
@@ -137,9 +137,11 @@ When existing code surprises you:
 
 ## Index freshness
 
-Indexes do **not** auto-refresh. There are no post-commit hooks. The
-index is built once at provisioning time (`cspace search init`) and
-updated only when you explicitly run `cspace search <corpus> index`.
+Indexes do **not** auto-refresh. There are no post-commit hooks. Search
+bootstrap at provisioning time is opt-in: advisors and coordinators get
+it automatically; other roles must run `cspace search init` explicitly
+or pass `--index` to `cspace up`. Once built, update with
+`cspace search <corpus> index`.
 
 ### Before high-stakes queries
 

--- a/search/config/config.go
+++ b/search/config/config.go
@@ -14,6 +14,12 @@ var defaultYAML []byte
 
 // Config is the top-level config shape.
 type Config struct {
+	// Enabled is the master switch for semantic search in this project.
+	// Must be set to true explicitly in search.yaml; otherwise every search
+	// CLI + MCP + bootstrap path fast-exits with ErrSearchDisabled.
+	// Prevents "I just cloned a repo with cspace baked in and now it's
+	// indexing node_modules on first container boot."
+	Enabled  bool                    `yaml:"enabled"`
 	Corpora  map[string]CorpusConfig `yaml:"corpora"`
 	Sidecars Sidecars                `yaml:"sidecars"`
 	Index    IndexConfig             `yaml:"index"`

--- a/search/config/config_test.go
+++ b/search/config/config_test.go
@@ -13,6 +13,11 @@ func TestLoad_Defaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
+	// Master switch must default to OFF so a fresh cspace project doesn't
+	// auto-index node_modules on first bootstrap.
+	if c.Enabled {
+		t.Errorf("expected top-level Enabled=false by default, got true")
+	}
 	if c.Corpora["code"].MaxBytes != 204800 {
 		t.Errorf("expected MaxBytes 204800, got %d", c.Corpora["code"].MaxBytes)
 	}
@@ -23,10 +28,10 @@ func TestLoad_Defaults(t *testing.T) {
 		t.Errorf("expected LockPath default")
 	}
 	if !c.Corpora["code"].Enabled {
-		t.Errorf("expected code corpus enabled by default")
+		t.Errorf("expected code corpus enabled by default (once search master switch is on)")
 	}
 	if !c.Corpora["commits"].Enabled {
-		t.Errorf("expected commits corpus enabled by default")
+		t.Errorf("expected commits corpus enabled by default (once search master switch is on)")
 	}
 	if c.Corpora["context"].Enabled {
 		t.Errorf("expected context corpus DISABLED by default")
@@ -66,6 +71,32 @@ corpora:
 	}
 }
 
+// Flipping the top-level `enabled:` switch is the documented project
+// opt-in — master switch activates search without touching per-corpus
+// flags, and per-corpus defaults (code+commits on) still apply.
+func TestLoad_MasterSwitchOptIn(t *testing.T) {
+	dir := t.TempDir()
+	override := []byte(`
+enabled: true
+`)
+	if err := os.WriteFile(filepath.Join(dir, "search.yaml"), override, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !c.Enabled {
+		t.Errorf("expected top-level Enabled=true after override")
+	}
+	if !c.Corpora["code"].Enabled {
+		t.Errorf("expected code corpus enabled (default survives master-switch override)")
+	}
+	if c.Corpora["issues"].Enabled {
+		t.Errorf("expected issues corpus still disabled by default")
+	}
+}
+
 // Flipping a disabled-by-default corpus back on via search.yaml must be
 // effective — this is the documented opt-in path for issues and context.
 func TestLoad_OptInDisabledCorpus(t *testing.T) {
@@ -90,26 +121,34 @@ corpora:
 	}
 }
 
-func TestBuildWithConfig_DisabledCorpusReturnsSentinel(t *testing.T) {
+// With the master switch off (default), no corpus can be built — even
+// code/commits which are per-corpus-enabled. Single-point gate.
+func TestBuildWithConfig_SearchDisabledBlocksEverything(t *testing.T) {
 	dir := t.TempDir()
-	cfg, err := Load(dir) // defaults: issues + context disabled
+	cfg, err := Load(dir)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	for _, id := range []string{"issues", "context"} {
+	for _, id := range []string{"code", "commits", "context", "issues"} {
 		rt, err := BuildWithConfig(dir, id, cfg)
 		if err == nil {
-			t.Errorf("%s: expected error, got runtime %+v", id, rt)
+			t.Errorf("%s: expected error with master switch off, got runtime %+v", id, rt)
 			continue
 		}
-		if !errors.Is(err, ErrCorpusDisabled) {
-			t.Errorf("%s: expected ErrCorpusDisabled, got %v", id, err)
+		if !errors.Is(err, ErrSearchDisabled) {
+			t.Errorf("%s: expected ErrSearchDisabled, got %v", id, err)
 		}
 	}
 }
 
-func TestBuildWithConfig_EnabledCorpusBuildsOK(t *testing.T) {
+// Once the master switch is on, per-corpus enable/disable takes over.
+// Default corpus set: code+commits build, context+issues return
+// ErrCorpusDisabled.
+func TestBuildWithConfig_PerCorpusAfterMasterSwitch(t *testing.T) {
 	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "search.yaml"), []byte("enabled: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := Load(dir)
 	if err != nil {
 		t.Fatalf("load: %v", err)
@@ -122,6 +161,16 @@ func TestBuildWithConfig_EnabledCorpusBuildsOK(t *testing.T) {
 		}
 		if rt == nil || rt.Corpus == nil {
 			t.Errorf("%s: expected non-nil runtime + corpus", id)
+		}
+	}
+	for _, id := range []string{"context", "issues"} {
+		_, err := BuildWithConfig(dir, id, cfg)
+		if err == nil {
+			t.Errorf("%s: expected ErrCorpusDisabled, got nil", id)
+			continue
+		}
+		if !errors.Is(err, ErrCorpusDisabled) {
+			t.Errorf("%s: expected ErrCorpusDisabled, got %v", id, err)
 		}
 	}
 }

--- a/search/config/default.yaml
+++ b/search/config/default.yaml
@@ -1,5 +1,12 @@
 # Default corpus configuration for cspace-search.
 # Projects override by placing a search.yaml at the project root.
+#
+# Master switch: search is off by default. Projects opt in by setting
+# `enabled: true` in their own search.yaml. Without that, every search
+# CLI + MCP + bootstrap path fast-exits without touching qdrant or llama.
+# Prevents newly-cloned cspace projects from auto-indexing node_modules
+# on first container boot.
+enabled: false
 corpora:
   code:
     enabled: true

--- a/search/config/init_template.yaml
+++ b/search/config/init_template.yaml
@@ -4,7 +4,15 @@
 # Uncomment and edit what you need. See the embedded default.yaml in the
 # cspace-search binary for the full schema.
 #
-# Corpus defaults:
+# -----------------------------------------------------------------------
+# Master switch. Search is OFF by default so a fresh cspace project
+# doesn't incidentally start indexing (e.g. pulling in node_modules).
+# Flip this to `true` when you want agents and CLIs in this project to
+# actually build indexes and run queries.
+enabled: false
+# -----------------------------------------------------------------------
+#
+# Corpus defaults (only relevant once `enabled: true` above):
 #   code     — enabled  (source of truth for "where does X happen?")
 #   commits  — enabled  (git history; "how did it get here?")
 #   context  — DISABLED (.cspace/context/ files are usually small enough

--- a/search/config/runtime.go
+++ b/search/config/runtime.go
@@ -14,6 +14,13 @@ import (
 // "disabled" vs "skipped" differently.
 var ErrCorpusDisabled = errors.New("corpus disabled in search.yaml")
 
+// ErrSearchDisabled signals that semantic search is not activated for
+// this project (top-level `enabled:` is false in search.yaml, or there
+// is no search.yaml). Supersedes ErrCorpusDisabled: if search is off at
+// the project level, no individual corpus is checked. Keeps fresh
+// cspace projects from incidentally indexing node_modules on first boot.
+var ErrSearchDisabled = errors.New("search not configured for this project")
+
 // Runtime bundles a loaded config and a chosen Corpus for one command run.
 type Runtime struct {
 	Cfg    *Config
@@ -31,11 +38,16 @@ func Build(projectRoot, corpusID string) (*Runtime, error) {
 
 // BuildWithConfig instantiates a Runtime using an already-loaded *Config,
 // avoiding a redundant disk read when the caller already holds the config.
-// Returns ErrCorpusDisabled (wrapped with the corpus id) when the named
-// corpus has corpora.<id>.enabled=false — intercepted at this single
-// chokepoint so every caller (CLI queries, init loops, MCP tools) refuses
-// the operation with one consistent, actionable error.
+// Returns ErrSearchDisabled when the project hasn't opted in via top-level
+// `enabled: true` in search.yaml; otherwise returns ErrCorpusDisabled
+// (wrapped with the corpus id) when the named corpus has
+// corpora.<id>.enabled=false. Single chokepoint so every caller (CLI
+// queries, init loops, MCP tools, phase-16 bootstrap) refuses the
+// operation with one consistent, actionable error.
 func BuildWithConfig(projectRoot, corpusID string, cfg *Config) (*Runtime, error) {
+	if !cfg.Enabled {
+		return nil, fmt.Errorf("%w (set `enabled: true` in %s/search.yaml to activate)", ErrSearchDisabled, projectRoot)
+	}
 	if cc, ok := cfg.Corpora[corpusID]; ok && !cc.Enabled {
 		return nil, fmt.Errorf("%q: %w (set corpora.%s.enabled=true in search.yaml to enable)", corpusID, ErrCorpusDisabled, corpusID)
 	}

--- a/search/corpus/staleness.go
+++ b/search/corpus/staleness.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -58,7 +59,7 @@ func CodeStaleness(projectRoot string, collection string, lister PointLister) (S
 
 	// Walk git ls-files and compute sha256 for each tracked file, counting
 	// files whose hash is not in the index.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", "-C", projectRoot, "ls-files")
@@ -163,6 +164,73 @@ func CommitsStaleness(projectRoot string, collection string, lister PointLister)
 		IsStale: true,
 		Reason:  "HEAD commit is not in the index",
 	}, nil
+}
+
+// --------------- staleness cache ---------------
+//
+// Staleness checks run git I/O + qdrant scrolls that cost 100-500ms. Caching
+// the result for a short TTL avoids paying that cost on every MCP query while
+// keeping the signal fresh enough for advisory use.
+
+// StalenessCache TTL — configurable for tests via CacheTTL.
+var CacheTTL = 30 * time.Second
+
+type cachedStaleness struct {
+	at  time.Time
+	st  Staleness
+	err error
+}
+
+var (
+	staleCache = map[string]cachedStaleness{}
+	staleMu    sync.Mutex
+)
+
+func staleCacheKey(corpus, projectRoot string) string {
+	return corpus + "\x00" + projectRoot
+}
+
+// CodeStalenessCached wraps CodeStaleness with an in-process cache (TTL = CacheTTL).
+func CodeStalenessCached(projectRoot, collection string, lister PointLister) (Staleness, error) {
+	key := staleCacheKey("code", projectRoot)
+	staleMu.Lock()
+	if c, ok := staleCache[key]; ok && time.Since(c.at) < CacheTTL {
+		staleMu.Unlock()
+		return c.st, c.err
+	}
+	staleMu.Unlock()
+
+	st, err := CodeStaleness(projectRoot, collection, lister)
+
+	staleMu.Lock()
+	staleCache[key] = cachedStaleness{at: time.Now(), st: st, err: err}
+	staleMu.Unlock()
+	return st, err
+}
+
+// CommitsStalenessCached wraps CommitsStaleness with an in-process cache (TTL = CacheTTL).
+func CommitsStalenessCached(projectRoot, collection string, lister PointLister) (Staleness, error) {
+	key := staleCacheKey("commits", projectRoot)
+	staleMu.Lock()
+	if c, ok := staleCache[key]; ok && time.Since(c.at) < CacheTTL {
+		staleMu.Unlock()
+		return c.st, c.err
+	}
+	staleMu.Unlock()
+
+	st, err := CommitsStaleness(projectRoot, collection, lister)
+
+	staleMu.Lock()
+	staleCache[key] = cachedStaleness{at: time.Now(), st: st, err: err}
+	staleMu.Unlock()
+	return st, err
+}
+
+// ResetStalenessCache clears the cache. Exported for tests.
+func ResetStalenessCache() {
+	staleMu.Lock()
+	staleCache = map[string]cachedStaleness{}
+	staleMu.Unlock()
 }
 
 // gitOutput runs a git command and returns its stdout as a string.

--- a/search/corpus/staleness.go
+++ b/search/corpus/staleness.go
@@ -38,7 +38,8 @@ type MaxDateLister interface {
 }
 
 // CodeStaleness compares `git ls-files` content hashes against the indexed
-// hashes in qdrant. O(tracked-files) — typically sub-second.
+// hashes in qdrant. Detects both changed/new files (tracked but not indexed)
+// and ghost entries (indexed but no longer tracked). O(tracked-files).
 func CodeStaleness(projectRoot string, collection string, lister PointLister) (Staleness, error) {
 	existing, err := lister.ExistingPoints(collection)
 	if err != nil {
@@ -49,16 +50,17 @@ func CodeStaleness(projectRoot string, collection string, lister PointLister) (S
 		return Staleness{IsStale: true, Reason: "index is empty — never indexed"}, nil
 	}
 
-	// Build a set of content_hash values that exist in qdrant.
-	indexedHashes := make(map[string]struct{}, len(existing))
+	// Build a set of content_hash values that exist in qdrant, tracking which
+	// ones are "seen" during the git walk so we can count ghosts afterward.
+	indexedHashes := make(map[string]bool, len(existing)) // hash -> seen
 	for _, h := range existing {
 		if h != "" {
-			indexedHashes[h] = struct{}{}
+			indexedHashes[h] = false // not seen yet
 		}
 	}
 
 	// Walk git ls-files and compute sha256 for each tracked file, counting
-	// files whose hash is not in the index.
+	// files whose hash is not in the index and marking indexed hashes as seen.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -82,17 +84,35 @@ func CodeStaleness(projectRoot string, collection string, lister PointLister) (S
 			continue // deleted/unreadable — skip
 		}
 		hash := fmt.Sprintf("%x", sha256.Sum256(data))
-		if _, ok := indexedHashes[hash]; !ok {
+		if _, ok := indexedHashes[hash]; ok {
+			indexedHashes[hash] = true // mark as seen
+		} else {
 			changed++
 		}
 	}
 	_ = sc.Err()
 	_ = cmd.Wait()
 
-	if changed > 0 {
+	// Count ghost entries: indexed hashes that were never seen in the git walk
+	// (files deleted or renamed since the last index).
+	ghosts := 0
+	for _, seen := range indexedHashes {
+		if !seen {
+			ghosts++
+		}
+	}
+
+	if changed > 0 || ghosts > 0 {
+		var parts []string
+		if changed > 0 {
+			parts = append(parts, fmt.Sprintf("%d files changed", changed))
+		}
+		if ghosts > 0 {
+			parts = append(parts, fmt.Sprintf("%d deleted since last index", ghosts))
+		}
 		return Staleness{
 			IsStale: true,
-			Reason:  fmt.Sprintf("%d files changed since last index", changed),
+			Reason:  strings.Join(parts, ", "),
 		}, nil
 	}
 	return Staleness{IsStale: false}, nil

--- a/search/corpus/staleness.go
+++ b/search/corpus/staleness.go
@@ -1,0 +1,148 @@
+package corpus
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Staleness reports whether the index for one corpus is current relative
+// to the git repo. Cheap: compares payload hashes and commit timestamps
+// already stored in qdrant rather than re-embedding.
+type Staleness struct {
+	IsStale       bool      `json:"is_stale"`
+	Reason        string    `json:"reason,omitempty"`
+	LastIndexedAt time.Time `json:"last_indexed_at,omitempty"`
+}
+
+// PointLister can scroll a qdrant collection and return id -> content_hash
+// or id -> payload maps. Satisfied by *qdrant.QdrantClient (via adapter)
+// without importing the qdrant package directly.
+type PointLister interface {
+	ExistingPoints(collection string) (map[uint64]string, error) // id -> content_hash
+}
+
+// CodeStaleness compares `git ls-files` content hashes against the indexed
+// hashes in qdrant. O(tracked-files) — typically sub-second.
+func CodeStaleness(projectRoot string, collection string, lister PointLister) (Staleness, error) {
+	existing, err := lister.ExistingPoints(collection)
+	if err != nil {
+		return Staleness{}, fmt.Errorf("reading existing points: %w", err)
+	}
+	// If the collection is empty, the index has never run.
+	if len(existing) == 0 {
+		return Staleness{IsStale: true, Reason: "index is empty — never indexed"}, nil
+	}
+
+	// Build a set of content_hash values that exist in qdrant.
+	indexedHashes := make(map[string]struct{}, len(existing))
+	for _, h := range existing {
+		if h != "" {
+			indexedHashes[h] = struct{}{}
+		}
+	}
+
+	// Walk git ls-files and compute sha256 for each tracked file, counting
+	// files whose hash is not in the index.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "-C", projectRoot, "ls-files")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return Staleness{}, fmt.Errorf("git ls-files pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return Staleness{}, fmt.Errorf("git ls-files start: %w", err)
+	}
+
+	changed := 0
+	sc := bufio.NewScanner(stdout)
+	sc.Buffer(make([]byte, 64*1024), 1024*1024)
+	for sc.Scan() {
+		rel := sc.Text()
+		abs := filepath.Join(projectRoot, rel)
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			continue // deleted/unreadable — skip
+		}
+		hash := fmt.Sprintf("%x", sha256.Sum256(data))
+		if _, ok := indexedHashes[hash]; !ok {
+			changed++
+		}
+	}
+	_ = sc.Err()
+	_ = cmd.Wait()
+
+	if changed > 0 {
+		return Staleness{
+			IsStale: true,
+			Reason:  fmt.Sprintf("%d files changed since last index", changed),
+		}, nil
+	}
+	return Staleness{IsStale: false}, nil
+}
+
+// CommitsStaleness compares the current HEAD commit against the latest
+// indexed commit date in qdrant. Cheap: one git log call + one qdrant
+// scroll for max date.
+func CommitsStaleness(projectRoot string, collection string, lister PointLister) (Staleness, error) {
+	existing, err := lister.ExistingPoints(collection)
+	if err != nil {
+		return Staleness{}, fmt.Errorf("reading existing points: %w", err)
+	}
+	if len(existing) == 0 {
+		return Staleness{IsStale: true, Reason: "index is empty — never indexed"}, nil
+	}
+
+	// Get current HEAD hash.
+	headHash, err := gitOutput(projectRoot, "rev-parse", "HEAD")
+	if err != nil {
+		return Staleness{}, fmt.Errorf("git rev-parse HEAD: %w", err)
+	}
+	headHash = strings.TrimSpace(headHash)
+
+	// Count commits since the indexed set. We check whether HEAD's hash
+	// exists among indexed content_hashes (commit hashes are stored in
+	// the "path" field, but content_hash is not set for commits — so we
+	// use a different approach: count total commits and compare to indexed).
+	countStr, err := gitOutput(projectRoot, "rev-list", "--count", "HEAD")
+	if err != nil {
+		return Staleness{}, fmt.Errorf("git rev-list --count: %w", err)
+	}
+	countStr = strings.TrimSpace(countStr)
+
+	// The indexed set has N points; the repo has M commits. If M > N,
+	// there are new commits.
+	indexedCount := len(existing)
+	var repoCount int
+	if _, err := fmt.Sscanf(countStr, "%d", &repoCount); err != nil {
+		return Staleness{}, fmt.Errorf("parsing commit count: %w", err)
+	}
+
+	diff := repoCount - indexedCount
+	if diff > 0 {
+		return Staleness{
+			IsStale: true,
+			Reason:  fmt.Sprintf("%d new commits since last index", diff),
+		}, nil
+	}
+	return Staleness{IsStale: false}, nil
+}
+
+// gitOutput runs a git command and returns its stdout as a string.
+func gitOutput(repoPath string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoPath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/search/corpus/staleness.go
+++ b/search/corpus/staleness.go
@@ -101,13 +101,6 @@ func CommitsStaleness(projectRoot string, collection string, lister PointLister)
 		return Staleness{IsStale: true, Reason: "index is empty — never indexed"}, nil
 	}
 
-	// Get current HEAD hash.
-	headHash, err := gitOutput(projectRoot, "rev-parse", "HEAD")
-	if err != nil {
-		return Staleness{}, fmt.Errorf("git rev-parse HEAD: %w", err)
-	}
-	headHash = strings.TrimSpace(headHash)
-
 	// Count commits since the indexed set. We check whether HEAD's hash
 	// exists among indexed content_hashes (commit hashes are stored in
 	// the "path" field, but content_hash is not set for commits — so we

--- a/search/corpus/staleness.go
+++ b/search/corpus/staleness.go
@@ -28,6 +28,14 @@ type PointLister interface {
 	ExistingPoints(collection string) (map[uint64]string, error) // id -> content_hash
 }
 
+// MaxDateLister extends PointLister with the ability to retrieve the maximum
+// "date" payload field from a collection. Used by CommitsStaleness to compare
+// HEAD's commit date against the latest indexed commit, avoiding the false-
+// positive caused by comparing raw counts under a commits.limit.
+type MaxDateLister interface {
+	MaxPayloadDate(collection string) (string, error) // "2006-01-02" or ""
+}
+
 // CodeStaleness compares `git ls-files` content hashes against the indexed
 // hashes in qdrant. O(tracked-files) — typically sub-second.
 func CodeStaleness(projectRoot string, collection string, lister PointLister) (Staleness, error) {
@@ -89,9 +97,9 @@ func CodeStaleness(projectRoot string, collection string, lister PointLister) (S
 	return Staleness{IsStale: false}, nil
 }
 
-// CommitsStaleness compares the current HEAD commit against the latest
-// indexed commit date in qdrant. Cheap: one git log call + one qdrant
-// scroll for max date.
+// CommitsStaleness compares HEAD's commit date against the latest indexed
+// commit date in qdrant. Uses date identity (not count) so repos with more
+// commits than commits.limit don't produce permanent false-positive warnings.
 func CommitsStaleness(projectRoot string, collection string, lister PointLister) (Staleness, error) {
 	existing, err := lister.ExistingPoints(collection)
 	if err != nil {
@@ -101,32 +109,60 @@ func CommitsStaleness(projectRoot string, collection string, lister PointLister)
 		return Staleness{IsStale: true, Reason: "index is empty — never indexed"}, nil
 	}
 
-	// Count commits since the indexed set. We check whether HEAD's hash
-	// exists among indexed content_hashes (commit hashes are stored in
-	// the "path" field, but content_hash is not set for commits — so we
-	// use a different approach: count total commits and compare to indexed).
-	countStr, err := gitOutput(projectRoot, "rev-list", "--count", "HEAD")
+	// Get HEAD's commit date.
+	headDate, err := gitOutput(projectRoot, "log", "-1", "--format=%aI", "HEAD")
 	if err != nil {
-		return Staleness{}, fmt.Errorf("git rev-list --count: %w", err)
+		return Staleness{}, fmt.Errorf("git log HEAD date: %w", err)
 	}
-	countStr = strings.TrimSpace(countStr)
-
-	// The indexed set has N points; the repo has M commits. If M > N,
-	// there are new commits.
-	indexedCount := len(existing)
-	var repoCount int
-	if _, err := fmt.Sscanf(countStr, "%d", &repoCount); err != nil {
-		return Staleness{}, fmt.Errorf("parsing commit count: %w", err)
+	headDate = strings.TrimSpace(headDate)
+	headTime, err := time.Parse(time.RFC3339, headDate)
+	if err != nil {
+		return Staleness{}, fmt.Errorf("parsing HEAD date %q: %w", headDate, err)
 	}
 
-	diff := repoCount - indexedCount
-	if diff > 0 {
-		return Staleness{
-			IsStale: true,
-			Reason:  fmt.Sprintf("%d new commits since last index", diff),
-		}, nil
+	// Get the max indexed commit date. If the lister supports MaxDateLister,
+	// use it for a single-pass scroll; otherwise fall back to counting (which
+	// is wrong under limits but at least gives something).
+	if dl, ok := lister.(MaxDateLister); ok {
+		maxDate, err := dl.MaxPayloadDate(collection)
+		if err != nil {
+			return Staleness{}, fmt.Errorf("max payload date: %w", err)
+		}
+		if maxDate == "" {
+			return Staleness{IsStale: true, Reason: "no indexed commit dates found"}, nil
+		}
+		maxTime, err := time.Parse("2006-01-02", maxDate)
+		if err != nil {
+			return Staleness{}, fmt.Errorf("parsing max indexed date %q: %w", maxDate, err)
+		}
+		// Truncate HEAD to date precision to match the indexed format.
+		headDay := headTime.Truncate(24 * time.Hour)
+		maxDay := maxTime.Truncate(24 * time.Hour)
+		if headDay.After(maxDay) {
+			return Staleness{
+				IsStale: true,
+				Reason:  fmt.Sprintf("HEAD (%s) is newer than latest indexed commit (%s)", headDay.Format("2006-01-02"), maxDate),
+			}, nil
+		}
+		return Staleness{IsStale: false}, nil
 	}
-	return Staleness{IsStale: false}, nil
+
+	// Fallback for listers that don't support MaxDateLister: compare HEAD's
+	// commit hash against the indexed set via point ID lookup.
+	headHash, err := gitOutput(projectRoot, "rev-parse", "HEAD")
+	if err != nil {
+		return Staleness{}, fmt.Errorf("git rev-parse HEAD: %w", err)
+	}
+	headHash = strings.TrimSpace(headHash)
+	headRec := Record{Path: headHash, Kind: "commit"}
+	headID := headRec.ID()
+	if _, ok := existing[headID]; ok {
+		return Staleness{IsStale: false}, nil
+	}
+	return Staleness{
+		IsStale: true,
+		Reason:  "HEAD commit is not in the index",
+	}, nil
 }
 
 // gitOutput runs a git command and returns its stdout as a string.

--- a/search/corpus/staleness_test.go
+++ b/search/corpus/staleness_test.go
@@ -1,0 +1,168 @@
+package corpus
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakePointLister implements PointLister for tests.
+type fakePointLister struct {
+	points map[uint64]string // id -> content_hash
+}
+
+func (f *fakePointLister) ExistingPoints(_ string) (map[uint64]string, error) {
+	return f.points, nil
+}
+
+// initGitRepo creates a temp dir with a git repo containing the given files.
+func initGitRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	for name, content := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func hashOf(content string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(content)))
+}
+
+func TestCodeStaleness_EmptyIndex(t *testing.T) {
+	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
+	lister := &fakePointLister{points: map[uint64]string{}}
+
+	st, err := CodeStaleness(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.IsStale {
+		t.Error("expected stale for empty index")
+	}
+	if !strings.Contains(st.Reason, "never indexed") {
+		t.Errorf("unexpected reason: %s", st.Reason)
+	}
+}
+
+func TestCodeStaleness_UpToDate(t *testing.T) {
+	content := "package main"
+	dir := initGitRepo(t, map[string]string{"main.go": content})
+
+	// Simulate an index that has the file's hash.
+	lister := &fakePointLister{points: map[uint64]string{
+		1: hashOf(content),
+	}}
+
+	st, err := CodeStaleness(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.IsStale {
+		t.Errorf("expected not stale, got reason: %s", st.Reason)
+	}
+}
+
+func TestCodeStaleness_FilesChanged(t *testing.T) {
+	dir := initGitRepo(t, map[string]string{
+		"a.go": "package a",
+		"b.go": "package b",
+	})
+
+	// Index only knows about a.go's hash — b.go's hash is missing.
+	lister := &fakePointLister{points: map[uint64]string{
+		1: hashOf("package a"),
+	}}
+
+	st, err := CodeStaleness(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.IsStale {
+		t.Error("expected stale")
+	}
+	if !strings.Contains(st.Reason, "files changed") {
+		t.Errorf("unexpected reason: %s", st.Reason)
+	}
+}
+
+func TestCommitsStaleness_EmptyIndex(t *testing.T) {
+	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
+	lister := &fakePointLister{points: map[uint64]string{}}
+
+	st, err := CommitsStaleness(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.IsStale {
+		t.Error("expected stale for empty index")
+	}
+}
+
+func TestCommitsStaleness_UpToDate(t *testing.T) {
+	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
+
+	// One commit in repo, one point in index.
+	lister := &fakePointLister{points: map[uint64]string{
+		1: "",
+	}}
+
+	st, err := CommitsStaleness(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.IsStale {
+		t.Errorf("expected not stale, got reason: %s", st.Reason)
+	}
+}
+
+func TestCommitsStaleness_NewCommits(t *testing.T) {
+	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
+	// Add a second commit.
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n// v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-m", "second")
+
+	// Index only knows about one commit.
+	lister := &fakePointLister{points: map[uint64]string{
+		1: "",
+	}}
+
+	st, err := CommitsStaleness(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.IsStale {
+		t.Error("expected stale")
+	}
+	if !strings.Contains(st.Reason, "new commits") {
+		t.Errorf("unexpected reason: %s", st.Reason)
+	}
+}

--- a/search/corpus/staleness_test.go
+++ b/search/corpus/staleness_test.go
@@ -128,6 +128,42 @@ func TestCodeStaleness_FilesChanged(t *testing.T) {
 	}
 }
 
+// TestCodeStaleness_DeletedFiles verifies that CodeStaleness detects
+// "ghost" entries: files that are still in the index but no longer tracked
+// in git (deleted since last index). PR #61 review item #4.
+func TestCodeStaleness_DeletedFiles(t *testing.T) {
+	dir := initGitRepo(t, map[string]string{
+		"a.go": "package a",
+		"b.go": "package b",
+		"c.go": "package c",
+	})
+
+	// Index has hashes for all three files.
+	lister := &fakePointLister{points: map[uint64]string{
+		1: hashOf("package a"),
+		2: hashOf("package b"),
+		3: hashOf("package c"),
+	}}
+
+	// Delete c.go and commit.
+	if err := os.Remove(filepath.Join(dir, "c.go")); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-m", "delete c.go")
+
+	st, err := CodeStaleness(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.IsStale {
+		t.Error("expected stale after file deletion")
+	}
+	if !strings.Contains(st.Reason, "deleted") {
+		t.Errorf("expected deletion-aware reason, got: %s", st.Reason)
+	}
+}
+
 func TestCommitsStaleness_EmptyIndex(t *testing.T) {
 	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
 	lister := &fakePointLister{points: map[uint64]string{}}

--- a/search/corpus/staleness_test.go
+++ b/search/corpus/staleness_test.go
@@ -234,3 +234,91 @@ func TestCommitsStaleness_RespectsLimit(t *testing.T) {
 		t.Errorf("expected not stale with matching HEAD date, got stale: %s", st.Reason)
 	}
 }
+
+// --- Cache tests ---
+
+// callCountLister wraps fakePointLister and counts ExistingPoints calls.
+type callCountLister struct {
+	fakePointLister
+	calls int
+}
+
+func (c *callCountLister) ExistingPoints(collection string) (map[uint64]string, error) {
+	c.calls++
+	return c.fakePointLister.ExistingPoints(collection)
+}
+
+func (c *callCountLister) MaxPayloadDate(collection string) (string, error) {
+	return c.fakePointLister.MaxPayloadDate(collection)
+}
+
+func TestStalenessCache_HitsWithinTTL(t *testing.T) {
+	ResetStalenessCache()
+	defer ResetStalenessCache()
+
+	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
+	lister := &callCountLister{
+		fakePointLister: fakePointLister{
+			points: map[uint64]string{1: hashOf("package main")},
+		},
+	}
+
+	// First call — cache miss, hits the lister.
+	st1, err := CodeStalenessCached(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lister.calls != 1 {
+		t.Fatalf("expected 1 call, got %d", lister.calls)
+	}
+
+	// Second call within TTL — cache hit, no additional lister calls.
+	st2, err := CodeStalenessCached(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lister.calls != 1 {
+		t.Errorf("expected still 1 call (cached), got %d", lister.calls)
+	}
+	if st1.IsStale != st2.IsStale {
+		t.Errorf("cached result differs: %v vs %v", st1, st2)
+	}
+}
+
+func TestStalenessCache_ExpiresAfterTTL(t *testing.T) {
+	ResetStalenessCache()
+	defer ResetStalenessCache()
+
+	// Use a very short TTL for this test.
+	oldTTL := CacheTTL
+	CacheTTL = 1 * time.Millisecond
+	defer func() { CacheTTL = oldTTL }()
+
+	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
+	lister := &callCountLister{
+		fakePointLister: fakePointLister{
+			points: map[uint64]string{1: hashOf("package main")},
+		},
+	}
+
+	// First call.
+	_, err := CodeStalenessCached(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lister.calls != 1 {
+		t.Fatalf("expected 1 call, got %d", lister.calls)
+	}
+
+	// Wait for the cache to expire.
+	time.Sleep(5 * time.Millisecond)
+
+	// Second call after TTL — cache miss, hits the lister again.
+	_, err = CodeStalenessCached(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lister.calls != 2 {
+		t.Errorf("expected 2 calls after TTL expiry, got %d", lister.calls)
+	}
+}

--- a/search/corpus/staleness_test.go
+++ b/search/corpus/staleness_test.go
@@ -8,15 +8,21 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
-// fakePointLister implements PointLister for tests.
+// fakePointLister implements PointLister and MaxDateLister for tests.
 type fakePointLister struct {
-	points map[uint64]string // id -> content_hash
+	points  map[uint64]string // id -> content_hash
+	maxDate string            // max date returned by MaxPayloadDate
 }
 
 func (f *fakePointLister) ExistingPoints(_ string) (map[uint64]string, error) {
 	return f.points, nil
+}
+
+func (f *fakePointLister) MaxPayloadDate(_ string) (string, error) {
+	return f.maxDate, nil
 }
 
 // initGitRepo creates a temp dir with a git repo containing the given files.
@@ -48,6 +54,17 @@ func runGit(t *testing.T, dir string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 	}
+}
+
+func gitOutputHelper(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s: %v", strings.Join(args, " "), err)
+	}
+	return string(out)
 }
 
 func hashOf(content string) string {
@@ -127,10 +144,18 @@ func TestCommitsStaleness_EmptyIndex(t *testing.T) {
 func TestCommitsStaleness_UpToDate(t *testing.T) {
 	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
 
-	// One commit in repo, one point in index.
-	lister := &fakePointLister{points: map[uint64]string{
-		1: "",
-	}}
+	// Get HEAD's date so we can set maxDate to match.
+	headDate := gitOutputHelper(t, dir, "log", "-1", "--format=%aI", "HEAD")
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(headDate))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// One commit in repo, one point in index, maxDate matching HEAD.
+	lister := &fakePointLister{
+		points:  map[uint64]string{1: ""},
+		maxDate: parsed.Format("2006-01-02"),
+	}
 
 	st, err := CommitsStaleness(dir, "test-collection", lister)
 	if err != nil {
@@ -143,17 +168,24 @@ func TestCommitsStaleness_UpToDate(t *testing.T) {
 
 func TestCommitsStaleness_NewCommits(t *testing.T) {
 	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
-	// Add a second commit.
-	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n// v2"), 0o644); err != nil {
+
+	// Record first commit's date as the "indexed" max date.
+	firstDate := gitOutputHelper(t, dir, "log", "-1", "--format=%aI", "HEAD")
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(firstDate))
+	if err != nil {
 		t.Fatal(err)
 	}
-	runGit(t, dir, "add", "-A")
-	runGit(t, dir, "commit", "-m", "second")
+	indexedDate := parsed.Format("2006-01-02")
 
-	// Index only knows about one commit.
-	lister := &fakePointLister{points: map[uint64]string{
-		1: "",
-	}}
+	// Add a second commit with a future date so HEAD > indexed.
+	runGit(t, dir, "commit", "--allow-empty", "-m", "second",
+		"--date=2099-01-01T00:00:00+00:00")
+
+	// Index only knows about the first commit's date.
+	lister := &fakePointLister{
+		points:  map[uint64]string{1: ""},
+		maxDate: indexedDate,
+	}
 
 	st, err := CommitsStaleness(dir, "test-collection", lister)
 	if err != nil {
@@ -162,7 +194,43 @@ func TestCommitsStaleness_NewCommits(t *testing.T) {
 	if !st.IsStale {
 		t.Error("expected stale")
 	}
-	if !strings.Contains(st.Reason, "new commits") {
+	if !strings.Contains(st.Reason, "newer") {
 		t.Errorf("unexpected reason: %s", st.Reason)
+	}
+}
+
+// TestCommitsStaleness_RespectsLimit is a regression test for PR #61 item #2:
+// with commits.limit=2 on a 5-commit repo, CommitsStaleness should report
+// stale ONLY if HEAD is newer than the latest indexed, not because total
+// commit count != indexed count.
+func TestCommitsStaleness_RespectsLimit(t *testing.T) {
+	dir := initGitRepo(t, map[string]string{"main.go": "package main"})
+
+	// Add 4 more commits (5 total).
+	for i := 2; i <= 5; i++ {
+		runGit(t, dir, "commit", "--allow-empty", "-m", fmt.Sprintf("commit %d", i))
+	}
+
+	// Get HEAD's date.
+	headDate := gitOutputHelper(t, dir, "log", "-1", "--format=%aI", "HEAD")
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(headDate))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate commits.limit=2: index has 2 points, but maxDate matches HEAD.
+	// Under the old count-based logic this would be "3 new commits" (5-2=3).
+	// Under the new date-based logic, it should be not stale.
+	lister := &fakePointLister{
+		points:  map[uint64]string{1: "", 2: ""},
+		maxDate: parsed.Format("2006-01-02"),
+	}
+
+	st, err := CommitsStaleness(dir, "test-collection", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.IsStale {
+		t.Errorf("expected not stale with matching HEAD date, got stale: %s", st.Reason)
 	}
 }

--- a/search/index/index.go
+++ b/search/index/index.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/elliottregan/cspace/search/corpus"
 )
@@ -32,20 +33,32 @@ type Upserter interface {
 	DeletePoints(collection string, ids []uint64) error
 }
 
+// StatusWriter is an optional callback interface for reporting index
+// lifecycle events to an external status tracker. When nil, Run skips
+// status updates. Satisfied by *status.Writer.
+type StatusWriter interface {
+	StartCorpus(corpusID string)
+	UpdateProgress(done, total int)
+	FinishCorpus(corpusID string, startedAt time.Time, indexedCount int)
+	FailCorpus(corpusID string, startedAt time.Time, runErr error)
+}
+
 // Config bundles the parts needed for one index run.
 type Config struct {
-	Corpus      corpus.Corpus
-	Embedder    Embedder
-	Upserter    Upserter
-	ProjectRoot string
-	BatchSize   int // default 32
-	Dim         int // default 768 (Jina v5 nano)
-	LockPath    string
-	Progress    func(done, total int)
+	Corpus       corpus.Corpus
+	Embedder     Embedder
+	Upserter     Upserter
+	ProjectRoot  string
+	BatchSize    int // default 32
+	Dim          int // default 768 (Jina v5 nano)
+	LockPath     string
+	Progress     func(done, total int)
+	StatusWriter StatusWriter // optional; nil = no status updates
 }
 
 // Run performs one end-to-end index pass: enumerate, embed changed records,
-// upsert, delete orphans.
+// upsert, delete orphans. If cfg.StatusWriter is set, lifecycle events
+// (start, progress, finish/fail) are reported for the status file.
 func Run(ctx context.Context, cfg Config) error {
 	if cfg.BatchSize == 0 {
 		cfg.BatchSize = 32
@@ -53,7 +66,28 @@ func Run(ctx context.Context, cfg Config) error {
 	if cfg.Dim == 0 {
 		cfg.Dim = 768
 	}
+
+	corpusID := cfg.Corpus.ID()
+	startedAt := time.Now()
+
+	if cfg.StatusWriter != nil {
+		cfg.StatusWriter.StartCorpus(corpusID)
+	}
+
+	err := runIndex(ctx, cfg)
+	if err != nil && cfg.StatusWriter != nil {
+		cfg.StatusWriter.FailCorpus(corpusID, startedAt, err)
+	}
+	return err
+}
+
+// IndexedCount is set by runIndex and read by Run to report the final count.
+// It is stored on Config so the caller can also inspect it.
+
+func runIndex(ctx context.Context, cfg Config) error {
 	collection := cfg.Corpus.Collection(cfg.ProjectRoot)
+	corpusID := cfg.Corpus.ID()
+	startedAt := time.Now()
 
 	if cfg.LockPath != "" {
 		release, err := acquireLock(cfg.LockPath)
@@ -91,6 +125,18 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	total := len(toEmbed)
+
+	// Wrap progress to also update the status writer.
+	origProgress := cfg.Progress
+	wrappedProgress := func(done, totalPts int) {
+		if origProgress != nil {
+			origProgress(done, totalPts)
+		}
+		if cfg.StatusWriter != nil {
+			cfg.StatusWriter.UpdateProgress(done, totalPts)
+		}
+	}
+
 	for i := 0; i < total; i += cfg.BatchSize {
 		end := i + cfg.BatchSize
 		if end > total {
@@ -116,7 +162,7 @@ func Run(ctx context.Context, cfg Config) error {
 				Payload: payloadFor(r),
 			}
 		}
-		if err := cfg.Upserter.UpsertPoints(collection, points, cfg.BatchSize, cfg.Progress); err != nil {
+		if err := cfg.Upserter.UpsertPoints(collection, points, cfg.BatchSize, wrappedProgress); err != nil {
 			return fmt.Errorf("upsert: %w", err)
 		}
 	}
@@ -132,6 +178,12 @@ func Run(ctx context.Context, cfg Config) error {
 		if err := cfg.Upserter.DeletePoints(collection, orphans); err != nil {
 			return fmt.Errorf("delete orphans: %w", err)
 		}
+	}
+
+	// Report total indexed count (existing - orphans + new).
+	indexedCount := len(existing) - len(orphans) + total
+	if cfg.StatusWriter != nil {
+		cfg.StatusWriter.FinishCorpus(corpusID, startedAt, indexedCount)
 	}
 
 	return nil

--- a/search/mcp/server.go
+++ b/search/mcp/server.go
@@ -4,12 +4,16 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
+	"time"
 
 	"github.com/elliottregan/cspace/search/cluster"
 	"github.com/elliottregan/cspace/search/config"
+	"github.com/elliottregan/cspace/search/corpus"
 	"github.com/elliottregan/cspace/search/embed"
 	"github.com/elliottregan/cspace/search/qdrant"
 	"github.com/elliottregan/cspace/search/query"
+	"github.com/elliottregan/cspace/search/status"
 
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -49,6 +53,13 @@ func (s *Server) Register(srv *mcpSDK.Server) {
 	}, func(ctx context.Context, req *mcpSDK.CallToolRequest, in listClustersInput) (*mcpSDK.CallToolResult, cluster.Result, error) {
 		return s.handleListClusters(ctx)
 	})
+
+	mcpSDK.AddTool[statusInput, StatusOutput](srv, &mcpSDK.Tool{
+		Name:        "search_status",
+		Description: "Show the index status and staleness for all search corpora. Returns per-corpus state (completed/failed/disabled/unknown), whether the index is stale, and any in-progress indexing run. Use before high-stakes queries to decide whether to reindex first.",
+	}, func(ctx context.Context, req *mcpSDK.CallToolRequest, in statusInput) (*mcpSDK.CallToolResult, StatusOutput, error) {
+		return s.handleStatus(ctx)
+	})
 }
 
 // --- Input types ---
@@ -62,6 +73,25 @@ type searchInput struct {
 }
 
 type listClustersInput struct{}
+
+type statusInput struct{}
+
+// StatusOutput is the structured output from the search_status MCP tool.
+type StatusOutput struct {
+	Corpora map[string]CorpusStatusEntry `json:"corpora"`
+	Current *status.RunningState         `json:"current"`
+}
+
+// CorpusStatusEntry describes one corpus's index state.
+type CorpusStatusEntry struct {
+	State        string `json:"state"`
+	FinishedAt   string `json:"finished_at,omitempty"`
+	DurationMS   int64  `json:"duration_ms,omitempty"`
+	IndexedCount int    `json:"indexed_count,omitempty"`
+	Error        string `json:"error,omitempty"`
+	Stale        bool   `json:"stale,omitempty"`
+	StaleReason  string `json:"stale_reason,omitempty"`
+}
 
 // --- Handlers ---
 
@@ -93,6 +123,10 @@ func (s *Server) handleSearch(ctx context.Context, corpusID string, in searchInp
 	if err != nil {
 		return nil, query.Envelope{}, err
 	}
+
+	// Annotate with staleness warning if applicable.
+	mcpAppendStalenessWarning(env, corpusID, s.ProjectRoot, s.Config)
+
 	buf, err := json.Marshal(env)
 	if err != nil {
 		return nil, query.Envelope{}, err
@@ -122,4 +156,109 @@ func (s *Server) handleListClusters(ctx context.Context) (*mcpSDK.CallToolResult
 	return &mcpSDK.CallToolResult{
 		Content: []mcpSDK.Content{&mcpSDK.TextContent{Text: string(buf)}},
 	}, *res, nil
+}
+
+func (s *Server) handleStatus(_ context.Context) (*mcpSDK.CallToolResult, StatusOutput, error) {
+	sf, err := status.Read(s.ProjectRoot)
+	if err != nil {
+		return nil, StatusOutput{}, err
+	}
+
+	allCorpora := []string{"code", "commits", "context", "issues"}
+	out := StatusOutput{Corpora: make(map[string]CorpusStatusEntry)}
+	if sf != nil {
+		out.Current = sf.Current
+	}
+
+	for _, id := range allCorpora {
+		entry := CorpusStatusEntry{State: "unknown"}
+
+		// Check if disabled in config.
+		if cc, ok := s.Config.Corpora[id]; ok && !cc.Enabled {
+			entry.State = "disabled"
+			out.Corpora[id] = entry
+			continue
+		}
+
+		// Pull state from status file.
+		if sf != nil {
+			if cs, ok := sf.Last[id]; ok {
+				entry.State = cs.State
+				if !cs.FinishedAt.IsZero() {
+					entry.FinishedAt = cs.FinishedAt.Format(time.RFC3339)
+				}
+				entry.DurationMS = cs.DurationMS
+				entry.IndexedCount = cs.IndexedCount
+				entry.Error = cs.Error
+			}
+		}
+
+		// Check staleness for code and commits.
+		if entry.State == "completed" && (id == "code" || id == "commits") {
+			qc := qdrant.NewQdrantClient(s.Config.Sidecars.QdrantURL)
+			adapter := &qdrant.Adapter{QdrantClient: qc}
+			collection := mcpCorpusCollection(id, s.ProjectRoot)
+			var st corpus.Staleness
+			switch id {
+			case "code":
+				st, _ = corpus.CodeStaleness(s.ProjectRoot, collection, adapter)
+			case "commits":
+				st, _ = corpus.CommitsStaleness(s.ProjectRoot, collection, adapter)
+			}
+			if st.IsStale {
+				entry.Stale = true
+				entry.StaleReason = st.Reason
+			}
+		}
+
+		out.Corpora[id] = entry
+	}
+
+	buf, err := json.Marshal(out)
+	if err != nil {
+		return nil, StatusOutput{}, err
+	}
+	return &mcpSDK.CallToolResult{
+		Content: []mcpSDK.Content{&mcpSDK.TextContent{Text: string(buf)}},
+	}, out, nil
+}
+
+// mcpCorpusCollection returns the qdrant collection name for a corpus.
+func mcpCorpusCollection(corpusID, projectRoot string) string {
+	switch corpusID {
+	case "code":
+		return "code-" + corpus.ProjectHash(projectRoot)
+	case "commits":
+		return "commits-" + corpus.ProjectHash(projectRoot)
+	default:
+		return ""
+	}
+}
+
+// mcpAppendStalenessWarning checks corpus staleness and appends a warning to
+// the envelope. Best-effort: errors are silently ignored.
+func mcpAppendStalenessWarning(env *query.Envelope, corpusID, projectRoot string, cfg *config.Config) {
+	if corpusID != "code" && corpusID != "commits" {
+		return
+	}
+	qc := qdrant.NewQdrantClient(cfg.Sidecars.QdrantURL)
+	adapter := &qdrant.Adapter{QdrantClient: qc}
+	collection := mcpCorpusCollection(corpusID, projectRoot)
+	if collection == "" {
+		return
+	}
+	var st corpus.Staleness
+	var err error
+	switch corpusID {
+	case "code":
+		st, err = corpus.CodeStaleness(projectRoot, collection, adapter)
+	case "commits":
+		st, err = corpus.CommitsStaleness(projectRoot, collection, adapter)
+	}
+	if err != nil || !st.IsStale {
+		return
+	}
+	warning := "index may be out of date: " + st.Reason +
+		" \u2014 run `cspace search " + corpusID + " index` to refresh"
+	env.Warning = strings.TrimSpace(env.Warning + "\n" + warning)
 }

--- a/search/mcp/server.go
+++ b/search/mcp/server.go
@@ -76,7 +76,10 @@ type listClustersInput struct{}
 type statusInput struct{}
 
 // StatusOutput is the structured output from the search_status MCP tool.
+// Enabled mirrors the top-level search.yaml `enabled:` field. When false,
+// Corpora is empty and clients should show a "not configured" signal.
 type StatusOutput struct {
+	Enabled bool                         `json:"enabled"`
 	Corpora map[string]CorpusStatusEntry `json:"corpora"`
 	Current *status.RunningState         `json:"current"`
 }
@@ -165,7 +168,7 @@ func (s *Server) handleStatus(_ context.Context) (*mcpSDK.CallToolResult, Status
 		}
 	}
 
-	cs, err := status.Compute(s.ProjectRoot, disabled, func(corpusID string) (bool, string) {
+	cs, err := status.Compute(s.ProjectRoot, s.Config.Enabled, disabled, func(corpusID string) (bool, string) {
 		qc := qdrant.NewQdrantClient(s.Config.Sidecars.QdrantURL)
 		adapter := &qdrant.Adapter{QdrantClient: qc}
 		collection := mcpCorpusCollection(corpusID, s.ProjectRoot)
@@ -184,6 +187,7 @@ func (s *Server) handleStatus(_ context.Context) (*mcpSDK.CallToolResult, Status
 
 	// Map ComputedStatus to StatusOutput (same shape, different type names).
 	out := StatusOutput{
+		Enabled: cs.Enabled,
 		Corpora: make(map[string]CorpusStatusEntry),
 		Current: cs.Current,
 	}

--- a/search/mcp/server.go
+++ b/search/mcp/server.go
@@ -193,7 +193,7 @@ func (s *Server) handleStatus(_ context.Context) (*mcpSDK.CallToolResult, Status
 			}
 		}
 
-		// Check staleness for code and commits.
+		// Check staleness for code and commits (cached to avoid per-query I/O).
 		if entry.State == "completed" && (id == "code" || id == "commits") {
 			qc := qdrant.NewQdrantClient(s.Config.Sidecars.QdrantURL)
 			adapter := &qdrant.Adapter{QdrantClient: qc}
@@ -201,9 +201,9 @@ func (s *Server) handleStatus(_ context.Context) (*mcpSDK.CallToolResult, Status
 			var st corpus.Staleness
 			switch id {
 			case "code":
-				st, _ = corpus.CodeStaleness(s.ProjectRoot, collection, adapter)
+				st, _ = corpus.CodeStalenessCached(s.ProjectRoot, collection, adapter)
 			case "commits":
-				st, _ = corpus.CommitsStaleness(s.ProjectRoot, collection, adapter)
+				st, _ = corpus.CommitsStalenessCached(s.ProjectRoot, collection, adapter)
 			}
 			if st.IsStale {
 				entry.Stale = true
@@ -251,9 +251,9 @@ func mcpAppendStalenessWarning(env *query.Envelope, corpusID, projectRoot string
 	var err error
 	switch corpusID {
 	case "code":
-		st, err = corpus.CodeStaleness(projectRoot, collection, adapter)
+		st, err = corpus.CodeStalenessCached(projectRoot, collection, adapter)
 	case "commits":
-		st, err = corpus.CommitsStaleness(projectRoot, collection, adapter)
+		st, err = corpus.CommitsStalenessCached(projectRoot, collection, adapter)
 	}
 	if err != nil || !st.IsStale {
 		return

--- a/search/mcp/server.go
+++ b/search/mcp/server.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
-	"time"
 
 	"github.com/elliottregan/cspace/search/cluster"
 	"github.com/elliottregan/cspace/search/config"
@@ -159,59 +158,45 @@ func (s *Server) handleListClusters(ctx context.Context) (*mcpSDK.CallToolResult
 }
 
 func (s *Server) handleStatus(_ context.Context) (*mcpSDK.CallToolResult, StatusOutput, error) {
-	sf, err := status.Read(s.ProjectRoot)
+	disabled := make(map[string]bool)
+	for id, cc := range s.Config.Corpora {
+		if !cc.Enabled {
+			disabled[id] = true
+		}
+	}
+
+	cs, err := status.Compute(s.ProjectRoot, disabled, func(corpusID string) (bool, string) {
+		qc := qdrant.NewQdrantClient(s.Config.Sidecars.QdrantURL)
+		adapter := &qdrant.Adapter{QdrantClient: qc}
+		collection := mcpCorpusCollection(corpusID, s.ProjectRoot)
+		var st corpus.Staleness
+		switch corpusID {
+		case "code":
+			st, _ = corpus.CodeStalenessCached(s.ProjectRoot, collection, adapter)
+		case "commits":
+			st, _ = corpus.CommitsStalenessCached(s.ProjectRoot, collection, adapter)
+		}
+		return st.IsStale, st.Reason
+	})
 	if err != nil {
 		return nil, StatusOutput{}, err
 	}
 
-	allCorpora := []string{"code", "commits", "context", "issues"}
-	out := StatusOutput{Corpora: make(map[string]CorpusStatusEntry)}
-	if sf != nil {
-		out.Current = sf.Current
+	// Map ComputedStatus to StatusOutput (same shape, different type names).
+	out := StatusOutput{
+		Corpora: make(map[string]CorpusStatusEntry),
+		Current: cs.Current,
 	}
-
-	for _, id := range allCorpora {
-		entry := CorpusStatusEntry{State: "unknown"}
-
-		// Check if disabled in config.
-		if cc, ok := s.Config.Corpora[id]; ok && !cc.Enabled {
-			entry.State = "disabled"
-			out.Corpora[id] = entry
-			continue
+	for id, c := range cs.Corpora {
+		out.Corpora[id] = CorpusStatusEntry{
+			State:        c.State,
+			FinishedAt:   c.FinishedAt,
+			DurationMS:   c.DurationMS,
+			IndexedCount: c.IndexedCount,
+			Error:        c.Error,
+			Stale:        c.Stale,
+			StaleReason:  c.StaleReason,
 		}
-
-		// Pull state from status file.
-		if sf != nil {
-			if cs, ok := sf.Last[id]; ok {
-				entry.State = cs.State
-				if !cs.FinishedAt.IsZero() {
-					entry.FinishedAt = cs.FinishedAt.Format(time.RFC3339)
-				}
-				entry.DurationMS = cs.DurationMS
-				entry.IndexedCount = cs.IndexedCount
-				entry.Error = cs.Error
-			}
-		}
-
-		// Check staleness for code and commits (cached to avoid per-query I/O).
-		if entry.State == "completed" && (id == "code" || id == "commits") {
-			qc := qdrant.NewQdrantClient(s.Config.Sidecars.QdrantURL)
-			adapter := &qdrant.Adapter{QdrantClient: qc}
-			collection := mcpCorpusCollection(id, s.ProjectRoot)
-			var st corpus.Staleness
-			switch id {
-			case "code":
-				st, _ = corpus.CodeStalenessCached(s.ProjectRoot, collection, adapter)
-			case "commits":
-				st, _ = corpus.CommitsStalenessCached(s.ProjectRoot, collection, adapter)
-			}
-			if st.IsStale {
-				entry.Stale = true
-				entry.StaleReason = st.Reason
-			}
-		}
-
-		out.Corpora[id] = entry
 	}
 
 	buf, err := json.Marshal(out)

--- a/search/mcp/server_test.go
+++ b/search/mcp/server_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +35,7 @@ func TestServer_HandleStatus_NoStatusFile(t *testing.T) {
 			},
 		},
 	}
-	result, out, err := s.handleStatus(nil)
+	result, out, err := s.handleStatus(context.TODO())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +90,7 @@ func TestServer_HandleStatus_WithStatusFile(t *testing.T) {
 			},
 		},
 	}
-	_, out, err := s.handleStatus(nil)
+	_, out, err := s.handleStatus(context.TODO())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/search/mcp/server_test.go
+++ b/search/mcp/server_test.go
@@ -1,6 +1,8 @@
 package mcp
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/elliottregan/cspace/search/config"
@@ -8,7 +10,7 @@ import (
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func TestServer_RegistersBothTools(t *testing.T) {
+func TestServer_RegistersAllTools(t *testing.T) {
 	srv := mcpSDK.NewServer(&mcpSDK.Implementation{Name: "test", Version: "0"}, nil)
 	s := &Server{ProjectRoot: ".", Config: &config.Config{
 		Corpora: map[string]config.CorpusConfig{
@@ -17,4 +19,90 @@ func TestServer_RegistersBothTools(t *testing.T) {
 	}}
 	// Register must not panic.
 	s.Register(srv)
+}
+
+func TestServer_HandleStatus_NoStatusFile(t *testing.T) {
+	dir := t.TempDir()
+	s := &Server{
+		ProjectRoot: dir,
+		Config: &config.Config{
+			Corpora: map[string]config.CorpusConfig{
+				"code":    {Enabled: true},
+				"commits": {Enabled: true},
+				"context": {Enabled: false},
+				"issues":  {Enabled: false},
+			},
+		},
+	}
+	result, out, err := s.handleStatus(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if out.Current != nil {
+		t.Error("expected no current run")
+	}
+	// context and issues should be disabled.
+	if out.Corpora["context"].State != "disabled" {
+		t.Errorf("expected context=disabled, got %q", out.Corpora["context"].State)
+	}
+	if out.Corpora["issues"].State != "disabled" {
+		t.Errorf("expected issues=disabled, got %q", out.Corpora["issues"].State)
+	}
+	// code and commits should be unknown (no status file).
+	if out.Corpora["code"].State != "unknown" {
+		t.Errorf("expected code=unknown, got %q", out.Corpora["code"].State)
+	}
+}
+
+func TestServer_HandleStatus_WithStatusFile(t *testing.T) {
+	dir := t.TempDir()
+	cspaceDir := filepath.Join(dir, ".cspace")
+	if err := os.MkdirAll(cspaceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := `{
+		"updated_at": "2026-04-22T03:00:00Z",
+		"current": null,
+		"last": {
+			"code": {"state": "completed", "finished_at": "2026-04-22T03:00:00Z", "indexed_count": 100},
+			"commits": {"state": "failed", "finished_at": "2026-04-22T03:00:00Z", "error": "embed: connection refused"}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(cspaceDir, "search-index-status.json"), []byte(statusJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{
+		ProjectRoot: dir,
+		Config: &config.Config{
+			Corpora: map[string]config.CorpusConfig{
+				"code":    {Enabled: true},
+				"commits": {Enabled: true},
+				"context": {Enabled: false},
+				"issues":  {Enabled: false},
+			},
+			Sidecars: config.Sidecars{
+				QdrantURL: "http://localhost:6333", // won't actually connect in test
+			},
+		},
+	}
+	_, out, err := s.handleStatus(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Corpora["code"].State != "completed" {
+		t.Errorf("expected code=completed, got %q", out.Corpora["code"].State)
+	}
+	if out.Corpora["code"].IndexedCount != 100 {
+		t.Errorf("expected indexed_count=100, got %d", out.Corpora["code"].IndexedCount)
+	}
+	if out.Corpora["commits"].State != "failed" {
+		t.Errorf("expected commits=failed, got %q", out.Corpora["commits"].State)
+	}
+	if out.Corpora["commits"].Error != "embed: connection refused" {
+		t.Errorf("unexpected error: %q", out.Corpora["commits"].Error)
+	}
 }

--- a/search/mcp/server_test.go
+++ b/search/mcp/server_test.go
@@ -27,6 +27,7 @@ func TestServer_HandleStatus_NoStatusFile(t *testing.T) {
 	s := &Server{
 		ProjectRoot: dir,
 		Config: &config.Config{
+			Enabled: true,
 			Corpora: map[string]config.CorpusConfig{
 				"code":    {Enabled: true},
 				"commits": {Enabled: true},
@@ -42,6 +43,9 @@ func TestServer_HandleStatus_NoStatusFile(t *testing.T) {
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
+	if !out.Enabled {
+		t.Error("expected Enabled=true when master switch is on")
+	}
 	if out.Current != nil {
 		t.Error("expected no current run")
 	}
@@ -55,6 +59,33 @@ func TestServer_HandleStatus_NoStatusFile(t *testing.T) {
 	// code and commits should be unknown (no status file).
 	if out.Corpora["code"].State != "unknown" {
 		t.Errorf("expected code=unknown, got %q", out.Corpora["code"].State)
+	}
+}
+
+// When the master switch is off, handleStatus reports Enabled=false and
+// empty corpora — even if a status file exists on disk from a prior
+// session.
+func TestServer_HandleStatus_SearchDisabled(t *testing.T) {
+	dir := t.TempDir()
+	s := &Server{
+		ProjectRoot: dir,
+		Config: &config.Config{
+			Enabled: false,
+			Corpora: map[string]config.CorpusConfig{
+				"code":    {Enabled: true},
+				"commits": {Enabled: true},
+			},
+		},
+	}
+	_, out, err := s.handleStatus(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Enabled {
+		t.Error("expected Enabled=false when master switch is off")
+	}
+	if len(out.Corpora) != 0 {
+		t.Errorf("expected empty Corpora when disabled, got %d entries", len(out.Corpora))
 	}
 }
 
@@ -79,6 +110,7 @@ func TestServer_HandleStatus_WithStatusFile(t *testing.T) {
 	s := &Server{
 		ProjectRoot: dir,
 		Config: &config.Config{
+			Enabled: true,
 			Corpora: map[string]config.CorpusConfig{
 				"code":    {Enabled: true},
 				"commits": {Enabled: true},

--- a/search/qdrant/adapter.go
+++ b/search/qdrant/adapter.go
@@ -31,5 +31,12 @@ func (a *Adapter) Search(collection string, vector []float32, topK int) ([]query
 	return out, nil
 }
 
+// MaxPayloadDate scrolls a collection and returns the maximum "date" payload
+// field (format "2006-01-02"). Used by CommitsStaleness to compare HEAD against
+// the latest indexed commit without false positives under commits.limit.
+func (a *Adapter) MaxPayloadDate(collection string) (string, error) {
+	return a.QdrantClient.MaxPayloadDate(collection)
+}
+
 var _ index.Upserter = (*Adapter)(nil)
 var _ query.Searcher = (*Adapter)(nil)

--- a/search/qdrant/qdrant.go
+++ b/search/qdrant/qdrant.go
@@ -152,6 +152,59 @@ func (c *QdrantClient) ExistingPoints(collection string) (map[uint64]string, err
 	return out, nil
 }
 
+// MaxPayloadDate scrolls a collection and returns the maximum "date" payload
+// value (format "2006-01-02"). Returns "" if the collection is empty or has
+// no date fields. Used by CommitsStaleness.
+func (c *QdrantClient) MaxPayloadDate(collection string) (string, error) {
+	var maxDate string
+	var offset any = nil
+	for {
+		body := map[string]any{
+			"limit":        256,
+			"with_payload": []string{"date"},
+			"with_vector":  false,
+		}
+		if offset != nil {
+			body["offset"] = offset
+		}
+		buf, _ := json.Marshal(body)
+		req, _ := http.NewRequest(http.MethodPost, c.BaseURL+"/collections/"+collection+"/points/scroll", bytes.NewReader(buf))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("scroll: %w", err)
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			_ = resp.Body.Close()
+			return "", nil
+		}
+		var parsed struct {
+			Result struct {
+				Points []struct {
+					ID      uint64         `json:"id"`
+					Payload map[string]any `json:"payload"`
+				} `json:"points"`
+				NextPageOffset any `json:"next_page_offset"`
+			} `json:"result"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+			_ = resp.Body.Close()
+			return "", err
+		}
+		_ = resp.Body.Close()
+		for _, p := range parsed.Result.Points {
+			if d, ok := p.Payload["date"].(string); ok && d > maxDate {
+				maxDate = d
+			}
+		}
+		if parsed.Result.NextPageOffset == nil {
+			break
+		}
+		offset = parsed.Result.NextPageOffset
+	}
+	return maxDate, nil
+}
+
 // DeletePoints removes the listed point IDs.
 func (c *QdrantClient) DeletePoints(collection string, ids []uint64) error {
 	body, _ := json.Marshal(map[string]any{"points": ids})

--- a/search/status/status.go
+++ b/search/status/status.go
@@ -8,6 +8,8 @@ package status
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -65,6 +67,78 @@ func Read(projectRoot string) (*File, error) {
 	return &f, nil
 }
 
+// ComputedStatus is the unified output shape for the status command — both
+// the MCP tool and the CLI serialize this same struct so their JSON output
+// is guaranteed identical. Extracted per PR #61 review item #5.
+type ComputedStatus struct {
+	Corpora map[string]ComputedCorpus `json:"corpora"`
+	Current *RunningState             `json:"current"`
+}
+
+// ComputedCorpus describes one corpus's index state plus staleness.
+type ComputedCorpus struct {
+	State        string `json:"state"` // completed, failed, disabled, unknown
+	FinishedAt   string `json:"finished_at,omitempty"`
+	DurationMS   int64  `json:"duration_ms,omitempty"`
+	IndexedCount int    `json:"indexed_count,omitempty"`
+	Error        string `json:"error,omitempty"`
+	Stale        bool   `json:"stale,omitempty"`
+	StaleReason  string `json:"stale_reason,omitempty"`
+}
+
+// StalenessChecker is a callback used by Compute to check staleness for
+// code/commits corpora. It decouples the status package from qdrant/corpus.
+type StalenessChecker func(corpusID string) (stale bool, reason string)
+
+// Compute builds a ComputedStatus from the on-disk status file and config.
+// disabledCorpora is the set of corpus IDs that are disabled in config.
+// checkStaleness is an optional callback for staleness checks (may be nil).
+func Compute(projectRoot string, disabledCorpora map[string]bool, checkStaleness StalenessChecker) (*ComputedStatus, error) {
+	sf, err := Read(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	allCorpora := []string{"code", "commits", "context", "issues"}
+	out := &ComputedStatus{Corpora: make(map[string]ComputedCorpus)}
+	if sf != nil {
+		out.Current = sf.Current
+	}
+
+	for _, id := range allCorpora {
+		co := ComputedCorpus{State: "unknown"}
+
+		if disabledCorpora[id] {
+			co.State = "disabled"
+			out.Corpora[id] = co
+			continue
+		}
+
+		if sf != nil {
+			if cs, ok := sf.Last[id]; ok {
+				co.State = cs.State
+				if !cs.FinishedAt.IsZero() {
+					co.FinishedAt = cs.FinishedAt.Format(time.RFC3339)
+				}
+				co.DurationMS = cs.DurationMS
+				co.IndexedCount = cs.IndexedCount
+				co.Error = cs.Error
+			}
+		}
+
+		if co.State == "completed" && (id == "code" || id == "commits") && checkStaleness != nil {
+			if stale, reason := checkStaleness(id); stale {
+				co.Stale = true
+				co.StaleReason = reason
+			}
+		}
+
+		out.Corpora[id] = co
+	}
+
+	return out, nil
+}
+
 // Writer manages atomic writes to the status file. It is safe for concurrent
 // use from a single process (the indexer's progress callback fires from
 // goroutines). Writes are throttled to at most once per second to avoid
@@ -77,6 +151,10 @@ type Writer struct {
 	// lastFlush tracks the wall-clock time of the most recent disk write so
 	// we can throttle progress-driven updates.
 	lastFlush time.Time
+
+	// ErrLog receives flush errors (disk full, permission denied, etc.)
+	// instead of silently dropping them. Defaults to os.Stderr when nil.
+	ErrLog io.Writer
 }
 
 // NewWriter creates a Writer targeting projectRoot. It loads any existing
@@ -102,11 +180,12 @@ func NewWriter(projectRoot string) (*Writer, error) {
 func (w *Writer) StartCorpus(corpusID string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	now := time.Now().UTC()
 	w.file.Current = &RunningState{
 		Corpus:    corpusID,
-		StartedAt: time.Now().UTC(),
+		StartedAt: now,
 	}
-	w.file.UpdatedAt = time.Now().UTC()
+	w.file.UpdatedAt = now
 	w.flush()
 }
 
@@ -117,8 +196,9 @@ func (w *Writer) UpdateProgress(done, total int) {
 	if w.file.Current == nil {
 		return
 	}
+	now := time.Now().UTC()
 	w.file.Current.Progress = Progress{Done: done, Total: total}
-	w.file.UpdatedAt = time.Now().UTC()
+	w.file.UpdatedAt = now
 	if time.Since(w.lastFlush) >= time.Second {
 		w.flush()
 	}
@@ -128,14 +208,15 @@ func (w *Writer) UpdateProgress(done, total int) {
 func (w *Writer) FinishCorpus(corpusID string, startedAt time.Time, indexedCount int) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	now := time.Now().UTC()
 	w.file.Last[corpusID] = CorpusState{
 		State:        "completed",
-		FinishedAt:   time.Now().UTC(),
+		FinishedAt:   now,
 		DurationMS:   time.Since(startedAt).Milliseconds(),
 		IndexedCount: indexedCount,
 	}
 	w.file.Current = nil
-	w.file.UpdatedAt = time.Now().UTC()
+	w.file.UpdatedAt = now
 	w.flush()
 }
 
@@ -143,37 +224,53 @@ func (w *Writer) FinishCorpus(corpusID string, startedAt time.Time, indexedCount
 func (w *Writer) FailCorpus(corpusID string, startedAt time.Time, runErr error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	now := time.Now().UTC()
 	w.file.Last[corpusID] = CorpusState{
 		State:      "failed",
-		FinishedAt: time.Now().UTC(),
+		FinishedAt: now,
 		DurationMS: time.Since(startedAt).Milliseconds(),
 		Error:      runErr.Error(),
 	}
 	w.file.Current = nil
-	w.file.UpdatedAt = time.Now().UTC()
+	w.file.UpdatedAt = now
 	w.flush()
 }
 
-// DisableCorpus records that a corpus is intentionally disabled.
+// DisableCorpus records that a corpus is intentionally disabled. Short-circuits
+// without flushing if the corpus is already disabled.
 func (w *Writer) DisableCorpus(corpusID string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	// No-op if already disabled — avoids unnecessary I/O in init loops.
+	if cs, ok := w.file.Last[corpusID]; ok && cs.State == "disabled" {
+		return
+	}
+	now := time.Now().UTC()
 	w.file.Last[corpusID] = CorpusState{State: "disabled"}
-	w.file.UpdatedAt = time.Now().UTC()
+	w.file.UpdatedAt = now
 	w.flush()
 }
 
 // flush writes the status file atomically (write tmp + rename). Caller
-// must hold w.mu.
+// must hold w.mu. Errors are reported to w.ErrLog (defaults to os.Stderr).
 func (w *Writer) flush() {
+	errLog := w.ErrLog
+	if errLog == nil {
+		errLog = os.Stderr
+	}
 	data, err := json.MarshalIndent(&w.file, "", "  ")
 	if err != nil {
+		_, _ = fmt.Fprintf(errLog, "status: marshal error: %v\n", err)
 		return
 	}
 	tmp := w.path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		_, _ = fmt.Fprintf(errLog, "status: write error: %v\n", err)
 		return
 	}
-	_ = os.Rename(tmp, w.path)
+	if err := os.Rename(tmp, w.path); err != nil {
+		_, _ = fmt.Fprintf(errLog, "status: rename error: %v\n", err)
+		return
+	}
 	w.lastFlush = time.Now()
 }

--- a/search/status/status.go
+++ b/search/status/status.go
@@ -1,0 +1,179 @@
+// Package status tracks the state of search index runs so agents and CLI
+// users can tell whether the index is idle, running, complete, or failed
+// without inspecting lock files or log tails.
+//
+// State is persisted to .cspace/search-index-status.json via atomic
+// write-tmp-then-rename so concurrent readers never see a partial file.
+package status
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// File is the on-disk JSON shape written to .cspace/search-index-status.json.
+type File struct {
+	UpdatedAt time.Time              `json:"updated_at"`
+	Current   *RunningState          `json:"current"` // nil when idle
+	Last      map[string]CorpusState `json:"last"`    // keyed by corpus id
+}
+
+// RunningState describes an in-progress index run.
+type RunningState struct {
+	Corpus    string    `json:"corpus"`
+	StartedAt time.Time `json:"started_at"`
+	Progress  Progress  `json:"progress"`
+}
+
+// Progress tracks items processed vs total.
+type Progress struct {
+	Done  int `json:"done"`
+	Total int `json:"total"`
+}
+
+// CorpusState records the outcome of the most recent index run for one corpus.
+type CorpusState struct {
+	State        string    `json:"state"` // "completed", "failed", "disabled"
+	FinishedAt   time.Time `json:"finished_at,omitempty"`
+	DurationMS   int64     `json:"duration_ms,omitempty"`
+	IndexedCount int       `json:"indexed_count,omitempty"`
+	Error        string    `json:"error,omitempty"`
+}
+
+// StatusPath returns the canonical path for the status file inside a project.
+func StatusPath(projectRoot string) string {
+	return filepath.Join(projectRoot, ".cspace", "search-index-status.json")
+}
+
+// Read loads and parses the status file. Returns nil (not an error) when the
+// file does not exist — the caller can treat that as "never indexed".
+func Read(projectRoot string) (*File, error) {
+	data, err := os.ReadFile(StatusPath(projectRoot))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
+// Writer manages atomic writes to the status file. It is safe for concurrent
+// use from a single process (the indexer's progress callback fires from
+// goroutines). Writes are throttled to at most once per second to avoid
+// hammering the filesystem during fast progress updates.
+type Writer struct {
+	path string
+	mu   sync.Mutex
+	file File
+
+	// lastFlush tracks the wall-clock time of the most recent disk write so
+	// we can throttle progress-driven updates.
+	lastFlush time.Time
+}
+
+// NewWriter creates a Writer targeting projectRoot. It loads any existing
+// status file so incremental updates preserve prior corpus states.
+func NewWriter(projectRoot string) (*Writer, error) {
+	p := StatusPath(projectRoot)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return nil, err
+	}
+	w := &Writer{path: p}
+	existing, err := Read(projectRoot)
+	if err == nil && existing != nil {
+		w.file = *existing
+	}
+	if w.file.Last == nil {
+		w.file.Last = make(map[string]CorpusState)
+	}
+	return w, nil
+}
+
+// StartCorpus records that an index run has begun for corpusID. Always
+// flushes immediately so a fast query sees "indexing is running".
+func (w *Writer) StartCorpus(corpusID string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.file.Current = &RunningState{
+		Corpus:    corpusID,
+		StartedAt: time.Now().UTC(),
+	}
+	w.file.UpdatedAt = time.Now().UTC()
+	w.flush()
+}
+
+// UpdateProgress records incremental progress. Throttled to ~1/sec.
+func (w *Writer) UpdateProgress(done, total int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file.Current == nil {
+		return
+	}
+	w.file.Current.Progress = Progress{Done: done, Total: total}
+	w.file.UpdatedAt = time.Now().UTC()
+	if time.Since(w.lastFlush) >= time.Second {
+		w.flush()
+	}
+}
+
+// FinishCorpus records a successful completion.
+func (w *Writer) FinishCorpus(corpusID string, startedAt time.Time, indexedCount int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.file.Last[corpusID] = CorpusState{
+		State:        "completed",
+		FinishedAt:   time.Now().UTC(),
+		DurationMS:   time.Since(startedAt).Milliseconds(),
+		IndexedCount: indexedCount,
+	}
+	w.file.Current = nil
+	w.file.UpdatedAt = time.Now().UTC()
+	w.flush()
+}
+
+// FailCorpus records a failed run.
+func (w *Writer) FailCorpus(corpusID string, startedAt time.Time, runErr error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.file.Last[corpusID] = CorpusState{
+		State:      "failed",
+		FinishedAt: time.Now().UTC(),
+		DurationMS: time.Since(startedAt).Milliseconds(),
+		Error:      runErr.Error(),
+	}
+	w.file.Current = nil
+	w.file.UpdatedAt = time.Now().UTC()
+	w.flush()
+}
+
+// DisableCorpus records that a corpus is intentionally disabled.
+func (w *Writer) DisableCorpus(corpusID string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.file.Last[corpusID] = CorpusState{State: "disabled"}
+	w.file.UpdatedAt = time.Now().UTC()
+	w.flush()
+}
+
+// flush writes the status file atomically (write tmp + rename). Caller
+// must hold w.mu.
+func (w *Writer) flush() {
+	data, err := json.MarshalIndent(&w.file, "", "  ")
+	if err != nil {
+		return
+	}
+	tmp := w.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, w.path)
+	w.lastFlush = time.Now()
+}

--- a/search/status/status.go
+++ b/search/status/status.go
@@ -71,6 +71,10 @@ func Read(projectRoot string) (*File, error) {
 // the MCP tool and the CLI serialize this same struct so their JSON output
 // is guaranteed identical. Extracted per PR #61 review item #5.
 type ComputedStatus struct {
+	// Enabled mirrors the top-level `enabled:` field of search.yaml. When
+	// false, search is opted out project-wide and Corpora is empty —
+	// clients should show a "not configured" message.
+	Enabled bool                      `json:"enabled"`
 	Corpora map[string]ComputedCorpus `json:"corpora"`
 	Current *RunningState             `json:"current"`
 }
@@ -91,16 +95,23 @@ type ComputedCorpus struct {
 type StalenessChecker func(corpusID string) (stale bool, reason string)
 
 // Compute builds a ComputedStatus from the on-disk status file and config.
+// searchEnabled mirrors the top-level search.yaml `enabled:` field; when
+// false, the output flags Enabled=false and skips the per-corpus loop
+// so clients see a single "not configured" signal.
 // disabledCorpora is the set of corpus IDs that are disabled in config.
 // checkStaleness is an optional callback for staleness checks (may be nil).
-func Compute(projectRoot string, disabledCorpora map[string]bool, checkStaleness StalenessChecker) (*ComputedStatus, error) {
+func Compute(projectRoot string, searchEnabled bool, disabledCorpora map[string]bool, checkStaleness StalenessChecker) (*ComputedStatus, error) {
+	if !searchEnabled {
+		return &ComputedStatus{Enabled: false, Corpora: map[string]ComputedCorpus{}}, nil
+	}
+
 	sf, err := Read(projectRoot)
 	if err != nil {
 		return nil, err
 	}
 
 	allCorpora := []string{"code", "commits", "context", "issues"}
-	out := &ComputedStatus{Corpora: make(map[string]ComputedCorpus)}
+	out := &ComputedStatus{Enabled: true, Corpora: make(map[string]ComputedCorpus)}
 	if sf != nil {
 		out.Current = sf.Current
 	}

--- a/search/status/status_test.go
+++ b/search/status/status_test.go
@@ -183,6 +183,79 @@ func TestRead_MissingFile(t *testing.T) {
 	}
 }
 
+// TestWriter_DisableCorpusDoesNotClobberExistingEntries is a regression test
+// for PR #61 item #1: an outer writer whose in-memory snapshot is stale can
+// clobber entries written by inner writers. The fix is single-use writers —
+// each DisableCorpus call uses a fresh writer that re-reads on construction.
+func TestWriter_DisableCorpusDoesNotClobberExistingEntries(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".cspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate runSearchIndex writing completed state for "code" and "commits"
+	// via fresh single-use writers (as index.Run does internally).
+	w1, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w1.FinishCorpus("code", time.Now(), 100)
+
+	w2, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w2.FinishCorpus("commits", time.Now(), 50)
+
+	// Now simulate the disabled-state writes for "context" and "issues" using
+	// fresh writers (as the fixed runSearchIndex does for ErrCorpusDisabled).
+	w3, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w3.DisableCorpus("context")
+
+	w4, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w4.DisableCorpus("issues")
+
+	// All four corpora must be present with correct states.
+	f, err := Read(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f == nil {
+		t.Fatal("expected non-nil status file")
+	}
+
+	want := map[string]string{
+		"code":    "completed",
+		"commits": "completed",
+		"context": "disabled",
+		"issues":  "disabled",
+	}
+	for id, wantState := range want {
+		cs, ok := f.Last[id]
+		if !ok {
+			t.Errorf("corpus %q missing from Last map", id)
+			continue
+		}
+		if cs.State != wantState {
+			t.Errorf("corpus %q: want state=%q, got %q", id, wantState, cs.State)
+		}
+	}
+	// Check that code still has its indexed count (not clobbered).
+	if f.Last["code"].IndexedCount != 100 {
+		t.Errorf("code indexed_count clobbered: want 100, got %d", f.Last["code"].IndexedCount)
+	}
+	if f.Last["commits"].IndexedCount != 50 {
+		t.Errorf("commits indexed_count clobbered: want 50, got %d", f.Last["commits"].IndexedCount)
+	}
+}
+
 func TestWriter_UpdateProgress(t *testing.T) {
 	dir := t.TempDir()
 	projectRoot := dir

--- a/search/status/status_test.go
+++ b/search/status/status_test.go
@@ -1,10 +1,12 @@
 package status
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -284,5 +286,103 @@ func TestWriter_UpdateProgress(t *testing.T) {
 	}
 	if f.Current.Progress.Done != 10 || f.Current.Progress.Total != 100 {
 		t.Errorf("unexpected progress: %+v", f.Current.Progress)
+	}
+}
+
+// TestWriter_FlushReportsErrors verifies that flush errors are written to
+// the ErrLog writer rather than silently dropped. PR #61 review item #6.
+func TestWriter_FlushReportsErrors(t *testing.T) {
+	// Point the Writer at a nonexistent directory — writes will fail.
+	var errBuf bytes.Buffer
+	w := &Writer{
+		path:   "/nonexistent-dir/status.json",
+		ErrLog: &errBuf,
+		file:   File{Last: make(map[string]CorpusState)},
+	}
+
+	w.FinishCorpus("code", time.Now(), 42)
+
+	if errBuf.Len() == 0 {
+		t.Error("expected flush error to be written to ErrLog, got nothing")
+	}
+	if !strings.Contains(errBuf.String(), "status:") {
+		t.Errorf("expected 'status:' prefix in error, got: %s", errBuf.String())
+	}
+}
+
+// TestWriter_DisableCorpusShortCircuit verifies that calling DisableCorpus
+// when the corpus is already disabled doesn't flush (no I/O). PR #61 item #9.
+func TestWriter_DisableCorpusShortCircuit(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".cspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First call: should flush.
+	w.DisableCorpus("context")
+	stat1, err := os.Stat(StatusPath(projectRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	modTime1 := stat1.ModTime()
+
+	// Let a bit of time pass so mod times differ.
+	time.Sleep(10 * time.Millisecond)
+
+	// Second call: should short-circuit (no flush).
+	w.DisableCorpus("context")
+	stat2, err := os.Stat(StatusPath(projectRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	modTime2 := stat2.ModTime()
+
+	if !modTime1.Equal(modTime2) {
+		t.Error("expected DisableCorpus to short-circuit when already disabled — mod time changed")
+	}
+}
+
+// TestCompute_Basic verifies the shared Compute function. PR #61 review item #5.
+func TestCompute_Basic(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".cspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a status file with code=completed, commits=failed.
+	w, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.FinishCorpus("code", time.Now(), 100)
+	w2, _ := NewWriter(projectRoot)
+	w2.FailCorpus("commits", time.Now(), errors.New("embed: timeout"))
+
+	disabled := map[string]bool{"context": true, "issues": true}
+	cs, err := Compute(projectRoot, disabled, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cs.Corpora["code"].State != "completed" {
+		t.Errorf("expected code=completed, got %q", cs.Corpora["code"].State)
+	}
+	if cs.Corpora["commits"].State != "failed" {
+		t.Errorf("expected commits=failed, got %q", cs.Corpora["commits"].State)
+	}
+	if cs.Corpora["context"].State != "disabled" {
+		t.Errorf("expected context=disabled, got %q", cs.Corpora["context"].State)
+	}
+	if cs.Corpora["issues"].State != "disabled" {
+		t.Errorf("expected issues=disabled, got %q", cs.Corpora["issues"].State)
+	}
+	if cs.Corpora["code"].IndexedCount != 100 {
+		t.Errorf("expected code indexed_count=100, got %d", cs.Corpora["code"].IndexedCount)
 	}
 }

--- a/search/status/status_test.go
+++ b/search/status/status_test.go
@@ -1,0 +1,215 @@
+package status
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWriter_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	cspaceDir := filepath.Join(projectRoot, ".cspace")
+	if err := os.MkdirAll(cspaceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w.StartCorpus("code")
+
+	// Status file should exist and be valid JSON.
+	data, err := os.ReadFile(StatusPath(projectRoot))
+	if err != nil {
+		t.Fatal("status file not created:", err)
+	}
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatal("invalid JSON:", err)
+	}
+	if f.Current == nil {
+		t.Fatal("expected current to be set")
+	}
+	if f.Current.Corpus != "code" {
+		t.Errorf("expected corpus=code, got %q", f.Current.Corpus)
+	}
+
+	// No .tmp file should remain.
+	if _, err := os.Stat(StatusPath(projectRoot) + ".tmp"); !os.IsNotExist(err) {
+		t.Error("tmp file should not exist after write")
+	}
+}
+
+func TestWriter_FinishCorpus(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".cspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now().Add(-50 * time.Millisecond) // simulate a run that took 50ms+
+	w.StartCorpus("code")
+	w.FinishCorpus("code", start, 42)
+
+	f, err := Read(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Current != nil {
+		t.Error("expected current to be nil after finish")
+	}
+	cs, ok := f.Last["code"]
+	if !ok {
+		t.Fatal("expected 'code' in Last map")
+	}
+	if cs.State != "completed" {
+		t.Errorf("expected state=completed, got %q", cs.State)
+	}
+	if cs.IndexedCount != 42 {
+		t.Errorf("expected indexed_count=42, got %d", cs.IndexedCount)
+	}
+	if cs.DurationMS <= 0 {
+		t.Errorf("expected positive duration_ms, got %d", cs.DurationMS)
+	}
+}
+
+func TestWriter_FailCorpus(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".cspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	w.StartCorpus("commits")
+	w.FailCorpus("commits", start, errors.New("embed batch 3: connection refused"))
+
+	f, err := Read(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Current != nil {
+		t.Error("expected current to be nil after fail")
+	}
+	cs := f.Last["commits"]
+	if cs.State != "failed" {
+		t.Errorf("expected state=failed, got %q", cs.State)
+	}
+	if cs.Error != "embed batch 3: connection refused" {
+		t.Errorf("unexpected error: %q", cs.Error)
+	}
+}
+
+func TestWriter_DisableCorpus(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".cspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w.DisableCorpus("context")
+
+	f, err := Read(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := f.Last["context"]
+	if cs.State != "disabled" {
+		t.Errorf("expected state=disabled, got %q", cs.State)
+	}
+}
+
+func TestWriter_PreservesExistingState(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".cspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// First writer records code as completed.
+	w1, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w1.FinishCorpus("code", time.Now(), 100)
+
+	// Second writer records commits as completed — code should still be there.
+	w2, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w2.FinishCorpus("commits", time.Now(), 50)
+
+	f, err := Read(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Last["code"].State != "completed" {
+		t.Error("code state was not preserved")
+	}
+	if f.Last["commits"].State != "completed" {
+		t.Error("commits state was not recorded")
+	}
+}
+
+func TestRead_MissingFile(t *testing.T) {
+	f, err := Read(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f != nil {
+		t.Error("expected nil for missing file")
+	}
+}
+
+func TestWriter_UpdateProgress(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".cspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := NewWriter(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w.StartCorpus("code")
+	// Force a flush by resetting lastFlush.
+	w.mu.Lock()
+	w.lastFlush = time.Time{}
+	w.mu.Unlock()
+	w.UpdateProgress(10, 100)
+
+	f, err := Read(projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Current == nil {
+		t.Fatal("expected current to be set")
+	}
+	if f.Current.Progress.Done != 10 || f.Current.Progress.Total != 100 {
+		t.Errorf("unexpected progress: %+v", f.Current.Progress)
+	}
+}

--- a/search/status/status_test.go
+++ b/search/status/status_test.go
@@ -366,9 +366,12 @@ func TestCompute_Basic(t *testing.T) {
 	w2.FailCorpus("commits", time.Now(), errors.New("embed: timeout"))
 
 	disabled := map[string]bool{"context": true, "issues": true}
-	cs, err := Compute(projectRoot, disabled, nil)
+	cs, err := Compute(projectRoot, true, disabled, nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !cs.Enabled {
+		t.Errorf("expected Enabled=true in output")
 	}
 	if cs.Corpora["code"].State != "completed" {
 		t.Errorf("expected code=completed, got %q", cs.Corpora["code"].State)
@@ -384,5 +387,34 @@ func TestCompute_Basic(t *testing.T) {
 	}
 	if cs.Corpora["code"].IndexedCount != 100 {
 		t.Errorf("expected code indexed_count=100, got %d", cs.Corpora["code"].IndexedCount)
+	}
+}
+
+// TestCompute_SearchDisabled verifies that when the master switch is
+// off, Compute returns Enabled=false and an empty corpora map — no
+// leaking prior state from a previous session when enabled was true.
+func TestCompute_SearchDisabled(t *testing.T) {
+	dir := t.TempDir()
+	projectRoot := dir
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".cspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a status file so we can verify it is NOT surfaced.
+	w, _ := NewWriter(projectRoot)
+	w.FinishCorpus("code", time.Now(), 100)
+
+	cs, err := Compute(projectRoot, false, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cs.Enabled {
+		t.Errorf("expected Enabled=false when master switch is off")
+	}
+	if len(cs.Corpora) != 0 {
+		t.Errorf("expected empty corpora map when disabled, got %d entries", len(cs.Corpora))
+	}
+	if cs.Current != nil {
+		t.Errorf("expected Current=nil when disabled")
 	}
 }


### PR DESCRIPTION
## Summary

- **Remove auto-reindex hooks** from `lefthook.yml` — the `post-commit`, `post-checkout`, and `post-merge` hooks that fired `cspace-search index` on every git event are gone. They were more costly than useful for typical commits.
- **Add staleness detection** (`search/corpus/staleness.go`) — cheap checks that compare git state against qdrant without re-embedding. `CodeStaleness` diffs `git ls-files` hashes; `CommitsStaleness` compares commit counts.
- **Add index status file** (`search/status/`) — atomic JSON status file at `.cspace/search-index-status.json` tracking per-corpus state (completed/failed/disabled), in-progress runs with throttled progress, and timestamps.
- **`cspace search status` CLI command** — human-readable and `--json` output showing all corpus states, staleness, and any running index. Added to both `cspace search` and standalone `cspace-search`.
- **Staleness warnings in query responses** — queries now annotate the `Envelope.Warning` field when the index is stale, across CLI and MCP surfaces.
- **`search_status` MCP tool** — structured status output for agents to check index health before high-stakes queries.
- **Updated `using-semantic-search` skill** — replaced auto-refresh docs with the new manual workflow: check status, reindex when stale.

Related decision: `.cspace/context/decisions/2026-04-22-scope-cspace-search-to-code-commits-close-docs-decisions-con.md`

## Checklist

- [x] Remove auto-reindex hooks from `lefthook.yml`
- [x] Add staleness detection (`search/corpus/staleness.go`)
- [x] Add status file writer + types (`search/status/`)
- [x] Add `cspace search status` CLI command (both surfaces)
- [x] Surface staleness warnings in query responses (CLI + MCP)
- [x] Expose `search_status` MCP tool
- [x] Integrate status file writes into `index.Run`
- [x] Update `using-semantic-search` skill
- [x] Unit tests for staleness, status, and MCP

## Test plan

- [x] `go test ./search/...` — all search package tests pass (corpus, status, mcp, index, query, config, cluster)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Manual: `cspace-search status` shows correct output for never-indexed, disabled, completed, and stale corpora
- [x] Manual: `cspace-search status --json` emits valid structured JSON
- [x] Manual: `cspace-search index --corpus=code` writes status file with correct state and count
- [ ] Manual: verify phase 16 background bootstrap still works in a fresh `cspace up` (requires live container)
- [ ] Manual: verify `search_status` MCP tool returns correct output via `cspace search mcp` stdio

---

## Additional: hook/CI hardening

### Audit findings

1. **`rc:` config was broken (root cause #1)** — `lefthook.yml` had `rc: export PATH="$HOME/go/bin:$PATH"` which is a raw shell command, but lefthook's `rc:` expects a file path. The generated hook script rendered this as `[ -f export PATH="..." ] && . export PATH="..."` — a file-existence test on a nonsensical filename. It never matched, so `~/go/bin` was never added to `PATH`, and `golangci-lint`/`goimports` were invisible to the hooks.

2. **`--new-from-rev=HEAD~1` was too narrow (root cause #2)** — Pre-commit lint only flagged issues introduced since the prior commit. Pre-existing lint in touched files slipped through, and if a prior commit was made without hooks (due to root cause #1), the delta was against an unchecked baseline.

3. **`lefthook install` was never automated (root cause #3)** — `make setup-hooks` existed but was not called by `make build`, `make test`, or any commonly-run target. The README didn't mention it. Fresh-clone contributors had no hooks active.

4. **CI lint was PR-only (root cause #4)** — The `lint` job had `if: github.event_name == 'pull_request'`, so pushes to `main` (e.g. admin merges) skipped lint entirely. The `check` job ran `vet` and `test` but not `fmt-check`, letting format regressions through.

5. **No `--no-verify` abuse found** — No commits in history used `--no-verify`.

6. **No `core.hooksPath` override** — Git config was clean.

### Changes

**`lefthook.yml` + `.lefthookrc`** (new file):
- Extract `export PATH="$HOME/go/bin:$PATH"` into `.lefthookrc`; point `rc:` at the file so the hook script sources it correctly.
- Widen pre-commit lint from `--new-from-rev=HEAD~1` to full `golangci-lint run ./...`.
- Add `vet-go` (`go vet ./...`) as a parallel pre-commit step gated on `*.go` files.

**`Makefile`**:
- `setup-hooks` now fails loudly if `lefthook` is not in PATH (instead of silently succeeding via the fallback chain in the hook script).
- New `check-hooks` target warns to stderr if `.git/hooks/pre-commit` is missing; wired into `build` so contributors notice on first build.

**`.github/workflows/ci.yml`**:
- Removed `if: github.event_name == 'pull_request'` from the `lint` job — lint now runs on pushes to `main` too.
- Added `Format check` step (`make fmt-check`) to the `check` job.
- **Note for maintainer**: mark `check`, `lint`, and `integration-search` as required status checks in repo settings after merge.

**`README.md`**:
- Added `make install-tools` and `make setup-hooks` to the Development section.
- Added a "Git Hooks" subsection explaining the lefthook setup.

**Lint fixups** (surfaced by the stricter pre-commit lint):
- `internal/cli/search.go` — gofmt: removed trailing whitespace in struct tag alignment.
- `search/corpus/staleness.go` — ineffassign: removed unused `headHash` variable (the function validates git state via `rev-list --count`).
- `search/mcp/server_test.go` — staticcheck SA1012: replaced `nil` context with `context.TODO()` in test calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Addressed review feedback

All items from [the review comment](https://github.com/elliottregan/cspace/pull/61#issuecomment-4293217617) are now fixed:

| # | Severity | Issue | Commit |
|---|----------|-------|--------|
| 1 | 🔴 Critical | Data-loss race in `runSearchInit` — outer writer clobbers inner writers | `94c8b6d` |
| 2 | 🔴 Critical | `CommitsStaleness` permanent false positive under `commits.limit` | `3c576c9` |
| 3 | 🟠 Significant | Staleness check costs 100–500ms on every query — added 30s TTL cache | `0d6cd6c` |
| 4 | 🟠 Significant | `CodeStaleness` misses deleted-but-still-indexed ghost entries | `494828c` |
| 5 | 🟡 Minor | Duplicate status logic between MCP and CLI — extracted `status.Compute` | `c76d629` |
| 6 | 🟡 Minor | `Writer.flush` swallows errors silently — added `ErrLog` callback | `c76d629` |
| 7 | 🟡 Minor | 30s git ls-files timeout too generous on hot path — reduced to 5s | `0d6cd6c` |
| 8 | 🟡 Minor | Redundant `time.Now().UTC()` calls — capture once per mutator | `c76d629` |
| 9 | 🟡 Minor | `DisableCorpus` flushes unnecessarily — added no-op short-circuit | `c76d629` |

### New tests added
- `TestWriter_DisableCorpusDoesNotClobberExistingEntries` — regression for #1
- `TestCommitsStaleness_RespectsLimit` — regression for #2
- `TestStalenessCache_HitsWithinTTL` / `TestStalenessCache_ExpiresAfterTTL` — cache behavior for #3
- `TestCodeStaleness_DeletedFiles` — ghost detection for #4
- `TestCompute_Basic` — shared Compute function for #5
- `TestWriter_FlushReportsErrors` — error surface for #6
- `TestWriter_DisableCorpusShortCircuit` — no-op behavior for #9

### Durable context decisions logged
5 pattern decisions logged to `.cspace/context/decisions/` in `4171564`:
1. Writer instances must refresh state before writing OR be single-use
2. Don't compare counts when limits are in play — compare identities or timestamps
3. Secondary work injected into query paths needs a latency budget
4. Delta detection needs symmetric difference, not one-sided membership
5. Don't use planet names for agent-spawned cspace instances

### Instance naming guidance
Updated `lib/skills/delegating-container-agents/SKILL.md`, `lib/agents/coordinator.md`, and `CLAUDE.md` to note that planet names are reserved for the TUI — agents should use descriptive names (`issue-<n>`, `cs-agent-<n>`, etc.) in `1b3fcd0`.

### Search bootstrap now opt-in
`b1980b5` — Phase 16 (search bootstrap) is now role-aware:
- `cspace up`: NO auto-index by default; pass `--index` to opt in
- `cspace advisor up`: auto-index (session-continuous, search-heavy)
- `cspace coordinate`: auto-index for the coordinator
- Logged decision #6: "Bootstrap search indexing is opt-in; advisors and coordinators get it by default"

🤖 Generated with [Claude Code](https://claude.com/claude-code)