### PR TITLE
Project-scoped search sidecars (one per project, not per instance)

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/elliottregan/cspace/internal/compose"
 	"github.com/elliottregan/cspace/internal/docker"
@@ -24,13 +25,18 @@ func newDownCmd() *cobra.Command {
 				return downEverywhere()
 			}
 
+			projectFlag, _ := cmd.Flags().GetBool("project")
+			if projectFlag {
+				return runDownProject()
+			}
+
 			allFlag, _ := cmd.Flags().GetBool("all")
 			if allFlag {
 				return runDownAll()
 			}
 
 			if len(args) == 0 {
-				return fmt.Errorf("usage: cspace down <name> | --all | --everywhere")
+				return fmt.Errorf("usage: cspace down <name> | --all | --project | --everywhere")
 			}
 
 			return runDownInstance(args[0])
@@ -38,6 +44,7 @@ func newDownCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("all", false, "Destroy all instances for this project")
+	cmd.Flags().Bool("project", false, "Destroy all instances AND the shared search stack for this project")
 	cmd.Flags().Bool("everywhere", false, "Destroy ALL cspace instances across all projects")
 
 	return cmd
@@ -78,6 +85,36 @@ func runDownAll() error {
 	return nil
 }
 
+// runDownProject tears down all instances AND the project-scoped search
+// sidecar stack for the current project.
+func runDownProject() error {
+	// First tear down all instances (same as --all).
+	names, err := instance.GetInstances(cfg)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range names {
+		fmt.Printf("Tearing down instance: %s\n", name)
+		if err := compose.Run(name, cfg, "down", "--volumes"); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: %v\n", err)
+		}
+	}
+
+	// Then tear down the project search stack + its volumes.
+	stackName := cfg.ProjectStackName()
+	fmt.Printf("Tearing down project search stack: %s\n", stackName)
+	if err := compose.ProjectStackDown(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: %v\n", err)
+	}
+
+	// Remove the project network last.
+	docker.NetworkRemove(cfg.ProjectNetwork())
+
+	fmt.Println("Project fully torn down.")
+	return nil
+}
+
 // downEverywhere tears down ALL cspace instances across all projects.
 // Requires user confirmation before proceeding.
 func downEverywhere() error {
@@ -86,24 +123,36 @@ func downEverywhere() error {
 		return err
 	}
 
-	if len(infos) == 0 {
-		fmt.Println("No cspace instances running anywhere.")
+	// Discover project stacks to tear down.
+	projectStacks := discoverProjectStacks()
+
+	if len(infos) == 0 && len(projectStacks) == 0 {
+		fmt.Println("No cspace instances or project stacks running anywhere.")
 		return nil
 	}
 
 	// Show what's about to be destroyed
 	fmt.Println("About to tear down ALL cspace instances across ALL projects:")
 	fmt.Println()
-	fmt.Printf("  %-16s %-20s\n", "INSTANCE", "PROJECT")
-	fmt.Printf("  %-16s %-20s\n", "--------", "-------")
-	for _, info := range infos {
-		project := info.Project
-		if project == "" {
-			project = "?"
+	if len(infos) > 0 {
+		fmt.Printf("  %-16s %-20s\n", "INSTANCE", "PROJECT")
+		fmt.Printf("  %-16s %-20s\n", "--------", "-------")
+		for _, info := range infos {
+			project := info.Project
+			if project == "" {
+				project = "?"
+			}
+			fmt.Printf("  %-16s %-20s\n", info.ComposeName, project)
 		}
-		fmt.Printf("  %-16s %-20s\n", info.ComposeName, project)
+		fmt.Println()
 	}
-	fmt.Println()
+	if len(projectStacks) > 0 {
+		fmt.Println("  Project search stacks:")
+		for _, stack := range projectStacks {
+			fmt.Printf("    %s\n", stack)
+		}
+		fmt.Println()
+	}
 
 	// Prompt for confirmation
 	fmt.Print("Type 'yes' to continue: ")
@@ -121,6 +170,48 @@ func downEverywhere() error {
 		}
 	}
 
+	// Tear down project stacks
+	for _, stack := range projectStacks {
+		fmt.Printf("Tearing down project stack: %s\n", stack)
+		if err := compose.ProjectStackDownDirect(stack); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: %v\n", err)
+		}
+	}
+
+	// Remove project networks for each unique project
+	seen := make(map[string]bool)
+	for _, info := range infos {
+		if info.Project != "" && !seen[info.Project] {
+			seen[info.Project] = true
+			docker.NetworkRemove("cspace-" + info.Project)
+		}
+	}
+
 	fmt.Println("Done.")
 	return nil
+}
+
+// discoverProjectStacks finds all running project-scoped search sidecar
+// stacks by querying Docker for compose projects matching the naming
+// convention "cspace-*-stack".
+func discoverProjectStacks() []string {
+	out, err := docker.Exec("ps", "--filter", "label=com.docker.compose.project",
+		"--format", `{{.Label "com.docker.compose.project"}}`)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var stacks []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "cspace-") && strings.HasSuffix(line, "-stack") && !seen[line] {
+			seen[line] = true
+			stacks = append(stacks, line)
+		}
+	}
+	return stacks
 }

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -115,6 +115,7 @@ func ComposeEnv(name string, cfg *config.Config) []string {
 		"CSPACE_LOGS_VOLUME=" + cfg.LogsVolume(),
 		"CSPACE_LABEL=" + cfg.InstanceLabel(),
 		"CSPACE_PROJECT_NETWORK=" + cfg.ProjectNetwork(),
+		"CSPACE_PROJECT_STACK_NAME=" + cfg.ProjectStackName(),
 		"CSPACE_HOME=" + cspaceHome,
 		"CSPACE_SESSIONS_DIR=" + cfg.SessionsDir(),
 		"HOST_PORT_DEV=" + strconv.Itoa(pm.Dev),

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -41,12 +41,14 @@ func TestComposeEnv(t *testing.T) {
 	}{
 		{"COMPOSE_PROJECT_NAME", "mp-mercury"},
 		{"CSPACE_CONTAINER_NAME", "mp-mercury"},
+		{"CSPACE_INSTANCE_NAME", "mercury"},
 		{"CSPACE_PROJECT_NAME", "myproject"},
 		{"CSPACE_PREFIX", "mp"},
 		{"CSPACE_IMAGE", "cspace-myproject"},
 		{"CSPACE_MEMORY_VOLUME", "cspace-myproject-memory"},
 		{"CSPACE_LOGS_VOLUME", "cspace-myproject-logs"},
 		{"CSPACE_LABEL", "cspace.project=myproject"},
+		{"CSPACE_PROJECT_STACK_NAME", "cspace-myproject-stack"},
 		{"CSPACE_HOME", "/home/user/.cspace"},
 		{"HOST_PORT_DEV", "0"},     // all instances use Docker-assigned ports
 		{"HOST_PORT_PREVIEW", "0"}, // all instances use Docker-assigned ports

--- a/internal/compose/project.go
+++ b/internal/compose/project.go
@@ -1,0 +1,102 @@
+package compose
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/elliottregan/cspace/internal/config"
+)
+
+// ProjectStackEnv computes the environment variables needed by the project
+// stack compose template (docker-compose.project.yml).
+func ProjectStackEnv(cfg *config.Config) []string {
+	cspaceHome := filepath.Dir(cfg.AssetsDir)
+
+	return []string{
+		"COMPOSE_PROJECT_NAME=" + cfg.ProjectStackName(),
+		"CSPACE_PROJECT_STACK_NAME=" + cfg.ProjectStackName(),
+		"CSPACE_PROJECT_NAME=" + cfg.Project.Name,
+		"CSPACE_PROJECT_NETWORK=" + cfg.ProjectNetwork(),
+		"CSPACE_HOME=" + cspaceHome,
+	}
+}
+
+// ProjectStackUp starts the project-scoped search sidecar stack.
+// Idempotent — reusing an already-running stack is a no-op.
+func ProjectStackUp(cfg *config.Config) error {
+	composeFile, err := cfg.ResolveTemplate("docker-compose.project.yml")
+	if err != nil {
+		return fmt.Errorf("resolving project stack compose file: %w", err)
+	}
+
+	stackName := cfg.ProjectStackName()
+	cmd := exec.Command("docker", "compose",
+		"-f", composeFile,
+		"-p", stackName,
+		"up", "-d",
+	)
+	cmd.Env = append(os.Environ(), ProjectStackEnv(cfg)...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("starting project stack %s: %w", stackName, err)
+	}
+	return nil
+}
+
+// ProjectStackDown tears down the project-scoped search sidecar stack,
+// removing its containers and volumes.
+func ProjectStackDown(cfg *config.Config) error {
+	composeFile, err := cfg.ResolveTemplate("docker-compose.project.yml")
+	if err != nil {
+		return fmt.Errorf("resolving project stack compose file: %w", err)
+	}
+
+	stackName := cfg.ProjectStackName()
+	cmd := exec.Command("docker", "compose",
+		"-f", composeFile,
+		"-p", stackName,
+		"down", "--volumes",
+	)
+	cmd.Env = append(os.Environ(), ProjectStackEnv(cfg)...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("stopping project stack %s: %w", stackName, err)
+	}
+	return nil
+}
+
+// ProjectStackRunning checks whether any container belonging to the
+// project stack is currently running.
+func ProjectStackRunning(cfg *config.Config) bool {
+	stackName := cfg.ProjectStackName()
+	out, err := exec.Command(
+		"docker", "compose",
+		"-p", stackName,
+		"ps", "--status", "running", "-q",
+	).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
+}
+
+// ProjectStackDownDirect tears down a project stack by compose project name
+// alone, without needing config or compose file resolution. Used by
+// `cspace down --everywhere` where we only have the stack name from Docker
+// labels.
+func ProjectStackDownDirect(stackName string) error {
+	cmd := exec.Command("docker", "compose",
+		"-p", stackName,
+		"down", "--volumes",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/compose/project_test.go
+++ b/internal/compose/project_test.go
@@ -1,0 +1,111 @@
+package compose
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elliottregan/cspace/internal/config"
+)
+
+func TestProjectStackEnv(t *testing.T) {
+	cfg := &config.Config{
+		Project: config.ProjectConfig{
+			Name:   "myproject",
+			Prefix: "mp",
+		},
+		ProjectRoot: "/home/user/myproject",
+		AssetsDir:   "/home/user/.cspace/lib",
+	}
+
+	env := ProjectStackEnv(cfg)
+
+	m := make(map[string]string)
+	for _, e := range env {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+		}
+	}
+
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"COMPOSE_PROJECT_NAME", "cspace-myproject-stack"},
+		{"CSPACE_PROJECT_STACK_NAME", "cspace-myproject-stack"},
+		{"CSPACE_PROJECT_NAME", "myproject"},
+		{"CSPACE_PROJECT_NETWORK", "cspace-myproject"},
+		{"CSPACE_HOME", "/home/user/.cspace"},
+	}
+
+	for _, tt := range tests {
+		got, ok := m[tt.key]
+		if !ok {
+			t.Errorf("ProjectStackEnv missing key %q", tt.key)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ProjectStackEnv[%q] = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestProjectStackEnvMatchesInstanceEnv(t *testing.T) {
+	// Verify that CSPACE_PROJECT_NETWORK and CSPACE_HOME are consistent
+	// between the instance env and the project stack env.
+	cfg := &config.Config{
+		Project: config.ProjectConfig{
+			Name:   "resume-redux",
+			Prefix: "re",
+		},
+		ProjectRoot: "/home/user/resume-redux",
+		AssetsDir:   "/home/user/.cspace/lib",
+	}
+
+	stackEnv := ProjectStackEnv(cfg)
+	instanceEnv := ComposeEnv("mercury", cfg)
+
+	stackMap := envToMap(stackEnv)
+	instanceMap := envToMap(instanceEnv)
+
+	// These keys must be identical across both envs
+	shared := []string{"CSPACE_PROJECT_NETWORK", "CSPACE_HOME", "CSPACE_PROJECT_NAME"}
+	for _, key := range shared {
+		sv, sok := stackMap[key]
+		iv, iok := instanceMap[key]
+		if !sok {
+			t.Errorf("ProjectStackEnv missing shared key %q", key)
+			continue
+		}
+		if !iok {
+			t.Errorf("ComposeEnv missing shared key %q", key)
+			continue
+		}
+		if sv != iv {
+			t.Errorf("shared key %q mismatch: stack=%q, instance=%q", key, sv, iv)
+		}
+	}
+
+	// CSPACE_PROJECT_STACK_NAME should be present in both
+	if _, ok := stackMap["CSPACE_PROJECT_STACK_NAME"]; !ok {
+		t.Error("ProjectStackEnv missing CSPACE_PROJECT_STACK_NAME")
+	}
+	if _, ok := instanceMap["CSPACE_PROJECT_STACK_NAME"]; !ok {
+		t.Error("ComposeEnv missing CSPACE_PROJECT_STACK_NAME")
+	}
+	if stackMap["CSPACE_PROJECT_STACK_NAME"] != instanceMap["CSPACE_PROJECT_STACK_NAME"] {
+		t.Errorf("CSPACE_PROJECT_STACK_NAME mismatch: stack=%q, instance=%q",
+			stackMap["CSPACE_PROJECT_STACK_NAME"], instanceMap["CSPACE_PROJECT_STACK_NAME"])
+	}
+}
+
+func envToMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, e := range env {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+		}
+	}
+	return m
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -309,6 +309,13 @@ func (c *Config) SessionsDir() string {
 	return filepath.Join(home, ".cspace", "sessions", c.Project.Name)
 }
 
+// ProjectStackName returns the docker-compose project name for the
+// project-scoped search sidecar stack. Distinct from any instance
+// compose project name (which uses ComposeName).
+func (c *Config) ProjectStackName() string {
+	return appPrefix + "-" + c.Project.Name + "-stack"
+}
+
 // InstanceLabel returns the Docker label for this project's instances.
 func (c *Config) InstanceLabel() string {
 	return appPrefix + ".project=" + c.Project.Name

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -437,6 +437,8 @@ func TestHelpers(t *testing.T) {
 		{"MemoryVolume", cfg.MemoryVolume(), "cspace-myapp-memory"},
 		{"LogsVolume", cfg.LogsVolume(), "cspace-myapp-logs"},
 		{"InstanceLabel", cfg.InstanceLabel(), "cspace.project=myapp"},
+		{"ProjectStackName", cfg.ProjectStackName(), "cspace-myapp-stack"},
+		{"ProjectNetwork", cfg.ProjectNetwork(), "cspace-myapp"},
 	}
 
 	for _, tt := range tests {

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -63,8 +63,8 @@ type Result struct {
 //
 // Progress is reported through p.Reporter (defaults to logReporter{}), which
 // receives one Phase call per entry in the Phases slice plus a final Done or
-// Error call. When the container is already running, phases 2–13 are skipped
-// and phase 1 is reported as "Reusing running container"; phase 14 (the
+// Error call. When the container is already running, phases 2–14 are skipped
+// and phase 1 is reported as "Reusing running container"; phase 15 (the
 // idempotent tail: marketplace, plugins, post-setup) always runs.
 //
 // Phases (see the Phases slice for labels):
@@ -73,17 +73,18 @@ type Result struct {
 //  3. Bundling repo
 //  4. Creating volumes
 //  5. Creating network
-//  6. Starting reverse proxy
-//  7. Setting up directories (teleport, memory, sessions, context)
-//  8. Starting containers (docker compose up -d)
-//  9. Waiting for container
-//  10. Configuring hosts (inject cspace.local → Traefik)
-//  11. Setting permissions (chown /workspace, /home/dev/.claude, /teleport)
-//  12. Initializing workspace (bundle unpack + init-workspace.sh)
-//  13. Configuring git & env (git identity, .env files, GH_TOKEN)
-//  14. Installing plugins (marketplace + plugins + post-setup)
-//  15. Syncing workspace (git fetch / checkout / pull, skip Claude onboarding)
-//  16. Bootstrapping search (cspace search init in the background)
+//  6. Starting search stack (project-scoped sidecars, idempotent)
+//  7. Starting reverse proxy
+//  8. Setting up directories (teleport, memory, sessions, context)
+//  9. Starting containers (docker compose up -d)
+//  10. Waiting for container
+//  11. Configuring hosts (inject cspace.local → Traefik)
+//  12. Setting permissions (chown /workspace, /home/dev/.claude, /teleport)
+//  13. Initializing workspace (bundle unpack + init-workspace.sh)
+//  14. Configuring git & env (git identity, .env files, GH_TOKEN)
+//  15. Installing plugins (marketplace + plugins + post-setup)
+//  16. Syncing workspace (git fetch / checkout / pull, skip Claude onboarding)
+//  17. Bootstrapping search (cspace search init in the background)
 func Run(p Params) (result Result, err error) {
 	reporter := p.reporter()
 	currentPhase := ""
@@ -161,10 +162,20 @@ func Run(p Params) (result Result, err error) {
 			return Result{}, fmt.Errorf("creating project network: %w", err)
 		}
 
-		// Phase 6: start the global reverse proxy and connect it to the
+		// Phase 6: start the project-scoped search sidecar stack
+		// (qdrant, llama-server, etc.). Idempotent — if the stack is
+		// already running from a prior instance's boot, this is a no-op.
+		// Runs before the instance compose up so sidecars are reachable
+		// via network aliases when the instance starts.
+		reportPhase(6, Phases[5])
+		if perr := compose.ProjectStackUp(cfg); perr != nil {
+			reportWarn(fmt.Sprintf("project search stack: %v", perr))
+		}
+
+		// Phase 7: start the global reverse proxy and connect it to the
 		// project network so Traefik can route traffic to instance
 		// containers.
-		reportPhase(6, Phases[5])
+		reportPhase(7, Phases[6])
 		if perr := docker.EnsureProxy(cfg.AssetsDir); perr != nil {
 			reportWarn(fmt.Sprintf("proxy: %v", perr))
 		}
@@ -172,11 +183,11 @@ func Run(p Params) (result Result, err error) {
 			reportWarn(fmt.Sprintf("connecting proxy to project network: %v", perr))
 		}
 
-		// Phase 7: set up host-side directories that compose will bind
+		// Phase 8: set up host-side directories that compose will bind
 		// mount (teleport, memory, sessions, context). Docker auto-creates
 		// missing bind-mount paths as root-owned — we create them first so
 		// they're writable by the invoking user.
-		reportPhase(7, Phases[6])
+		reportPhase(8, Phases[7])
 		tpDir := teleportHostDir()
 		if err = ensureTeleportDir(tpDir); err != nil {
 			return Result{}, err
@@ -194,44 +205,44 @@ func Run(p Params) (result Result, err error) {
 			return Result{}, err
 		}
 
-		// Phase 8: start instance containers.
-		reportPhase(8, Phases[7])
+		// Phase 9: start instance containers.
+		reportPhase(9, Phases[8])
 		if err = compose.Run(name, cfg, "up", "-d"); err != nil {
 			return Result{}, fmt.Errorf("starting container: %w", err)
 		}
 
-		// Phase 9: wait for container readiness.
-		reportPhase(9, Phases[8])
+		// Phase 10: wait for container readiness.
+		reportPhase(10, Phases[9])
 		if err = WaitForReady(composeName, 120*time.Second); err != nil {
 			return Result{}, err
 		}
 
-		// Phase 10: inject /etc/hosts entries so cspace.local hostnames
+		// Phase 11: inject /etc/hosts entries so cspace.local hostnames
 		// resolve to Traefik's Docker IP inside all containers.
-		reportPhase(10, Phases[9])
+		reportPhase(11, Phases[10])
 		if herr := docker.InjectHosts(composeName, cfg.ProjectNetwork()); herr != nil {
 			reportWarn(fmt.Sprintf("hosts injection: %v", herr))
 		}
 
-		// Phase 11: fix volume ownership. /teleport is a host bind mount
+		// Phase 12: fix volume ownership. /teleport is a host bind mount
 		// that Docker auto-creates as root when the host path doesn't
 		// already exist (common in nested DinD setups), so explicitly fix
 		// it alongside the named volumes to ensure the dev user can write
 		// bundles there.
-		reportPhase(11, Phases[10])
+		reportPhase(12, Phases[11])
 		if _, err = instance.DcExecRoot(composeName, "chown", "-R", "dev:dev", "/workspace", "/home/dev/.claude", "/teleport"); err != nil {
 			return Result{}, fmt.Errorf("fixing ownership: %w", err)
 		}
 
-		// Phase 12: copy bundle and init workspace.
-		reportPhase(12, Phases[11])
+		// Phase 13: copy bundle and init workspace.
+		reportPhase(13, Phases[12])
 		if err = initWorkspace(composeName, bundlePath, branch, remoteURL); err != nil {
 			return Result{}, fmt.Errorf("initializing workspace: %w", err)
 		}
 
-		// Phase 13: configure git identity, copy .env files, setup
+		// Phase 14: configure git identity, copy .env files, setup
 		// GH_TOKEN + gh auth.
-		reportPhase(13, Phases[12])
+		reportPhase(14, Phases[13])
 		configureGit(composeName, cfg.ProjectRoot)
 		copyEnvFile(composeName, cfg.ProjectRoot, ".env")
 		copyEnvFile(composeName, cfg.ProjectRoot, ".env.local")
@@ -250,9 +261,9 @@ func Run(p Params) (result Result, err error) {
 		reporter.Port(b.Label, b.URL)
 	}
 
-	// Phase 14: idempotent tail (marketplace + plugins + post-setup). Runs
+	// Phase 15: idempotent tail (marketplace + plugins + post-setup). Runs
 	// for both new and reused containers.
-	reportPhase(14, Phases[13])
+	reportPhase(15, Phases[14])
 	if merr := ensureMarketplace(composeName); merr != nil {
 		reportWarn(fmt.Sprintf("marketplace setup: %v", merr))
 	}
@@ -263,12 +274,12 @@ func Run(p Params) (result Result, err error) {
 		reportWarn(fmt.Sprintf("post-setup: %v", perr))
 	}
 
-	// Phase 15: last-mile workspace sync. Folded into provision.Run so
+	// Phase 16: last-mile workspace sync. Folded into provision.Run so
 	// callers can exec Claude immediately after Run returns, with no
 	// post-overlay shell commands flashing the main terminal buffer.
 	// SkipOnboarding pre-accepts Claude Code's first-run prompts; the
 	// git ops bring /workspace up to date before handoff.
-	reportPhase(15, Phases[14])
+	reportPhase(16, Phases[15])
 	if sErr := instance.SkipOnboarding(composeName); sErr != nil {
 		reportWarn(fmt.Sprintf("skip onboarding: %v", sErr))
 	}
@@ -282,12 +293,12 @@ func Run(p Params) (result Result, err error) {
 		_, _ = instance.DcExec(composeName, "git", "pull", "--ff-only", "--quiet")
 	}
 
-	// Phase 16: bootstrap semantic search — opt-in. Fires only when
+	// Phase 17: bootstrap semantic search — opt-in. Fires only when
 	// BootstrapSearch is true (advisors, coordinators, or explicit --index).
 	// Runs `cspace search init` in the background so the Claude handoff
 	// isn't blocked. Content-hash check makes re-runs a near no-op.
 	if p.BootstrapSearch {
-		reportPhase(16, Phases[15])
+		reportPhase(17, Phases[16])
 		if _, err := instance.DcExec(composeName, "bash", "-c",
 			"mkdir -p /workspace/.cspace && nohup cspace search init --quiet >>/workspace/.cspace/search-index.log 2>&1 &"); err != nil {
 			reportWarn(fmt.Sprintf("search bootstrap: %v", err))

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -62,16 +62,16 @@ func TestGitRemoteURL(t *testing.T) {
 }
 
 // TestBootstrapSearchParam verifies that the BootstrapSearch field controls
-// whether Phase 16 would fire. We can't run provision.Run in a unit test
+// whether Phase 17 would fire. We can't run provision.Run in a unit test
 // (it needs Docker), but we can verify the Params field exists and the
 // Phases list still has the correct count.
 func TestBootstrapSearchParam(t *testing.T) {
-	// Verify Phases has 16 entries (search bootstrap is the last one).
-	if len(Phases) != 16 {
-		t.Errorf("expected 16 provision phases, got %d", len(Phases))
+	// Verify Phases has 17 entries (search bootstrap is the last one).
+	if len(Phases) != 17 {
+		t.Errorf("expected 17 provision phases, got %d", len(Phases))
 	}
-	if Phases[15] != "Bootstrapping search" {
-		t.Errorf("expected phase 16 to be 'Bootstrapping search', got %q", Phases[15])
+	if Phases[16] != "Bootstrapping search" {
+		t.Errorf("expected phase 17 to be 'Bootstrapping search', got %q", Phases[16])
 	}
 
 	// Verify default Params has BootstrapSearch=false (opt-in).

--- a/internal/provision/reporter.go
+++ b/internal/provision/reporter.go
@@ -43,6 +43,7 @@ var Phases = []string{
 	"Bundling repo",
 	"Creating volumes",
 	"Creating network",
+	"Starting search stack",
 	"Starting reverse proxy",
 	"Setting up directories",
 	"Starting containers",

--- a/internal/provision/reporter_test.go
+++ b/internal/provision/reporter_test.go
@@ -38,19 +38,22 @@ func TestReporterInterfaceImplementations(t *testing.T) {
 }
 
 func TestPhasesReference(t *testing.T) {
-	if len(Phases) != 16 {
-		t.Errorf("Phases: got %d entries, want 16", len(Phases))
+	if len(Phases) != 17 {
+		t.Errorf("Phases: got %d entries, want 17", len(Phases))
 	}
 	if Phases[0] != "Validating name" {
 		t.Errorf("Phases[0]: got %q", Phases[0])
 	}
-	if Phases[13] != "Installing plugins" {
-		t.Errorf("Phases[13]: got %q", Phases[13])
+	if Phases[5] != "Starting search stack" {
+		t.Errorf("Phases[5]: got %q", Phases[5])
 	}
-	if Phases[14] != "Syncing workspace" {
+	if Phases[14] != "Installing plugins" {
 		t.Errorf("Phases[14]: got %q", Phases[14])
 	}
-	if Phases[15] != "Bootstrapping search" {
+	if Phases[15] != "Syncing workspace" {
 		t.Errorf("Phases[15]: got %q", Phases[15])
+	}
+	if Phases[16] != "Bootstrapping search" {
+		t.Errorf("Phases[16]: got %q", Phases[16])
 	}
 }

--- a/lib/templates/docker-compose.core.yml
+++ b/lib/templates/docker-compose.core.yml
@@ -5,6 +5,11 @@
 include:
   - docker-compose.search.yml
 
+# Search sidecars (qdrant, llama-server, llama-clustering, reduce-api,
+# hdbscan-api) are defined in docker-compose.project.yml and run at
+# project scope — one set shared by all instances. Instances reach them
+# via network aliases on the project network (http://qdrant:6333, etc.).
+
 services:
   cspace:
     image: ${CSPACE_IMAGE:-cspace-dev}
@@ -113,125 +118,6 @@ services:
     tty: true
     stdin_open: true
 
-  # llama.cpp embedding server — provides on-device vector embeddings for
-  # `cspace search`. Uses jina-embeddings-v5-text-nano (retrieval adapter),
-  # 768-dim, 8K context. Accessible at http://llama-server:8080.
-  # Model is downloaded from HuggingFace on first start and cached in the
-  # llama-models volume. Override with LLAMA_HF_REPO / LLAMA_HF_FILE.
-  llama-server:
-    image: ${LLAMA_IMAGE:-ghcr.io/ggml-org/llama.cpp:server}
-    container_name: ${CSPACE_CONTAINER_NAME}.llama
-    command:
-      - --hf-repo
-      - ${LLAMA_HF_REPO:-jinaai/jina-embeddings-v5-text-nano-retrieval-GGUF}
-      - --hf-file
-      - ${LLAMA_HF_FILE:-v5-nano-retrieval-Q8_0.gguf}
-      - --embedding
-      - --port
-      - "8080"
-      - --host
-      - "0.0.0.0"
-      - -c
-      - "8192"
-      - -b
-      - "8192"
-      - -ub
-      - "8192"
-    volumes:
-      - llama-models:/root/.cache
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 60
-      start_period: 120s
-    networks:
-      - default
-
-  # Second llama.cpp server running the Jina clustering adapter for
-  # `cspace search clusters`. Retrieval (query→document) and clustering
-  # (document↔document) need different adapters, so both run in parallel
-  # on separate containers. Accessible at http://llama-clustering:8080.
-  llama-clustering:
-    image: ${LLAMA_IMAGE:-ghcr.io/ggml-org/llama.cpp:server}
-    container_name: ${CSPACE_CONTAINER_NAME}.llama-cluster
-    command:
-      - --hf-repo
-      - ${LLAMA_CLUSTERING_HF_REPO:-jinaai/jina-embeddings-v5-text-nano-clustering-GGUF}
-      - --hf-file
-      - ${LLAMA_CLUSTERING_HF_FILE:-v5-nano-clustering-Q8_0.gguf}
-      - --embedding
-      - --port
-      - "8080"
-      - --host
-      - "0.0.0.0"
-      - -c
-      - "8192"
-      - -b
-      - "8192"
-      - -ub
-      - "8192"
-    volumes:
-      - llama-models:/root/.cache
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 60
-      start_period: 120s
-    networks:
-      - default
-
-  # Dimension reduction service for `cspace search clusters`. Uses PaCMAP /
-  # LocalMAP to project high-dim embeddings onto 2D. Pre-built image from
-  # mindthemath — we only consume its /reduce endpoint.
-  reduce-api:
-    image: ${REDUCE_API_IMAGE:-mindthemath/reduce-api}
-    container_name: ${CSPACE_CONTAINER_NAME}.reduce-api
-    healthcheck:
-      test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8000/health\")' || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 15s
-    networks:
-      - default
-
-  # HDBSCAN clustering service for 2D points. Runs after reduce-api. Minimal
-  # image built locally from lib/hdbscan-api/ (just hdbscan + flask).
-  hdbscan-api:
-    image: ${HDBSCAN_API_IMAGE:-cspace-hdbscan-api}
-    container_name: ${CSPACE_CONTAINER_NAME}.hdbscan
-    build:
-      context: ${CSPACE_HOME}/lib/hdbscan-api
-    healthcheck:
-      # hdbscan-api image has python but no wget/curl; match reduce-api's probe.
-      test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8090/health\")' || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
-    networks:
-      - default
-
-  # Qdrant vector database — stores commit embeddings for `cspace search`.
-  # Accessible inside the container at http://qdrant:6333 (REST) / :6334 (gRPC).
-  # Data persists in the qdrant-storage volume across container restarts.
-  qdrant:
-    image: ${QDRANT_IMAGE:-qdrant/qdrant}
-    container_name: ${CSPACE_CONTAINER_NAME}.qdrant
-    volumes:
-      - qdrant-storage:/qdrant/storage
-    healthcheck:
-      # qdrant/qdrant image ships without curl/wget; probe TCP via bash builtin.
-      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/6333'"]
-      interval: 5s
-      timeout: 3s
-      retries: 30
-      start_period: 10s
-    networks:
-      - default
-
   # Consolidated browser sidecar — headless Chrome (CDP on 9222) + Playwright
   # run-server (3000) in one container. Both MCP servers (chrome-devtools,
   # playwright) run here via docker exec from the agent container.
@@ -277,15 +163,15 @@ volumes:
   workspace:
   claude-home:
   gh-config:
-  llama-models:
-  qdrant-storage:
   # cspace-logs is the only shared/external volume — the supervisor writes
   # NDJSON events under /logs/events/<instance>/ and opens per-instance
   # sockets under /logs/messages/<instance>/, so the host-side `cspace` CLI
-  # can reach every running instance through one mount. All other volumes
-  # above are per-compose-project (e.g. qdrant-storage MUST be per-instance
-  # or concurrent qdrants conflict on a single WAL and crash). Keep this
-  # entry LAST so its `name:`/`external:` subkeys don't get silently
+  # can reach every running instance through one mount.
+  #
+  # Search sidecar volumes (qdrant-storage, llama-models) are now per-project
+  # named volumes in docker-compose.project.yml — one qdrant process per
+  # project avoids the WAL-conflict crash while sharing a single index. Keep
+  # cspace-logs LAST so its `name:`/`external:` subkeys don't get silently
   # claimed by a newly-inserted volume above.
   cspace-logs:
     name: ${CSPACE_LOGS_VOLUME:-cspace-logs}

--- a/lib/templates/docker-compose.project.yml
+++ b/lib/templates/docker-compose.project.yml
@@ -1,0 +1,166 @@
+# Project-scoped search sidecars — one per project, shared by all instances.
+#
+# Launched by `cspace up` before the per-instance stack. Every instance
+# resolves these services via Docker network aliases on the project network
+# (e.g. http://qdrant:6333, http://llama-server:8080). The sidecar URLs
+# in search/config/default.yaml stay literal; no per-instance parameterization.
+#
+# Lifecycle:
+#   - `cspace up <instance>` brings this stack up if not already running.
+#   - `cspace down <instance>` leaves this stack running.
+#   - `cspace down --project` tears down all instances AND this stack.
+#   - `cspace down --everywhere` tears down everything.
+#
+# Compose project name: cspace-<project>-stack (set via COMPOSE_PROJECT_NAME).
+
+services:
+  # llama.cpp embedding server — provides on-device vector embeddings for
+  # `cspace search`. Uses jina-embeddings-v5-text-nano (retrieval adapter),
+  # 768-dim, 8K context. Accessible at http://llama-server:8080.
+  # Model is downloaded from HuggingFace on first start and cached in the
+  # llama-models volume. Override with LLAMA_HF_REPO / LLAMA_HF_FILE.
+  llama-server:
+    image: ${LLAMA_IMAGE:-ghcr.io/ggml-org/llama.cpp:server}
+    container_name: ${CSPACE_PROJECT_STACK_NAME}-llama
+    command:
+      - --hf-repo
+      - ${LLAMA_HF_REPO:-jinaai/jina-embeddings-v5-text-nano-retrieval-GGUF}
+      - --hf-file
+      - ${LLAMA_HF_FILE:-v5-nano-retrieval-Q8_0.gguf}
+      - --embedding
+      - --port
+      - "8080"
+      - --host
+      - "0.0.0.0"
+      - -c
+      - "8192"
+      - -b
+      - "8192"
+      - -ub
+      - "8192"
+    volumes:
+      - llama-models:/root/.cache
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+      start_period: 120s
+    networks:
+      default: {}
+      project:
+        aliases:
+          - llama-server
+
+  # Second llama.cpp server running the Jina clustering adapter for
+  # `cspace search clusters`. Retrieval (query->document) and clustering
+  # (document<->document) need different adapters, so both run in parallel
+  # on separate containers. Accessible at http://llama-clustering:8080.
+  llama-clustering:
+    image: ${LLAMA_IMAGE:-ghcr.io/ggml-org/llama.cpp:server}
+    container_name: ${CSPACE_PROJECT_STACK_NAME}-llama-c
+    command:
+      - --hf-repo
+      - ${LLAMA_CLUSTERING_HF_REPO:-jinaai/jina-embeddings-v5-text-nano-clustering-GGUF}
+      - --hf-file
+      - ${LLAMA_CLUSTERING_HF_FILE:-v5-nano-clustering-Q8_0.gguf}
+      - --embedding
+      - --port
+      - "8080"
+      - --host
+      - "0.0.0.0"
+      - -c
+      - "8192"
+      - -b
+      - "8192"
+      - -ub
+      - "8192"
+    volumes:
+      - llama-models:/root/.cache
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+      start_period: 120s
+    networks:
+      default: {}
+      project:
+        aliases:
+          - llama-clustering
+
+  # Dimension reduction service for `cspace search clusters`. Uses PaCMAP /
+  # LocalMAP to project high-dim embeddings onto 2D. Pre-built image from
+  # mindthemath — we only consume its /reduce endpoint.
+  reduce-api:
+    image: ${REDUCE_API_IMAGE:-mindthemath/reduce-api}
+    container_name: ${CSPACE_PROJECT_STACK_NAME}-reduce
+    healthcheck:
+      test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8000/health\")' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    networks:
+      default: {}
+      project:
+        aliases:
+          - reduce-api
+
+  # HDBSCAN clustering service for 2D points. Runs after reduce-api. Minimal
+  # image built locally from lib/hdbscan-api/ (just hdbscan + flask).
+  hdbscan-api:
+    image: ${HDBSCAN_API_IMAGE:-cspace-hdbscan-api}
+    container_name: ${CSPACE_PROJECT_STACK_NAME}-hdbscan
+    build:
+      context: ${CSPACE_HOME}/lib/hdbscan-api
+    healthcheck:
+      # hdbscan-api image has python but no wget/curl; match reduce-api's probe.
+      test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8090/health\")' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      default: {}
+      project:
+        aliases:
+          - hdbscan-api
+
+  # Qdrant vector database — stores commit embeddings for `cspace search`.
+  # Accessible inside the container at http://qdrant:6333 (REST) / :6334 (gRPC).
+  # Data persists in the per-project qdrant volume across container restarts.
+  # Single qdrant process per project avoids the WAL-conflict crash (see
+  # commit 19293ee).
+  qdrant:
+    image: ${QDRANT_IMAGE:-qdrant/qdrant}
+    container_name: ${CSPACE_PROJECT_STACK_NAME}-qdrant
+    volumes:
+      - qdrant-storage:/qdrant/storage
+    healthcheck:
+      # qdrant/qdrant image ships without curl/wget; probe TCP via bash builtin.
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/6333'"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+    networks:
+      default: {}
+      project:
+        aliases:
+          - qdrant
+
+volumes:
+  # Per-project named volumes. Unlike the old per-instance volumes, these
+  # are shared across all instances of the same project — safe because
+  # there's exactly one qdrant process and one llama-server process per project.
+  llama-models:
+    name: cspace-${CSPACE_PROJECT_NAME}-llama-models
+  qdrant-storage:
+    name: cspace-${CSPACE_PROJECT_NAME}-qdrant
+
+networks:
+  default: {}
+  project:
+    external: true
+    name: ${CSPACE_PROJECT_NETWORK}

--- a/lib/templates/docker-compose.search.yml
+++ b/lib/templates/docker-compose.search.yml
@@ -1,15 +1,13 @@
 # cspace-search-mcp sidecar — exposes the MCP server for semantic search.
-# Depends on shared search infrastructure (llama-server, qdrant, reduce-api,
-# hdbscan-api) from docker-compose.core.yml.
+# Per-instance: each Claude session gets its own MCP process.
+# Reaches the project-scoped search infrastructure (llama-server, qdrant,
+# reduce-api, hdbscan-api) via network aliases on the project network.
+# No depends_on — the project stack starts before the instance stack,
+# so sidecars are typically healthy by the time the first query arrives.
 services:
   cspace-search-mcp:
     image: ${CSPACE_IMAGE:-cspace-dev}
     container_name: ${CSPACE_CONTAINER_NAME}.search-mcp
-    depends_on:
-      llama-server:
-        condition: service_healthy
-      qdrant:
-        condition: service_healthy
     command: ["/usr/local/bin/cspace-search-mcp"]
     working_dir: /workspace
     volumes:
@@ -20,3 +18,4 @@ services:
     restart: unless-stopped
     networks:
       - default
+      - project


### PR DESCRIPTION
## Summary

Closes #62

- **Hoists the five search sidecars** (qdrant, llama-server, llama-clustering, reduce-api, hdbscan-api) from per-instance scope into per-project scope, so every instance in a project shares one set of sidecars instead of spinning up its own copy.
- **Adds `docker-compose.project.yml`** — a new compose template declaring the five sidecars at project scope, with per-project named volumes (`cspace-<project>-qdrant`, `cspace-<project>-llama-models`) and Docker network aliases on the project network.
- **Adds `cspace down --project`** flag to tear down all instances AND the shared search stack for the current project.

## Architecture

```
project network: cspace-<project>-net

  project stack (N=1, compose: cspace-<project>-stack)
    qdrant, llama-server, llama-clustering,
    reduce-api, hdbscan-api

  instance stacks (N: mercury, venus, ...)
    cspace service + browser sidecar + search-mcp
```

Each instance resolves sidecars via **network aliases** (`qdrant`, `llama-server`, etc.) — the sidecar URLs in `search/config/default.yaml` are unchanged.

## Changes

| File | What changed |
|------|-------------|
| `lib/templates/docker-compose.project.yml` | **New.** Five sidecar services with project network aliases and per-project named volumes |
| `lib/templates/docker-compose.core.yml` | Removed five sidecar services and their volume definitions |
| `lib/templates/docker-compose.search.yml` | Removed `depends_on` (sidecars in separate compose project), added `project` network |
| `internal/compose/project.go` | **New.** `ProjectStackUp/Down/Running/DownDirect`, `ProjectStackEnv` |
| `internal/compose/compose.go` | Added `CSPACE_PROJECT_STACK_NAME` to `ComposeEnv` |
| `internal/config/config.go` | Added `ProjectStackName()` helper (`cspace-<project>-stack`) |
| `internal/provision/provision.go` | New phase 6 "Starting search stack" (17 phases total, shifted from 16) |
| `internal/provision/reporter.go` | Added "Starting search stack" to `Phases` slice |
| `internal/cli/down.go` | Added `--project` flag; global teardown now discovers and removes project stacks |
| Tests | Updated phase counts (16->17), added `ProjectStackEnv`/`ProjectStackName` tests |

## Lifecycle

- `cspace up <instance>` — brings the project stack up first (idempotent), then the instance
- `cspace down <instance>` — removes only the instance; project stack stays running
- `cspace down --project` — removes all instances + project stack + volumes + network
- Global teardown removes everything across all projects (including stacks)

## Migration

Users on v0.9.5 or earlier with per-instance sidecars:
- **New instances** bypass old volumes entirely — they use the project stack
- **Reused running instances** keep old per-instance sidecars until torn down (no conflict — project stack is additive)
- **`cspace rebuild --reindex`** forces fresh provisioning, joining the new architecture
- Old per-instance sidecar volumes orphan naturally and can be cleaned with `docker volume prune`

## Guardrails preserved

- Single-writer qdrant invariant maintained (one process per project, not per-instance)
- Master switch (`enabled: true` in `search.yaml`) untouched
- Role-aware bootstrap from PR #61 untouched
- No changes to search code, staleness logic, status format, or MCP wire format
- Emergency teardown still works

## Test plan

- [x] `go test ./internal/provision/` — phase count updated to 17, all assertions pass
- [x] `go test ./internal/compose/` — `ProjectStackEnv`, `ComposeEnv` with `CSPACE_PROJECT_STACK_NAME`
- [x] `go test ./internal/config/` — `ProjectStackName` helper
- [x] `go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] `docker compose config` renders project template correctly with network aliases and named volumes
