### PR TITLE
feat: cspace-browser plugin — packaged browser MCP servers (Phase 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ sync-embedded:
 	@cp lib/defaults.json lib/planets.json internal/assets/embedded/
 	@cp lib/templates/Dockerfile internal/assets/embedded/templates/
 	@cp lib/runtime/scripts/*.sh internal/assets/embedded/runtime/scripts/
+	@rm -f internal/assets/embedded/runtime/scripts/*.test.sh
 	@cp lib/runtime/features/*.sh internal/assets/embedded/runtime/features/
 	@cp lib/agent-supervisor-bun/package.json \
 	    lib/agent-supervisor-bun/bun.lock \

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ sync-embedded:
 	    lib/agent-supervisor-bun/build.ts \
 	    internal/assets/embedded/agent-supervisor-bun/
 	@cp lib/agent-supervisor-bun/src/*.ts internal/assets/embedded/agent-supervisor-bun/src/
+	@mkdir -p internal/assets/embedded/plugins
+	@cp -R lib/plugins/. internal/assets/embedded/plugins/
 
 build: check-hooks sync-embedded bin/cspace-go
 

--- a/docs/superpowers/plans/2026-06-18-cspace-browser-plugin.md
+++ b/docs/superpowers/plans/2026-06-18-cspace-browser-plugin.md
@@ -503,8 +503,9 @@ git commit --allow-empty -m "test: verify cspace-browser plugin registration, is
 
 ## Spike result
 
-_(Filled in during Task 5.)_
+Resolved 2026-06-18 by authoritative SDK-docs consult rather than a container boot (faster + definitive; the question is a fixed SDK-capability fact).
 
-- **Branch chosen:** TBD (A = SDK loads plugin servers / B = SDK needs manual registration)
-- **Observed headless tool names:** TBD
-- **Notes:** TBD
+- **Branch chosen:** **B** — keep the explicit registration in `claude-runner.ts`, renamed to `cspace-playwright`/`cspace-chrome-devtools` with `--isolated` on playwright.
+- **Why:** `@anthropic-ai/claude-agent-sdk`'s `query()` does NOT auto-load MCP servers from CLI-installed/enabled plugins. By default it loads MCP servers only from `options.mcpServers` and from `.mcp.json` reachable via `settingSources` (user/project/local) — NOT from `~/.claude/plugins/…` or `/opt/cspace/plugins/…`. So the headless supervisor cannot rely on the installed `cspace-browser` plugin; it must register the servers itself. The plugin still covers all interactive sessions (`cspace ssh`/`attach` via the `claude` CLI). No collision: the SDK session has only the manual servers; interactive sessions have only the plugin's — same names, disjoint sessions.
+- **Follow-up (cleaner single-source, not done in Phase 1):** the SDK also accepts `options.plugins: [{ type: "local", path: "/opt/cspace/plugins/cspace-browser" }]`, which WOULD load the plugin's `.mcp.json` into the headless session — making the plugin the single definition for both paths and removing the duplicate `mcpServers` block. Adopt later after confirming the baked SDK version supports `options.plugins`. Tracked for a Phase-1.5/Phase-2 cleanup.
+- **Sources:** docs.claude.com Agent SDK — MCP, Plugins, and Settings Sources pages.

--- a/lib/agent-supervisor-bun/src/claude-runner.ts
+++ b/lib/agent-supervisor-bun/src/claude-runner.ts
@@ -51,26 +51,26 @@ export async function runClaude(
       // $CSPACE_BROWSER_CDP_URL. If the env var is unset, tool calls fail at
       // runtime — declined gracefully, doesn't crash the supervisor.
       //
-      // The @claude-plugins-official `playwright` plugin's plugin.json is
-      // missing the `mcpServers` field upstream, so installing the plugin
-      // does NOT actually register a `playwright` MCP server in Claude Code.
-      // We register it ourselves here. cmd_up.go also sets
-      // PLAYWRIGHT_MCP_CDP_ENDPOINT — harmless today (it duplicates the
-      // --cdp-endpoint argv) and future-proofs us if/when upstream fixes
-      // the plugin manifest and that registration starts taking effect.
+      // Server names ("cspace-playwright", "cspace-chrome-devtools") and
+      // flags match the cspace-browser Claude Code plugin
+      // (lib/plugins/cspace-browser) so the headless and interactive paths
+      // expose identical tool names to the agent. The Agent SDK's query()
+      // does NOT auto-load CLI plugin MCP servers, so we register them here
+      // explicitly — the plugin registration only takes effect when Claude
+      // Code itself is driving the session interactively.
       mcpServers: {
-        playwright: {
+        "cspace-playwright": {
           type: "stdio",
           command: "playwright-mcp",
           args: process.env.CSPACE_BROWSER_CDP_URL
-            ? ["--cdp-endpoint", process.env.CSPACE_BROWSER_CDP_URL]
-            : [],
+            ? ["--isolated", "--cdp-endpoint", process.env.CSPACE_BROWSER_CDP_URL]
+            : ["--isolated"],
         },
-        "chrome-devtools": {
+        "cspace-chrome-devtools": {
           type: "stdio",
           command: "chrome-devtools-mcp",
           args: process.env.CSPACE_BROWSER_CDP_URL
-            ? ["--browser-url", process.env.CSPACE_BROWSER_CDP_URL]
+            ? ["--browserUrl", process.env.CSPACE_BROWSER_CDP_URL]
             : [],
         },
       },

--- a/lib/plugins/.claude-plugin/marketplace.json
+++ b/lib/plugins/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "cspace",
+  "owner": { "name": "cspace" },
+  "plugins": [
+    {
+      "name": "cspace-browser",
+      "source": "./cspace-browser",
+      "description": "Browser automation MCP servers (Playwright + Chrome DevTools) wired to the cspace Chromium CDP sidecar."
+    }
+  ]
+}

--- a/lib/plugins/cspace-browser/.claude-plugin/plugin.json
+++ b/lib/plugins/cspace-browser/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "cspace-browser",
+  "version": "0.1.0",
+  "description": "cspace browser MCP servers (Playwright CDP-attached/isolated + Chrome DevTools), wired to the container's Chromium CDP sidecar via CSPACE_BROWSER_CDP_URL."
+}

--- a/lib/plugins/cspace-browser/.mcp.json
+++ b/lib/plugins/cspace-browser/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "cspace-playwright": {
+      "command": "playwright-mcp",
+      "args": ["--cdp-endpoint", "${CSPACE_BROWSER_CDP_URL}", "--isolated"]
+    },
+    "cspace-chrome-devtools": {
+      "command": "chrome-devtools-mcp",
+      "args": ["--browserUrl", "${CSPACE_BROWSER_CDP_URL}"]
+    }
+  }
+}

--- a/lib/runtime/scripts/cspace-entrypoint.sh
+++ b/lib/runtime/scripts/cspace-entrypoint.sh
@@ -102,52 +102,6 @@ if [ ! -f "$CLAUDE_JSON" ]; then
 JSON
 fi
 
-# Register the browser MCP servers at user scope so EVERY Claude session
-# in the sandbox — supervisor-driven, interactive `cspace ssh`/`attach`,
-# headless `claude -p` — gets playwright/chrome-devtools tools wired to
-# the browser sidecar. Registration via the supervisor's --mcp-config
-# alone (lib/agent-supervisor-bun/src/claude-runner.ts) leaves
-# interactive sessions with no browser tools; this closes that gap. The
-# supervisor still passes the same server names via --mcp-config, which
-# takes precedence — no duplicate toolsets.
-#
-# ${CSPACE_BROWSER_CDP_URL} is written as a LITERAL placeholder (single
-# quotes below are deliberate): Claude Code expands env vars in MCP
-# config at server spawn, so the registration tracks the live env
-# instead of freezing boot-time state.
-#
-# Projects override per-name: a `playwright` entry in the project's
-# .mcp.json shadows this user-scope one (and a bare `npx @playwright/mcp`
-# registration still reaches the sidecar via the exported
-# PLAYWRIGHT_MCP_CDP_ENDPOINT env alias). Rewritten every boot; removed
-# when the sidecar is disabled so agents don't see browser tools that
-# cannot work.
-if command -v jq >/dev/null 2>&1; then
-    if [ -n "${CSPACE_BROWSER_CDP_URL:-}" ]; then
-        BROWSER_MCP_FILTER='.mcpServers = (.mcpServers // {}) + {
-          "playwright": {
-            "type": "stdio",
-            "command": "playwright-mcp",
-            "args": ["--cdp-endpoint", "${CSPACE_BROWSER_CDP_URL}"]
-          },
-          "chrome-devtools": {
-            "type": "stdio",
-            "command": "chrome-devtools-mcp",
-            "args": ["--browser-url", "${CSPACE_BROWSER_CDP_URL}"]
-          }
-        }'
-    else
-        BROWSER_MCP_FILTER='del(.mcpServers.playwright, .mcpServers."chrome-devtools")'
-    fi
-    CLAUDE_JSON_TMP=$(mktemp)
-    if jq "$BROWSER_MCP_FILTER" "$CLAUDE_JSON" > "$CLAUDE_JSON_TMP" 2>/dev/null; then
-        mv "$CLAUDE_JSON_TMP" "$CLAUDE_JSON"
-    else
-        echo "[cspace-entrypoint] WARN: failed to update mcpServers in $CLAUDE_JSON"
-        rm -f "$CLAUDE_JSON_TMP"
-    fi
-fi
-
 # Write ~/.claude/settings.json so the cspace statusline shows up in
 # interactive `claude`. The statusline is baked into the image at
 # /usr/local/bin/cspace-statusline.sh (its version is tied to the image,

--- a/lib/runtime/scripts/cspace-install-plugins.sh
+++ b/lib/runtime/scripts/cspace-install-plugins.sh
@@ -45,6 +45,26 @@ if [ -n "$cspace_cfg" ]; then
     fi
 fi
 
+# --- cspace-browser plugin (image-local marketplace) ---
+# Register + install cspace's browser MCP plugin from the marketplace baked
+# into the image. Gated on a browser sidecar being present
+# (CSPACE_BROWSER_CDP_URL set) — this reproduces the old entrypoint behavior of
+# not exposing browser tools that can't reach a CDP endpoint. Self-contained:
+# does NOT go through the WANT/MARKETPLACES loop (that loop assumes GitHub
+# owner/repo marketplaces and would mishandle a local filesystem path).
+# Idempotent: `marketplace list` grep skips re-add; `plugins install` no-ops if
+# already installed. CSPACE_BROWSER_MARKET_DIR is overridable for tests.
+CSPACE_BROWSER_MARKET_DIR="${CSPACE_BROWSER_MARKET_DIR:-/opt/cspace/plugins}"
+if [ -n "${CSPACE_BROWSER_CDP_URL:-}" ] && [ -f "${CSPACE_BROWSER_MARKET_DIR}/.claude-plugin/marketplace.json" ]; then
+    if ! claude plugins marketplace list 2>/dev/null | grep -q "^[ *]*cspace\b"; then
+        echo "[install-plugins] adding image-local marketplace cspace from ${CSPACE_BROWSER_MARKET_DIR}"
+        claude plugins marketplace add "${CSPACE_BROWSER_MARKET_DIR}" || true
+    fi
+    echo "[install-plugins] installing cspace-browser@cspace"
+    claude plugins install --scope user "cspace-browser@cspace" || true
+fi
+# --- end cspace-browser ---
+
 # Build the combined enable list. Each entry is normalized to
 # "<plugin>@<marketplace>"; bare names from cspace's plugins.install
 # get @claude-plugins-official appended.

--- a/lib/runtime/scripts/cspace-install-plugins.test.sh
+++ b/lib/runtime/scripts/cspace-install-plugins.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Tests the cspace-browser block in cspace-install-plugins.sh using a `claude` stub.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/cspace-install-plugins.sh"
+fail() { echo "FAIL: $1"; exit 1; }
+
+run_case() {  # $1=label  $2=cdp_url ("" = unset)  ; echoes the captured claude calls
+  local tmp; tmp="$(mktemp -d)"
+  mkdir -p "$tmp/bin" "$tmp/market/.claude-plugin"
+  echo '{"name":"cspace","owner":{"name":"cspace"},"plugins":[{"name":"cspace-browser","source":"./cspace-browser"}]}' > "$tmp/market/.claude-plugin/marketplace.json"
+  # stub `claude`: record args, print nothing for `marketplace list`
+  cat > "$tmp/bin/claude" <<EOF
+#!/usr/bin/env bash
+echo "claude \$*" >> "$tmp/calls.log"
+exit 0
+EOF
+  chmod +x "$tmp/bin/claude"
+  HOME="$tmp" PATH="$tmp/bin:$PATH" \
+    CSPACE_BROWSER_MARKET_DIR="$tmp/market" \
+    CSPACE_BROWSER_CDP_URL="$2" \
+    bash "$SCRIPT" >/dev/null 2>&1
+  cat "$tmp/calls.log" 2>/dev/null || true
+}
+
+present="$(run_case present 'http://10.0.0.5:9222')"
+echo "$present" | grep -q 'plugins marketplace add .*/market' || fail "present: marketplace not added"
+echo "$present" | grep -q 'plugins install --scope user cspace-browser@cspace' || fail "present: plugin not installed"
+
+absent="$(run_case absent '')"
+echo "$absent" | grep -q 'cspace-browser@cspace' && fail "absent: plugin installed despite no CDP url"
+
+echo "PASS"

--- a/lib/templates/Dockerfile
+++ b/lib/templates/Dockerfile
@@ -168,6 +168,16 @@ RUN chmod +x /usr/local/bin/cspace-entrypoint.sh \
 RUN mkdir -p /opt/cspace/features
 COPY lib/runtime/features/*.sh /opt/cspace/features/
 RUN chmod +x /opt/cspace/features/*.sh
+
+# cspace-shipped Claude Code plugins (local marketplace source). Baked
+# read-only; cspace-install-plugins.sh registers /opt/cspace/plugins as a
+# filesystem marketplace (no network). The `RUN test` guard turns the known
+# Apple Container "COPY <dir> yields empty dir" quirk into a loud build failure
+# instead of a silent missing-plugin at runtime.
+RUN mkdir -p /opt/cspace/plugins
+COPY lib/plugins /opt/cspace/plugins
+RUN test -f /opt/cspace/plugins/.claude-plugin/marketplace.json \
+ && test -f /opt/cspace/plugins/cspace-browser/.mcp.json
 USER dev
 
 # Version label set at build time via `--build-arg CSPACE_VERSION=...`.


### PR DESCRIPTION
## Summary

Phase 1 of packaging cspace's browser MCP servers as an in-repo, conflict-scoped Claude Code plugin (`cspace-browser`), installed at container boot — replacing the imperative entrypoint `jq` registration. Runs on today's per-instance browser sidecar; the shared-singleton browser is a documented Phase 2.

- Design spec: `docs/superpowers/specs/2026-06-18-cspace-browser-plugin-design.md`
- Plan: `docs/superpowers/plans/2026-06-18-cspace-browser-plugin.md`

## What's in it

- **Plugin** `lib/plugins/cspace-browser/` + local marketplace (`lib/plugins/.claude-plugin/marketplace.json`, name `cspace`) declaring two MCP servers, defensively `cspace-`prefixed so a project's own `playwright` can't shadow them (plugin servers are lowest precedence):
  - `cspace-playwright` → `playwright-mcp --cdp-endpoint ${CSPACE_BROWSER_CDP_URL} --isolated`
  - `cspace-chrome-devtools` → `chrome-devtools-mcp --browserUrl ${CSPACE_BROWSER_CDP_URL}`
- **Baked into the image** (`Dockerfile` COPY → `/opt/cspace/plugins` + a `RUN test` guard for the Apple Container empty-COPY-dir quirk; mirrored via `make sync-embedded`).
- **Installed at boot** by `cspace-install-plugins.sh`, gated on `CSPACE_BROWSER_CDP_URL` (so `--no-browser` instances skip it), with a stub-driven shell test.
- **Removed** the imperative browser-MCP `jq` block from `cspace-entrypoint.sh`.
- **Supervisor** (`claude-runner.ts`): renamed the headless registration to `cspace-playwright`/`cspace-chrome-devtools` + added `--isolated` (Branch B — the Agent SDK doesn't auto-load CLI-plugin MCP servers, so the headless agent needs explicit registration; the plugin covers interactive `ssh`/`attach`).

## Validation

- Image builds clean (COPY guard passes → plugin baked; supervisor compiles).
- In the real image with a CDP URL set: marketplace registers, `cspace-browser@cspace` installs + enables, both MCP servers register and **connect** with correct names/flags/env-expansion (`plugin:cspace-browser:cspace-playwright … ✔ Connected`).
- No CDP URL (the `--no-browser` equivalent): plugin correctly skipped.
- Per-context `--isolated` isolation mechanism-validated separately (Playwright 1.61, host experiment).
- All Go tests + the install-script shell test pass; `go vet` clean. Final whole-branch review: ready to merge.

## Scope / deferrals (documented in the spec)

- **Phase 2:** shared singleton browser; per-instance `/etc/hosts` hostnames.
- **Phase 1.5:** supervisor loading the plugin via the SDK's `options.plugins` (single source — retires the duplicate registration in `claude-runner.ts`).
- Agent-driving end-to-end isolation not run here (mechanism-proven). `chrome-devtools-mcp` shares context across instances by accepted design (`playwright` carries the isolation guarantee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)