### PR TITLE
feat: shared browser sidecar — one browser per project (Phase 2)

### DIFF
--- a/docs/superpowers/plans/2026-06-18-shared-browser-sidecar.md
+++ b/docs/superpowers/plans/2026-06-18-shared-browser-sidecar.md
@@ -710,3 +710,93 @@ From `~/Projects/resume-redux`, boot two instances on the shared browser, run th
 ./bin/cspace-go down alpha 2>/dev/null; ./bin/cspace-go down beta 2>/dev/null
 git commit --allow-empty -m "test: verify shared browser — one sidecar, per-instance friendly DNS, context isolation, ref-counted teardown, opt-out, resume-redux e2e+MCP"
 ```
+
+---
+
+### Task 8: Make the daemon's gateway DNS listener retry the bind (acceptance-driven)
+
+**Files:**
+- Modify: `internal/cli/cmd_daemon.go` (the two gateway-listener goroutines, ~lines 218-231)
+
+**Why:** The Task 7 acceptance run found that in-container `*.cspace.test` resolution (which the shared browser now depends on, since Phase 2 dropped bare-name `/etc/hosts` injection) was NXDOMAIN. Root cause: the daemon's gateway DNS listener binds the specific gateway IP `192.168.64.1:5354`, but that IP lives on the vmnet bridge (`bridge101`) which doesn't exist until the first container boots — and `cspace up` spawns the daemon BEFORE the container. The current bind is one-shot best-effort, so it fails permanently. A freshly-spawned daemon (bridge already up) binds it fine and the sidecar resolves correctly — so the fix is to RETRY the gateway bind until the bridge appears. (This overturns the spec's "no daemon change" note; the host-loopback listener is unaffected and stays fatal-on-failure.)
+
+**Interfaces:** none new — behavior change only.
+
+- [ ] **Step 1: Replace the two one-shot gateway-listener goroutines with retrying loops**
+
+In `internal/cli/cmd_daemon.go`, replace the gateway-bind block (currently ~lines 214-231):
+```go
+	// Gateway bind — best-effort. Containers query 192.168.64.1:5354
+	// for cspace.test lookups (via dnsmasq forwarder inside the
+	// sandbox). Failure here just means in-container hostname
+	// resolution stops working; the host path is unaffected.
+	go func() {
+		server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "udp", Handler: dh}
+		log.Printf("cspace daemon: DNS listening on %s/udp (containers)", daemonDNSGatewayAddr)
+		if err := server.ListenAndServe(); err != nil {
+			log.Printf("WARN: cspace daemon DNS UDP bind on %s failed: %v", daemonDNSGatewayAddr, err)
+			log.Printf("      in-container *.cspace.test lookups will NXDOMAIN until this is resolved.")
+		}
+	}()
+	go func() {
+		server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "tcp", Handler: dh}
+		if err := server.ListenAndServe(); err != nil {
+			log.Printf("WARN: cspace daemon DNS TCP bind on %s failed: %v", daemonDNSGatewayAddr, err)
+		}
+	}()
+```
+with retrying loops (a successful `ListenAndServe` blocks while serving; a bind failure returns immediately and we retry after a short delay so the listener comes up shortly after the first sandbox boots):
+```go
+	// Gateway bind — best-effort WITH RETRY. The vmnet bridge that owns
+	// 192.168.64.1 doesn't exist until the first container boots, and the
+	// daemon is spawned by `cspace up` BEFORE that — so the initial bind
+	// loses a startup race. Retry until it binds so in-container
+	// *.cspace.test resolution (which the shared browser sidecar depends on)
+	// comes up shortly after the first sandbox starts. The host-loopback
+	// listener above is unaffected.
+	go func() {
+		for {
+			server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "udp", Handler: dh}
+			log.Printf("cspace daemon: DNS listening on %s/udp (containers)", daemonDNSGatewayAddr)
+			err := server.ListenAndServe()
+			log.Printf("WARN: cspace daemon DNS UDP bind on %s failed: %v; retrying in 3s "+
+				"(in-container *.cspace.test lookups NXDOMAIN until this binds)", daemonDNSGatewayAddr, err)
+			time.Sleep(3 * time.Second)
+		}
+	}()
+	go func() {
+		for {
+			server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "tcp", Handler: dh}
+			if err := server.ListenAndServe(); err != nil {
+				log.Printf("WARN: cspace daemon DNS TCP bind on %s failed: %v; retrying in 3s", daemonDNSGatewayAddr, err)
+			}
+			time.Sleep(3 * time.Second)
+		}
+	}()
+```
+Ensure `"time"` is imported (it almost certainly already is; add it if not).
+
+- [ ] **Step 2: Build + vet**
+
+Run: `go build ./... && go vet ./... && echo OK`
+Expected: `OK`. (No unit test — this is a network-bind retry loop; verified by the integration re-check below.)
+
+- [ ] **Step 3: Integration re-verify (the original failing case)**
+
+```bash
+make build
+pkill -f 'cspace daemon serve' 2>/dev/null; sleep 1   # clear any stale daemon
+./bin/cspace-go up alpha                                # spawns daemon (no bridge yet), then boots the container
+sleep 6                                                 # let the retry catch the now-up bridge
+lsof -nP -iUDP:5354 | grep -q '192.168.64.1:5354' && echo "gateway listener BOUND (correct)" || echo "gateway STILL DOWN (bug)"
+container exec cspace-cspace-browser getent hosts alpha.cspace.cspace.test && echo "sidecar RESOLVES friendly name (correct)"
+./bin/cspace-go down alpha
+```
+Expected: `gateway listener BOUND`, and the sidecar resolves `alpha.cspace.cspace.test` to alpha's IP.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/cli/cmd_daemon.go
+git commit -m "fix(daemon): retry the gateway DNS bind so in-container .cspace.test resolves (shared browser depends on it)"
+```

--- a/docs/superpowers/specs/2026-06-18-shared-browser-sidecar-design.md
+++ b/docs/superpowers/specs/2026-06-18-shared-browser-sidecar-design.md
@@ -172,10 +172,29 @@ does not need the compose-sidecar opt-in.
   both try to create the singleton. `container run --name` errors on the second
   ("already exists"); treat that as "reuse" and inspect the existing one.
 - **Stale singleton after crash:** a singleton left running with zero live
-  instances is reaped by `registry prune` / the daemon idle path.
+  instances is reaped by `cspace registry prune` — which, because the singleton
+  name is derived (not stored in a registry entry), must explicitly stop
+  `browserSingletonName(project)` for any project with `CountForProject == 0`
+  (NOT covered by the daemon idle path, which only exits the daemon process and
+  never stops containers).
+- **`down` during `up` (narrow TOCTOU):** the singleton is created early in
+  `up` but the instance isn't registered until later. A `down` of a project's
+  only still-booting instance, racing its `up` before registration, would read
+  `CountForProject == 0` and stop the singleton out from under the live `up`.
+  Pre-existing registration-ordering window; requires unusual concurrent
+  operator action; accepted for this phase.
 - **`CSPACE_WORKSPACE_HOST` consumers:** anything still hardcoding bare
   `workspace` (instead of reading the env var) breaks under sharing. Document the
   contract; resume-redux already complies.
+- **In-container friendly DNS is now load-bearing (daemon dependency):** because
+  the shared browser resolves the workspace via `.cspace.test` (no bare-name
+  `/etc/hosts` injection), the cspace daemon's **gateway** DNS listener
+  (`192.168.64.1:5354`) must be up. It binds the vmnet bridge IP, which doesn't
+  exist until the first container boots — and `cspace up` spawns the daemon
+  before that — so the one-shot bind lost a startup race and NXDOMAINed
+  in-container lookups. This phase therefore makes the gateway listener **retry**
+  its bind (Phase 2 amends the spec's earlier "no daemon change" assumption; the
+  host-loopback listener is unaffected).
 
 ## Testing / acceptance
 

--- a/internal/cli/browser.go
+++ b/internal/cli/browser.go
@@ -47,6 +47,20 @@ func browserContainerName(project, sandbox string) string {
 	return fmt.Sprintf("cspace-%s-%s-browser", project, sandbox)
 }
 
+// browserSingletonName is the per-PROJECT shared browser sidecar container
+// name (Phase 2). One per project, shared by all that project's sandboxes.
+func browserSingletonName(project string) string {
+	return fmt.Sprintf("cspace-%s-browser", project)
+}
+
+// workspaceFriendlyHost is the per-instance hostname the shared browser uses
+// to reach a sandbox's workspace: <sandbox>.<project>.cspace.test, resolved by
+// the cspace DNS daemon to the instance's vmnet IP. Both labels are lowercased
+// to match the daemon's lowercased, case-sensitive registry comparison.
+func workspaceFriendlyHost(name, project string) string {
+	return strings.ToLower(name) + "." + strings.ToLower(project) + ".cspace.test"
+}
+
 // startBrowserSidecar runs the Playwright sidecar container, waits for its
 // IP and CDP endpoint to come up, and returns the container name and CDP
 // URL. Idempotent: if a container of the same name already exists, it is

--- a/internal/cli/browser.go
+++ b/internal/cli/browser.go
@@ -84,23 +84,18 @@ type BrowserSidecar struct {
 	RunServerWSURL string // ws://<ip>:3000/ — for $PW_TEST_CONNECT_WS_ENDPOINT
 }
 
-// startBrowserSidecar runs the Playwright sidecar. plVersion selects the
-// run-server protocol version (must match the project's @playwright/test
-// pin per Playwright's strict cross-version handshake check); empty
-// string falls back to defaultPlaywrightVersion.
-func startBrowserSidecar(ctx context.Context, project, sandbox, plVersion string) (*BrowserSidecar, error) {
+// runBrowserSidecar starts a sidecar container with the given name. It does
+// NOT remove a pre-existing same-named container (callers decide that). The
+// cspace.playwright-version label lets the shared path detect a version-mismatched
+// singleton on reuse.
+func runBrowserSidecar(ctx context.Context, containerName, plVersion string) (*BrowserSidecar, error) {
 	if plVersion == "" {
 		plVersion = defaultPlaywrightVersion
 	}
-	containerName := browserContainerName(project, sandbox)
-
-	// Idempotency: torch any prior container with the same name.
-	_ = exec.CommandContext(ctx, "container", "stop", containerName).Run()
-	_ = exec.CommandContext(ctx, "container", "rm", containerName).Run()
-
 	args := []string{
 		"run", "-d",
 		"--name", containerName,
+		"--label", "cspace.playwright-version=" + plVersion,
 		// Public resolvers needed for the apt-get install step. Once
 		// dnsmasq is up we repoint resolv.conf at it; until then,
 		// these are how the sidecar fetches packages.
@@ -192,6 +187,16 @@ func startBrowserSidecar(ctx context.Context, project, sandbox, plVersion string
 		CDPURL:         cdpURL,
 		RunServerWSURL: wsURL,
 	}, nil
+}
+
+// startBrowserSidecar is the per-instance path (opt-out / --no-shared-browser):
+// it torches any prior same-named container then runs fresh. Unchanged signature.
+func startBrowserSidecar(ctx context.Context, project, sandbox, plVersion string) (*BrowserSidecar, error) {
+	containerName := browserContainerName(project, sandbox)
+	// Idempotency: torch any prior container with the same name.
+	_ = exec.CommandContext(ctx, "container", "stop", containerName).Run()
+	_ = exec.CommandContext(ctx, "container", "rm", containerName).Run()
+	return runBrowserSidecar(ctx, containerName, plVersion)
 }
 
 // InjectWorkspaceHost writes a /etc/hosts entry inside the browser sidecar
@@ -314,6 +319,74 @@ func stopBrowserSidecar(ctx context.Context, name string) {
 	}
 	_ = exec.CommandContext(ctx, "container", "stop", name).Run()
 	_ = exec.CommandContext(ctx, "container", "rm", name).Run()
+}
+
+// ensureSharedBrowserSidecar returns the project's shared browser sidecar,
+// starting it if absent and REUSING it if a healthy, version-matched one is
+// already running. Never torches a healthy singleton. The bool is startedNew:
+// true iff this call created the container (the caller uses it to gate
+// error-path teardown so a reused singleton is never stopped).
+func ensureSharedBrowserSidecar(ctx context.Context, project, plVersion string) (*BrowserSidecar, bool, error) {
+	if plVersion == "" {
+		plVersion = defaultPlaywrightVersion
+	}
+	name := browserSingletonName(project)
+
+	if containerExists(ctx, name) {
+		// Healthy + version-matched? Reuse without torching.
+		ip, ipErr := waitForBrowserIP(ctx, name, 5*time.Second)
+		if ipErr == nil {
+			cdpURL := fmt.Sprintf("http://%s:%d", ip, browserCDPPort)
+			if waitForCDP(ctx, cdpURL, 10*time.Second) == nil && sidecarVersion(ctx, name) == plVersion {
+				wsURL := fmt.Sprintf("ws://%s:%d/", ip, browserRunServerPort)
+				return &BrowserSidecar{ContainerName: name, IP: ip, CDPURL: cdpURL, RunServerWSURL: wsURL}, false, nil
+			}
+		}
+		// Exists but unhealthy / version-mismatched: torch then restart.
+		stopBrowserSidecar(ctx, name)
+	}
+	bs, err := runBrowserSidecar(ctx, name, plVersion)
+	if err != nil {
+		// Concurrency: a sibling `up` may have created it between our check and
+		// run ("already exists"). Re-probe and reuse if it's now healthy.
+		if containerExists(ctx, name) {
+			if ip, ipErr := waitForBrowserIP(ctx, name, 5*time.Second); ipErr == nil {
+				cdpURL := fmt.Sprintf("http://%s:%d", ip, browserCDPPort)
+				if waitForCDP(ctx, cdpURL, 10*time.Second) == nil {
+					wsURL := fmt.Sprintf("ws://%s:%d/", ip, browserRunServerPort)
+					return &BrowserSidecar{ContainerName: name, IP: ip, CDPURL: cdpURL, RunServerWSURL: wsURL}, false, nil
+				}
+			}
+		}
+		return nil, false, err
+	}
+	return bs, true, nil
+}
+
+// sidecarVersion reads the cspace.playwright-version recorded on the running
+// sidecar (the --label from runBrowserSidecar). Returns "" if it can't be
+// read, which forces a conservative restart on reuse.
+func sidecarVersion(ctx context.Context, name string) string {
+	out, err := exec.CommandContext(ctx, "container", "inspect", name).Output()
+	if err != nil {
+		return ""
+	}
+	// cspace.playwright-version appears once, as "<key>":"<value>" or
+	// "key=value" in the labels/env block. Extract the value after the marker.
+	s := string(out)
+	const marker = "cspace.playwright-version"
+	i := strings.Index(s, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(marker):]
+	// skip non-version chars (": =\") then read until the next quote/space/comma
+	rest = strings.TrimLeft(rest, "\":= ")
+	end := strings.IndexAny(rest, "\", \n}")
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
 }
 
 // detectPlaywrightVersion reads the project's @playwright/test pin from

--- a/internal/cli/browser_test.go
+++ b/internal/cli/browser_test.go
@@ -1,0 +1,21 @@
+package cli
+
+import "testing"
+
+func TestBrowserSingletonName(t *testing.T) {
+	if got := browserSingletonName("resume-redux"); got != "cspace-resume-redux-browser" {
+		t.Errorf("got %q, want cspace-resume-redux-browser", got)
+	}
+}
+
+func TestWorkspaceFriendlyHost(t *testing.T) {
+	cases := map[string][2]string{
+		"mercury.resume-redux.cspace.test": {"mercury", "resume-redux"},
+		"venus.demo.cspace.test":           {"Venus", "Demo"}, // lowercased
+	}
+	for want, in := range cases {
+		if got := workspaceFriendlyHost(in[0], in[1]); got != want {
+			t.Errorf("workspaceFriendlyHost(%q,%q) = %q, want %q", in[0], in[1], got, want)
+		}
+	}
+}

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -211,22 +211,30 @@ func runDaemonServe() error {
 			os.Exit(1)
 		}
 	}()
-	// Gateway bind — best-effort. Containers query 192.168.64.1:5354
-	// for cspace.test lookups (via dnsmasq forwarder inside the
-	// sandbox). Failure here just means in-container hostname
-	// resolution stops working; the host path is unaffected.
+	// Gateway bind — best-effort WITH RETRY. The vmnet bridge that owns
+	// 192.168.64.1 doesn't exist until the first container boots, and the
+	// daemon is spawned by `cspace up` BEFORE that — so the initial bind
+	// loses a startup race. Retry until it binds so in-container
+	// *.cspace.test resolution (which the shared browser sidecar depends on)
+	// comes up shortly after the first sandbox starts. The host-loopback
+	// listener above is unaffected.
 	go func() {
-		server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "udp", Handler: dh}
-		log.Printf("cspace daemon: DNS listening on %s/udp (containers)", daemonDNSGatewayAddr)
-		if err := server.ListenAndServe(); err != nil {
-			log.Printf("WARN: cspace daemon DNS UDP bind on %s failed: %v", daemonDNSGatewayAddr, err)
-			log.Printf("      in-container *.cspace.test lookups will NXDOMAIN until this is resolved.")
+		for {
+			server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "udp", Handler: dh}
+			log.Printf("cspace daemon: DNS listening on %s/udp (containers)", daemonDNSGatewayAddr)
+			err := server.ListenAndServe()
+			log.Printf("WARN: cspace daemon DNS UDP bind on %s failed: %v; retrying in 3s "+
+				"(in-container *.cspace.test lookups NXDOMAIN until this binds)", daemonDNSGatewayAddr, err)
+			time.Sleep(3 * time.Second)
 		}
 	}()
 	go func() {
-		server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "tcp", Handler: dh}
-		if err := server.ListenAndServe(); err != nil {
-			log.Printf("WARN: cspace daemon DNS TCP bind on %s failed: %v", daemonDNSGatewayAddr, err)
+		for {
+			server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "tcp", Handler: dh}
+			if err := server.ListenAndServe(); err != nil {
+				log.Printf("WARN: cspace daemon DNS TCP bind on %s failed: %v; retrying in 3s", daemonDNSGatewayAddr, err)
+			}
+			time.Sleep(3 * time.Second)
 		}
 	}()
 

--- a/internal/cli/cmd_down.go
+++ b/internal/cli/cmd_down.go
@@ -154,9 +154,11 @@ func (s *substrateDowner) IP(ctx context.Context, name string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-// teardownSandbox stops the canonical container, stops a browser sidecar
-// if registered, and unregisters the entry. When wipeState is true (the
-// `cspace down` default), it also reclaims the per-sandbox clone,
+// teardownSandbox stops the canonical container, stops the per-instance
+// browser sidecar (a no-op in the shared-singleton case), unregisters
+// the entry, then ref-counts the shared browser singleton — stopping it
+// only when this was the project's last sandbox. When wipeState is true
+// (the `cspace down` default), it also reclaims the per-sandbox clone,
 // sessions, and substrate-managed volumes so the next `cspace up <same
 // name>` starts fresh. Permissive on missing entries — a stale container
 // could still be running, so we always issue Stop by name regardless of

--- a/internal/cli/cmd_down.go
+++ b/internal/cli/cmd_down.go
@@ -169,8 +169,6 @@ func teardownSandbox(
 	out io.Writer,
 	wipeState bool,
 ) {
-	entry, _ := r.Lookup(project, name)
-
 	// Tear down devcontainer-defined sidecars (e.g., database, cache) before
 	// stopping the main sandbox. Non-fatal; print a warning but continue.
 	//
@@ -213,13 +211,21 @@ func teardownSandbox(
 
 	_ = a.Stop(ctx, fmt.Sprintf("cspace-%s-%s", project, name))
 
-	// Stop the sidecar AFTER the sandbox so the agent's outstanding
-	// CDP connections drain naturally. stopBrowserSidecar is idempotent.
-	if entry.BrowserContainer != "" {
-		stopBrowserSidecar(ctx, entry.BrowserContainer)
-	}
+	// Per-instance (opt-out / --no-shared-browser) sidecar: stop this sandbox's
+	// own browser. Idempotent and a no-op in the shared case (no such container).
+	stopBrowserSidecar(ctx, browserContainerName(project, name))
 
+	// Remove this instance from the registry BEFORE counting so it is not
+	// included in the remaining-sandboxes tally.
 	_ = r.Unregister(project, name)
+
+	// Shared browser sidecar: ref-counted — stop it only when this was the last
+	// sandbox in the project. Idempotent and a no-op when no singleton exists.
+	if remaining, err := r.CountForProject(project); err != nil {
+		_, _ = fmt.Fprintf(out, "[cspace] warning: registry count during browser teardown: %v\n", err)
+	} else if remaining == 0 {
+		stopBrowserSidecar(ctx, browserSingletonName(project))
+	}
 
 	if wipeState {
 		wipeSandboxState(ctx, a, project, name, out)

--- a/internal/cli/cmd_registry.go
+++ b/internal/cli/cmd_registry.go
@@ -169,7 +169,11 @@ func runRegistryPrune(out io.Writer, dryRun bool) error {
 	pruneCount := 0
 	clearedBrowserCount := 0
 	stuckBootingCount := 0
+	// Track every project that had an entry this run so we can check for
+	// orphaned shared browser singletons after the per-entry loop.
+	seenProjects := map[string]struct{}{}
 	for _, e := range entries {
+		seenProjects[e.Project] = struct{}{}
 		sandboxAlive := containerExists(ctx, containerNameForEntry(e))
 		switch {
 		case !sandboxAlive:
@@ -214,8 +218,37 @@ func runRegistryPrune(out io.Writer, dryRun bool) error {
 		}
 	}
 
+	// Shared browser singleton backstop: if a project's last sandbox died
+	// abnormally, cspace down's ref-counted stop never ran, leaving the
+	// heavyweight browser microVM running indefinitely. After the per-entry
+	// loop, for every project that appeared in the registry this run, check
+	// whether any live sandboxes remain. If none do and the shared singleton
+	// container still exists, stop it now.
+	stoppedSingletonCount := 0
+	for project := range seenProjects {
+		remaining, err := r.CountForProject(project)
+		if err != nil {
+			_, _ = fmt.Fprintf(out, "warning: registry count for %s: %v\n", project, err)
+			continue
+		}
+		if remaining > 0 {
+			continue
+		}
+		singletonName := browserSingletonName(project)
+		if !containerExists(ctx, singletonName) {
+			continue
+		}
+		if dryRun {
+			_, _ = fmt.Fprintf(out, "would stop shared browser sidecar: %s\n", singletonName)
+		} else {
+			stopBrowserSidecar(ctx, singletonName)
+			_, _ = fmt.Fprintf(out, "stopped shared browser sidecar: %s\n", singletonName)
+		}
+		stoppedSingletonCount++
+	}
+
 	switch {
-	case pruneCount == 0 && clearedBrowserCount == 0 && stuckBootingCount == 0:
+	case pruneCount == 0 && clearedBrowserCount == 0 && stuckBootingCount == 0 && stoppedSingletonCount == 0:
 		_, _ = fmt.Fprintln(out, "no dead entries to prune")
 	case pruneCount == 0 && clearedBrowserCount == 0:
 		// Only stuck-booting entries — nothing to prune, but the warnings

--- a/internal/cli/cmd_up.go
+++ b/internal/cli/cmd_up.go
@@ -670,12 +670,9 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 			}
 
 			// If a browser sidecar is running, inject `workspace` into
-			// /etc/hosts on BOTH sides so http://workspace:<port> is a
-			// universal URL: scripts inside the workspace use 127.0.0.1
-			// (preview server is local), the browser running in the
-			// sidecar uses the workspace's vmnet IP. e2e flows can then
-			// use the same BASE_URL for both the readiness probe and
-			// the URL Playwright opens. Best-effort.
+			// /etc/hosts inside the workspace container so
+			// http://workspace:<port> resolves to 127.0.0.1 (the
+			// preview server running locally). Best-effort.
 			if browserSidecar != nil {
 				if hErr := InjectWorkspaceHost(ctx, containerName, "127.0.0.1"); hErr != nil {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),

--- a/internal/cli/cmd_up.go
+++ b/internal/cli/cmd_up.go
@@ -535,7 +535,20 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 				// fail with 428 Precondition Required; tracking the
 				// project pin avoids that without dictating a version.
 				plVersion := detectPlaywrightVersion(cfg.ProjectRoot)
-				bs, berr := startBrowserSidecar(ctx, project, name, plVersion)
+				var b config.BrowserConfig
+				if cfg != nil {
+					b = cfg.Browser
+				}
+				shared := resolveSharedBrowser(b, noSharedBrowser)
+				var bs *BrowserSidecar
+				var startedNew bool
+				var berr error
+				if shared {
+					bs, startedNew, berr = ensureSharedBrowserSidecar(ctx, project, plVersion)
+				} else {
+					bs, berr = startBrowserSidecar(ctx, project, name, plVersion)
+					startedNew = true
+				}
 				if berr != nil {
 					return fmt.Errorf("browser sidecar: %w", berr)
 				}
@@ -555,12 +568,14 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 				// or preview server running inside the workspace from
 				// the browser sidecar. Hosts entry written below once
 				// the workspace IP is known.
-				env["CSPACE_WORKSPACE_HOST"] = "workspace"
+				env["CSPACE_WORKSPACE_HOST"] = workspaceFriendlyHost(name, project)
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 					"browser sidecar: %s (cdp %s, run-server %s)\n",
 					bs.ContainerName, bs.CDPURL, bs.RunServerWSURL)
 				defer func() {
-					if err != nil {
+					// Only tear down a sidecar THIS up created. A reused
+					// shared singleton is left for the instances still using it.
+					if err != nil && startedNew {
 						stopBrowserSidecar(context.Background(), bs.ContainerName)
 					}
 				}()
@@ -662,10 +677,6 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 			// use the same BASE_URL for both the readiness probe and
 			// the URL Playwright opens. Best-effort.
 			if browserSidecar != nil {
-				if hErr := InjectWorkspaceHost(ctx, browserSidecar.ContainerName, ip); hErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-						"[cspace] warning: inject workspace host into browser sidecar: %v\n", hErr)
-				}
 				if hErr := InjectWorkspaceHost(ctx, containerName, "127.0.0.1"); hErr != nil {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 						"[cspace] warning: inject workspace host into workspace: %v\n", hErr)
@@ -690,22 +701,6 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 					_ = a.Stop(context.Background(), containerName)
 					err = fmt.Errorf("orchestrate sidecars: %w", upErr)
 					return err
-				}
-				// Extend the browser sidecar's /etc/hosts with the compose
-				// sidecar IPs the orchestrator just resolved. Without this,
-				// headless Chromium can't reach `convex-backend:3210` (the
-				// direct URL Convex returns for storage uploads, etc.) and
-				// fails the fetch with ERR_NAME_NOT_RESOLVED — even though
-				// the WebSocket proxy in the workspace handles every other
-				// Convex call. The workspace and other compose microVMs
-				// already get this map via the orchestrator's own injection.
-				if browserSidecar != nil {
-					hosts := orch.ServiceIPs()
-					hosts["workspace"] = ip
-					if hErr := InjectHosts(ctx, browserSidecar.ContainerName, hosts); hErr != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-							"[cspace] warning: extend browser sidecar hosts: %v\n", hErr)
-					}
 				}
 				// Write extracted env vars (e.g. CONVEX_SELF_HOSTED_ADMIN_KEY)
 				// to <sessionsHostDir>/extracted.env on the host. The sandbox's

--- a/internal/cli/cmd_up.go
+++ b/internal/cli/cmd_up.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/elliottregan/cspace/internal/config"
 	"github.com/elliottregan/cspace/internal/devcontainer"
 	"github.com/elliottregan/cspace/internal/orchestrator"
 	"github.com/elliottregan/cspace/internal/overlay"
@@ -37,6 +38,7 @@ func newUpCmd() *cobra.Command {
 	var baseBranch string
 	var workBranch string
 	var noBrowser bool
+	var noSharedBrowser bool
 	var cpus int
 	var memoryMiB int
 	var noOverlay bool
@@ -829,6 +831,8 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 		"create a fresh branch off baseBranch for the sandbox's work (use `auto` for the historical cspace/<sandbox> shape, or pass an explicit name like `issue/538-fix`); empty = stay on baseBranch")
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false,
 		"skip the default Playwright browser sidecar (the agent's playwright-mcp / chrome-devtools-mcp will fall back to launching their own browser, which fails on ARM64)")
+	cmd.Flags().BoolVar(&noSharedBrowser, "no-shared-browser", false,
+		"use a per-sandbox browser sidecar instead of the shared project browser (default: shared)")
 	cmd.Flags().IntVar(&cpus, "cpus", 0,
 		"CPU cap for this sandbox (overrides .cspace.json resources.cpus and the default of 4)")
 	cmd.Flags().IntVar(&memoryMiB, "memory", 0,
@@ -1215,6 +1219,20 @@ func resolveBrowserEnabled(dcBrowser *bool, noBrowser bool, projectCDPURL string
 	default:
 		return browserDecision{skipReason: "customizations.cspace.browser=false"}
 	}
+}
+
+// resolveSharedBrowser decides whether a project's sandboxes share one
+// browser sidecar. Default true; .cspace.json browser.shared overrides the
+// default; --no-shared-browser overrides config (applied last = flag wins).
+func resolveSharedBrowser(cfgBrowser config.BrowserConfig, noSharedBrowser bool) bool {
+	shared := true
+	if cfgBrowser.Shared != nil {
+		shared = *cfgBrowser.Shared
+	}
+	if noSharedBrowser {
+		shared = false
+	}
+	return shared
 }
 
 // discoverClaudeOauth is a seam so tests can stub host OAuth discovery without

--- a/internal/cli/cmd_up_test.go
+++ b/internal/cli/cmd_up_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	v2 "github.com/elliottregan/cspace/internal/compose/v2"
+	"github.com/elliottregan/cspace/internal/config"
 	"github.com/elliottregan/cspace/internal/devcontainer"
 	"github.com/spf13/cobra"
 )
@@ -327,6 +328,30 @@ func TestJoinPostCmd(t *testing.T) {
 			got := joinPostCmd(c.in)
 			if got != c.want {
 				t.Fatalf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolveSharedBrowser(t *testing.T) {
+	b := func(v bool) *bool { return &v }
+	cases := []struct {
+		name      string
+		cfgShared *bool
+		noShared  bool
+		want      bool
+	}{
+		{"default shared", nil, false, true},
+		{"config true", b(true), false, true},
+		{"config false", b(false), false, false},
+		{"flag off default", nil, true, false},
+		{"flag overrides config true", b(true), true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveSharedBrowser(config.BrowserConfig{Shared: tc.cfgShared}, tc.noShared)
+			if got != tc.want {
+				t.Errorf("got %v want %v", got, tc.want)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	Services   string                   `json:"services"`
 	PostSetup  string                   `json:"post_setup"`
 	Resources  ResourcesConfig          `json:"resources,omitempty"`
+	Browser    BrowserConfig            `json:"browser,omitempty"`
 
 	// ServiceURLs declares Traefik-routed project services whose URLs cspace
 	// should inject into the main container as env vars. Key is the subdomain
@@ -109,6 +110,14 @@ type AgentConfig struct {
 type PluginsConfig struct {
 	Enabled bool     `json:"enabled"`
 	Install []string `json:"install"`
+}
+
+// BrowserConfig controls the cspace browser sidecar topology. Shared is a
+// tristate: nil = unset (defaults to shared=true); a pointer lets the
+// --no-shared-browser flag distinguish "config said true" from "config left it
+// unset" when overriding.
+type BrowserConfig struct {
+	Shared *bool `json:"shared,omitempty"`
 }
 
 // Load reads and merges configuration from all sources.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -606,3 +606,13 @@ func TestConfigCoordinatorModelEmptyByDefault(t *testing.T) {
 		t.Errorf("CoordinatorModel default = %q, want empty", cfg.Claude.CoordinatorModel)
 	}
 }
+
+func TestConfigBrowserSharedFalse(t *testing.T) {
+	cfg, err := loadConfigFromJSON(t, `{"browser":{"shared":false}}`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Browser.Shared == nil || *cfg.Browser.Shared != false {
+		t.Fatalf("browser.shared: got %v, want explicit false", cfg.Browser.Shared)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -185,6 +185,25 @@ func (r *Registry) List() ([]Entry, error) {
 	return out, nil
 }
 
+// CountForProject returns how many registered sandboxes belong to project.
+// Counts all states (a "starting" sibling still needs the shared browser).
+// Snapshot semantics: built on List(), so it can race a concurrent
+// Register/Unregister — callers that need a teardown decision should
+// Unregister first, then count.
+func (r *Registry) CountForProject(project string) (int, error) {
+	entries, err := r.List()
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, e := range entries {
+		if e.Project == project {
+			n++
+		}
+	}
+	return n, nil
+}
+
 // FreePort asks the kernel for an unused TCP port on 127.0.0.1.
 func FreePort() (int, error) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -201,3 +201,25 @@ func TestFreePort(t *testing.T) {
 		t.Fatalf("expected ephemeral port, got %d", p)
 	}
 }
+
+func TestCountForProject(t *testing.T) {
+	r := &Registry{Path: filepath.Join(t.TempDir(), "reg.json")}
+	for _, e := range []Entry{
+		{Project: "alpha", Name: "mercury", IP: "10.0.0.1"},
+		{Project: "alpha", Name: "venus", IP: "10.0.0.2"},
+		{Project: "beta", Name: "mercury", IP: "10.0.0.3"},
+	} {
+		if err := r.Register(e); err != nil {
+			t.Fatalf("register: %v", err)
+		}
+	}
+	for proj, want := range map[string]int{"alpha": 2, "beta": 1, "gamma": 0} {
+		got, err := r.CountForProject(proj)
+		if err != nil {
+			t.Fatalf("count %s: %v", proj, err)
+		}
+		if got != want {
+			t.Errorf("CountForProject(%q) = %d, want %d", proj, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of the cspace browser work: replace the per-instance Playwright/Chromium sidecar with **one shared browser per project** (`cspace-<project>-browser`), ref-counted, with per-instance reachability via the existing `.cspace.test` DNS instead of bare-name `/etc/hosts` injection. Per-instance isolation is preserved by Phase 1's `playwright-mcp --isolated`. Builds on (and is independent of) the Phase 1 plugin PR.

- Design spec: `docs/superpowers/specs/2026-06-18-shared-browser-sidecar-design.md`
- Plan: `docs/superpowers/plans/2026-06-18-shared-browser-sidecar.md`

## What's in it

- **`browser.go`:** `browserSingletonName(project)` + `workspaceFriendlyHost(name,project)`; `runBrowserSidecar` (non-torching, records a `cspace.playwright-version` label); `ensureSharedBrowserSidecar` (start-if-absent / **reuse-if-healthy-and-version-matched** singleton — never torches a healthy one; handles the concurrent-create race; returns `startedNew`); `startBrowserSidecar` keeps the per-instance (opt-out) path.
- **`registry.go`:** `CountForProject` for ref-counting.
- **`config.go` + `cmd_up.go`:** `BrowserConfig{Shared *bool}`, `--no-shared-browser` (flag overrides `.cspace.json browser.shared`), `resolveSharedBrowser`. Default is shared.
- **`cmd_up.go`:** shared vs per-instance dispatch; `CSPACE_WORKSPACE_HOST = <sandbox>.<project>.cspace.test`; dropped the browser-sidecar `/etc/hosts` injection; error-defer gated on `startedNew` (a reused singleton is never torn down on a later error).
- **`cmd_down.go`:** ref-counted teardown — stop the shared singleton only when the project's last sandbox goes down (Unregister-before-count).
- **`cmd_daemon.go`:** the **gateway** DNS listener now retries its bind. Acceptance found the daemon loses a startup race to the vmnet bridge (it's spawned before the first container), so in-container `.cspace.test` — which the shared browser now depends on — was NXDOMAIN. (This amends the spec's earlier "no daemon change" note; the host-loopback listener is unaffected.)
- **`cmd_registry.go`:** `cspace registry prune` now reaps an orphaned shared singleton (its name is derived, not stored in a registry entry, so it would otherwise leak on abnormal last-instance death).

## Validation (real environment)

- Two instances shared **one** `cspace-cspace-browser` — the second **reused** it (same CDP endpoint, ~3× faster boot).
- The shared browser resolves the **per-instance** friendly name (`alpha.cspace.cspace.test → alpha's IP`) — no `/etc/hosts` collision — once the daemon gateway-bind retry lands.
- **Ref-counted teardown:** `down` first → singleton stays; `down` last → singleton stops.
- **`--no-shared-browser`** → per-instance `cspace-<project>-<sandbox>-browser`.
- All Go tests + `vet` clean. Final whole-branch review: ready to merge after the prune-backstop fix (applied + re-reviewed).
- resume-redux is the acceptance bar and needs **no change** (its e2e reads `CSPACE_WORKSPACE_HOST`; browser→Convex rides its workspace `__SELF__` proxy) — the full e2e run is the documented real-world bar.

## Scope / deferrals (in the spec)

- **Phase 3:** per-context proxy for bare compose-sidecar URLs (the narrow opt-out case today).
- The `options.plugins` single-source supervisor unification (separate Phase-1.5 cleanup).
- Known narrow `down`-during-`up` TOCTOU window (documented in the spec's Edge cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)