### PR TITLE
Sandbox name-resolution reliability + env isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,8 @@ Shell scripts fired by Claude Code's hook system: progress logging on `PostToolU
 **Agent secrets** (Phase 0+): cspace-owned secrets (Anthropic API key, future GH tokens, etc.) live in `~/.cspace/secrets.env` (user-global) and `<project>/.cspace/secrets.env` (project-local override; gitignored). Project-local overrides global; an explicitly-set host shell env var still wins for one-off overrides. Format is dotenv-style (`KEY=value`, `# comments`, optional `"…"` or `'…'` quoting). The project's own `.env` is **not** loaded by cspace — that file is the app's domain and is read at runtime by the app's own dotenv tooling. Keep cspace and app secrets separate.
 Security caveat: secrets currently transit `-e` flags into the substrate. Apple Container's `vminitd` is known to log the full process env, so anyone with `container logs` access on the host can read these values. P1 will add Keychain-backed values (`KEY=keychain:<service-name>` resolved via `security find-generic-password` on macOS, equivalents on Linux) and an alternative delivery path that doesn't transit `-e`.
 
+**Project env overrides** (`.env.cspace`): distinct from the secrets above — a project-owned, static, committed file that neutralizes host/cloud env vars (e.g. a stale `CONVEX_DEPLOYMENT`) that a project's own `.env` would otherwise leak into the sandbox. Wired via a second `env_file:` entry in the project's devcontainer compose file; cspace never writes dynamic per-sandbox values into it. See `docs/env-cspace.md` for the convention, precedence rules, and the related `$CSPACE_WORKSPACE_HOST` / e2e `baseURL` guidance.
+
 ## Commit Style
 
 Short imperative sentences describing what changed and why. Examples from history:

--- a/docs/devcontainer-subset.md
+++ b/docs/devcontainer-subset.md
@@ -107,7 +107,7 @@ microVMs don't share the host's port space the way Docker Desktop does
 — each microVM gets its own vmnet IP. cspace surfaces forwarded ports in
 two ways:
 
-- **From the host browser:** `http://<sandbox>.<project>.cspace2.local:<port>` —
+- **From the host browser:** `http://<sandbox>.<project>.cspace.test:<port>` —
   resolved by cspace's DNS daemon to the sandbox's vmnet IP.
 - **From sibling services inside the sandbox cluster:** `http://<service>:<port>` —
   resolved by the injected `/etc/hosts` entries.
@@ -115,6 +115,14 @@ two ways:
 The `ports:` directive itself is informational in cspace. We don't fail
 the file when it's present, but we don't bind the host port — the access
 pattern above replaces it.
+
+The same qualified name is exported inside the sandbox as
+`$CSPACE_WORKSPACE_HOST` — use it (not `$(hostname)` or `localhost`) whenever
+code running inside or alongside the sandbox needs an externally-reachable
+address for the workspace, including a project's e2e `baseURL`. See
+[docs/env-cspace.md](./env-cspace.md) for the full convention, plus the
+related `.env.cspace` pattern for neutralizing host/cloud env vars inside the
+container.
 
 ## cspace customizations
 
@@ -189,7 +197,7 @@ Expected divergences:
   Projects relying on `extractCredentials` need a manual fallback when
   opening in VS Code (e.g., a documented step to copy the admin key from
   the convex-backend container).
-- Port access pattern differs: cspace uses `<sandbox>.<project>.cspace2.local:<port>`,
+- Port access pattern differs: cspace uses `<sandbox>.<project>.cspace.test:<port>`,
   VS Code uses `localhost:<forwardedPort>`. The compose file is identical;
   the URL pattern in your local docs/links may need to vary.
 

--- a/docs/env-cspace.md
+++ b/docs/env-cspace.md
@@ -60,18 +60,35 @@ self-hosted backend URL, the workspace host) continue to ride the existing
 ## Precedence (stated honestly)
 
 `.env.cspace` only wins **among `env_file` entries** — specifically, it wins
-over `.env` because it's declared later in the `env_file:` list. It does
-**not** out-rank other env sources. All of the following still beat an
-`env_file`-sourced value for the same key:
+over `.env` because it's declared later in the `env_file:` list. Beyond that,
+here is the actual merge order `cspace up` applies (later steps overwrite
+earlier ones on key collision — see `internal/cli/cmd_up.go`):
 
-- Compose service `environment:` (explicit keys always beat `env_file:` per
-  the compose spec, independent of cspace)
-- devcontainer.json `containerEnv`
-- `.cspace/secrets.env` (cspace-delivered secrets — see below)
-- `cspace up --env KEY=VALUE`
+1. `.cspace/secrets.env` (cspace-delivered secrets) — merged into the env map
+   first (`cmd_up.go:250-252`).
+2. Compose service `environment:`, which includes whatever compose-go already
+   resolved from `env_file:` entries — i.e. **`.env` and `.env.cspace`** —
+   merges next (`cmd_up.go:285-291`), overwriting same-named keys from step 1.
+3. devcontainer.json `containerEnv` merges after that (`cmd_up.go:295-297`).
+4. `cspace up --env KEY=VALUE` merges last (`cmd_up.go:395-401`) and always
+   wins.
 
-Don't fight this: if a value declared in `.env.cspace` isn't taking effect,
-check whether one of the above is also setting that key.
+So, highest to lowest: **`--env` > devcontainer `containerEnv` > compose
+`env_file` (`.env.cspace` / `.env`) > `.cspace/secrets.env`**.
+
+**Security caveat:** because `.env.cspace` out-ranks `.cspace/secrets.env` in
+this order, a project that redeclares one of cspace's own secret key names
+(`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`,
+`GITHUB_PERSONAL_ACCESS_TOKEN`) in `.env.cspace` **silently overrides the
+delivered secret** — the sandbox ends up running with whatever `.env.cspace`
+set (often blank or stale) instead of the credential cspace loaded from the
+keychain/secrets file, with no warning. `.env.cspace` must not redeclare
+cspace secret keys.
+
+This ordering is arguably surprising — one might expect a cspace-delivered
+secret to always win over a project's committed override file — and is
+tracked as a possible follow-up. The above is what ships today, not an
+aspiration; don't design around a "secrets always win" assumption.
 
 ## Naming caveat
 
@@ -94,8 +111,10 @@ These two files solve different problems and shouldn't be confused:
 
 Avoid reusing one of cspace's own secret key names
 (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`,
-`GITHUB_PERSONAL_ACCESS_TOKEN`) as a key in `.env.cspace` — see the precedence
-note above.
+`GITHUB_PERSONAL_ACCESS_TOKEN`) as a key in `.env.cspace` — per the precedence
+note above, `.env.cspace` out-ranks `.cspace/secrets.env`, so reusing one of
+these keys silently overrides the delivered secret rather than the other way
+around.
 
 ## Inert on the local box
 

--- a/docs/env-cspace.md
+++ b/docs/env-cspace.md
@@ -1,0 +1,154 @@
+# `.env.cspace` — project-declared container overrides
+
+`.env.cspace` is a convention (not a cspace-enforced feature) for neutralizing
+host/cloud environment variables that leak into a sandbox via a project's own
+`.env`, without touching that `.env` or forking behavior for the local,
+container-free workflow.
+
+It exists because a project's `.env` is written for the developer's own
+machine. Inside a cspace sandbox some of those values are wrong — a cloud
+database deployment ID when the sandbox runs a self-hosted backend, a
+`localhost` URL that isn't reachable from the browser sidecar, and so on.
+`.env.cspace` is where the project declares "when running under cspace,
+these values change."
+
+## Wiring
+
+Add a second `env_file` entry to the project's devcontainer compose file,
+pointing at a sibling `.env.cspace` next to the existing `.env`:
+
+```yaml
+# .devcontainer/docker-compose.yml (project-side)
+env_file:
+  - path: ../.env          # required: false
+  - path: ../.env.cspace   # required: false — later file wins
+```
+
+Both entries are `required: false` so the file is optional — a project with
+no `.env.cspace` behaves exactly as before. compose-go (the compose
+implementation cspace uses to parse `dockerComposeFile`) evaluates `env_file:`
+entries in list order and lets a later file's keys override an earlier file's
+keys, so anything `.env.cspace` sets replaces the same key from `.env` — for
+**every** shell in the container, login or not (unlike a `/etc/profile.d`
+hack, which only fires for login shells).
+
+## What goes in it
+
+`.env.cspace` is **project-owned, static, and committed** — the same
+lifecycle as `.env.example`, not a secrets file. A project author who knows
+their own conflicting vars declares the overrides once:
+
+```bash
+# .env.cspace — cspace-mode overrides, committed
+CONVEX_DEPLOYMENT=
+```
+
+That example blanks a cloud Convex deployment ID that `.env` sets for local
+dev, so a self-hosted `convex` CLI inside the sandbox doesn't try to talk to
+the cloud deployment. The Convex CLI coerces `CONVEX_DEPLOYMENT=""` to null
+and won't re-read the stale value. cspace itself has no Convex-specific
+knowledge — it only defines the file convention; the project supplies the
+contents.
+
+**cspace never writes per-sandbox dynamic values into `.env.cspace`.** It's a
+single file at the repo root shared by every concurrent sandbox for the
+project — a per-sandbox write from cspace would race between sandboxes and
+dirty the working tree. Values that differ per sandbox (admin keys, the
+self-hosted backend URL, the workspace host) continue to ride the existing
+`/sessions/extracted.env` channel, not this file.
+
+## Precedence (stated honestly)
+
+`.env.cspace` only wins **among `env_file` entries** — specifically, it wins
+over `.env` because it's declared later in the `env_file:` list. It does
+**not** out-rank other env sources. All of the following still beat an
+`env_file`-sourced value for the same key:
+
+- Compose service `environment:` (explicit keys always beat `env_file:` per
+  the compose spec, independent of cspace)
+- devcontainer.json `containerEnv`
+- `.cspace/secrets.env` (cspace-delivered secrets — see below)
+- `cspace up --env KEY=VALUE`
+
+Don't fight this: if a value declared in `.env.cspace` isn't taking effect,
+check whether one of the above is also setting that key.
+
+## Naming caveat
+
+`.env.cspace` intentionally matches the shape of Vite's and Nuxt's
+`.env.<mode>` convention (`.env.production`, `.env.staging`, ...). That's
+coincidental, not a hook into either tool's mode system — **never run the app
+with `--mode cspace`**, or the frontend build tooling will pick up
+`.env.cspace` itself and apply it in contexts where that's not intended.
+`.env.cspace` is meant exclusively for the compose `env_file:` wiring above,
+not the app's own dotenv loading.
+
+## Relationship to `.cspace/secrets.env`
+
+These two files solve different problems and shouldn't be confused:
+
+| File | Owner | Contents | Delivery |
+|---|---|---|---|
+| `.cspace/secrets.env` | cspace / the developer | cspace-delivered credentials (`ANTHROPIC_API_KEY`, `GH_TOKEN`, ...) | Loaded by the CLI, passed as container env at boot. Gitignored. |
+| `.env.cspace` | the project | Project-declared container overrides (neutralizing host/cloud vars) | Loaded by compose's `env_file:` mechanism inside the container build. Committed. |
+
+Avoid reusing one of cspace's own secret key names
+(`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`,
+`GITHUB_PERSONAL_ACCESS_TOKEN`) as a key in `.env.cspace` — see the precedence
+note above.
+
+## Inert on the local box
+
+Because the compose `env_file:` entries only take effect when the compose
+file is actually loaded (i.e., inside a cspace/devcontainer boot),
+`.env.cspace` has **zero effect** on the box-native workflow (`pnpm dev` / a
+locally-run process with no container). Nothing about the local workflow has
+to change to adopt this convention — the file simply sits there unread until
+a sandbox boots.
+
+## Reaching the workspace: `$CSPACE_WORKSPACE_HOST`
+
+Every `cspace up` sets `CSPACE_WORKSPACE_HOST` inside the devcontainer,
+unconditionally — even with `--no-browser`. Its value is the sandbox's
+qualified DNS name, `<sandbox>.<project>.cspace.test`, resolved by cspace's
+DNS daemon to the sandbox's current vmnet IP.
+
+Use `$CSPACE_WORKSPACE_HOST` — never the raw container hostname (`$(hostname)`
+or similar) — whenever code running inside (or alongside) the sandbox needs an
+address for the workspace that's reachable from *outside* the devcontainer's
+own network namespace. The raw hostname only resolves inside the devcontainer
+itself; the shared browser sidecar and the host both need the qualified name.
+
+The statusline (`lib/runtime/scripts/statusline.sh`) already surfaces this
+same FQDN (`${CONTAINER}.${PROJECT}.cspace.test`) next to each listening port,
+so `cspace up`'s status output and `$CSPACE_WORKSPACE_HOST` always agree.
+
+### e2e `baseURL` convention
+
+The `run-server` e2e browser (Playwright) runs **remotely**, in the shared
+browser sidecar container — not inside the devcontainer and not on the host.
+That means a project's end-to-end test config pointing `baseURL` at
+`localhost` is wrong inside cspace: `localhost` from the sidecar's point of
+view is the sidecar itself, not the dev server.
+
+Projects should make their Playwright (or equivalent) `baseURL` fall back to
+`$CSPACE_WORKSPACE_HOST` when it's set:
+
+```ts
+// playwright.config.ts
+const port = 4173;
+const baseURL = process.env.CSPACE_WORKSPACE_HOST
+  ? `http://${process.env.CSPACE_WORKSPACE_HOST}:${port}`
+  : `http://localhost:${port}`;
+
+export default defineConfig({
+  use: { baseURL },
+  // ...
+});
+```
+
+cspace can't inject this for you — it doesn't know the app's dev-server port —
+so this is a project-side default, the same "adapt to cspace when present,
+otherwise behave exactly as before" shape as the `.env.cspace` convention
+above. Outside a cspace sandbox `CSPACE_WORKSPACE_HOST` is unset, so the
+fallback to `localhost` keeps the box-native workflow unchanged.

--- a/docs/image-dependencies.md
+++ b/docs/image-dependencies.md
@@ -8,7 +8,7 @@ For the overlay to function, the image must provide:
 |---|---|---|
 | **glibc** | Supervisor is a Bun-compiled binary linked against glibc | ✓ |
 | **iptables** | Loopback NAT for ports bound to 127.0.0.1 inside the sandbox | ✓ (auto-installed via apt if missing on debian/ubuntu) |
-| **dnsmasq** | DNS forwarder (sibling-service hostnames + cspace2.local) | ✓ (auto-installed via apt if missing on debian/ubuntu) |
+| **dnsmasq** | DNS forwarder (sibling-service hostnames + cspace.test) | ✓ (auto-installed via apt if missing on debian/ubuntu) |
 | **bash** | Entrypoint is a bash script | ✓ |
 | **tini** (recommended) | PID 1 reaping; cspace's entrypoint will work without it but zombies accumulate | ✓ |
 | **sudo** (recommended) | Init script drops from root to your `remoteUser` after privileged setup | ✓ |
@@ -57,7 +57,7 @@ RUN dnf install -y iptables nftables dnsmasq
   inside the sandbox aren't reachable from sibling services or host
   browsers. Install iptables for your distro.
 - **dnsmasq absent and apt-get unavailable:** bare-name service DNS
-  (`http://convex-backend:3210`) and `*.cspace2.local` resolution fail.
+  (`http://convex-backend:3210`) and `*.cspace.test` resolution fail.
   Install dnsmasq for your distro.
 - **bash absent:** entrypoint can't run. Use an image with bash; busybox
   alone isn't enough because the entrypoint relies on bash builtins.

--- a/docs/superpowers/plans/2026-07-13-sandbox-name-resolution-and-env-isolation.md
+++ b/docs/superpowers/plans/2026-07-13-sandbox-name-resolution-and-env-isolation.md
@@ -1,0 +1,749 @@
+# Sandbox Name-Resolution Reliability + Env Isolation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make cspace's `*.cspace.test` name resolution survive the life of the sandboxes (not die mid-session), give the shared browser correct per-sandbox routing, fail loud when the DNS chain is broken, and add a non-invasive project env-override file — so the agent's MCP browser, the Playwright `run-server` e2e browser, host→site access, and the convex `__SELF__` proxy all resolve reliably.
+
+**Architecture:** `cspace up` spawns the `.cspace.test` DNS daemon. Today it's spawned un-detached with stderr on a parent-held pipe (`cmd_up.go:1152-1159`), so it takes `SIGPIPE` on its next log write after `cspace up` exits. The fix detaches it (`Setsid` + log file), adds a `/health` version handshake with a race-safe stop-and-respawn, verifies in-container resolution at boot, extends `cspace doctor`, refreshes stale registry IPs on lookup, deletes the dead `ServiceIPs` field, sets `CSPACE_WORKSPACE_HOST` unconditionally, and documents an `.env.cspace` convention.
+
+**Tech Stack:** Go (Cobra CLI, `github.com/miekg/dns`), Apple Container substrate (vmnet `192.168.64.0/24`, gateway `.1`), `~/.cspace/sandbox-registry.json`, dnsmasq inside containers forwarding `*.cspace.test` → `192.168.64.1:5354`.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-sandbox-name-resolution-and-env-isolation-design.md`
+
+## Global Constraints
+
+- **One PR**, implemented in the task order below (highest-leverage first).
+- Build: `make build` (runs `make sync-embedded`). Test: `make test` (`go test ./...`). Static analysis: `make vet` and the repo's `golangci-lint` (default linters include `unused` — write-only fields/dead symbols fail the lint). All must pass before each commit.
+- Go only; **no new external dependencies**.
+- `SysProcAttr{Setsid: true}` compiles on both build targets (darwin + linux — the only goos in `.goreleaser.yml`), so the daemon-spawn code needs **no** `runtime.GOOS` guard. (Correcting an earlier assumption.)
+- DNS facts are fixed: domain `cspace.test.`, host loopback `127.0.0.1:5354`, container-facing gateway `192.168.64.1:5354`, HTTP registry `127.0.0.1:6280` (`0.0.0.0` bind), TTL `5`. The daemon idle-exit gate (exit only when idle **and** `len(entries)==0`, `cmd_daemon.go:163-165`) is **correct — do not touch it.** The bug is detachment, not idle policy.
+- `Version` is a mutable package var (`internal/cli/root.go:15`), ldflags-stamped. Tests that mutate it MUST restore it with `t.Cleanup`.
+- Devcontainer base is `node:24-bookworm-slim` (Debian) and the sidecar is `mcr.microsoft.com/playwright:*-noble` (Ubuntu) — both glibc, both ship `getent`. (CLAUDE.md's "Alpine" is stale.)
+- Commit bodies end with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- `internal/cli/daemon_spawn.go` *(new)* — detached `*exec.Cmd` builder + `~/.cspace/daemon.log` path (unit-testable, keeps `cmd_up.go` focused).
+- `internal/cli/cmd_up.go` — `ensureRegistryDaemon` (detach + version handshake); hoist `CSPACE_WORKSPACE_HOST`; call the boot gate.
+- `internal/cli/cmd_daemon.go` — env-overridable DNS listen addrs; `/health` version; extract `stopRegistryDaemon`; `daemonDNSHandler` IP refresh.
+- `internal/cli/cmd_send.go`, `internal/cli/cmd_attach.go` — re-ensure the daemon.
+- `internal/cli/resolve_gate.go` *(new)* — `verifyInContainerResolution(...)`, reused by the boot gate and the doctor probe.
+- `internal/cli/probes.go` — a gateway-DNS `ProbeCheck` and an in-container-resolution `ProbeCheck`, both inside `ProbeDaemon`.
+- `internal/orchestrator/types.go`, `internal/orchestrator/lifecycle.go` — delete the dead `ServiceIPs()` method, the `serviceIPs` field, and its write (`lifecycle.go:205`). **Keep `InjectHosts`** (it is live — `InjectWorkspaceHost` calls it, `browser.go:209`); only fix its stale docstring.
+- `docs/env-cspace.md`, agent-guidance docs — `.env.cspace` convention + `$CSPACE_WORKSPACE_HOST`.
+
+---
+
+## Task 1: Detach the daemon (the core SIGPIPE fix)
+
+**Files:** Create `internal/cli/daemon_spawn.go`, `internal/cli/daemon_spawn_test.go`; Modify `internal/cli/cmd_daemon.go` (env-overridable listen addrs), `internal/cli/cmd_up.go:1139-1198`.
+
+**Interfaces:**
+- Produces `daemonLogPath() (string, error)` → `~/.cspace/daemon.log`.
+- Produces `newDaemonCommand(self string) (*exec.Cmd, *os.File, error)` — `self daemon serve`, `SysProcAttr{Setsid:true}`, stdout+stderr = an `*os.File` log (never a parent-held pipe). Caller closes the file after `Start`.
+- Produces (in `cmd_daemon.go`) env overrides `CSPACE_DAEMON_DNS_ADDR` / `CSPACE_DAEMON_GATEWAY_ADDR` so tests bind ephemeral ports instead of the real `5354`.
+
+- [ ] **Step 1: Make the daemon DNS listen addresses overridable (so tests don't collide with a real daemon)**
+
+In `cmd_daemon.go`, change the `const daemonDNSListenAddr`/`daemonDNSGatewayAddr` usage in `runDaemonServe` to read overrides first:
+```go
+func daemonDNSAddrs() (listen, gateway string) {
+	listen = daemonDNSListenAddr
+	if v := os.Getenv("CSPACE_DAEMON_DNS_ADDR"); v != "" {
+		listen = v
+	}
+	gateway = daemonDNSGatewayAddr
+	if v := os.Getenv("CSPACE_DAEMON_GATEWAY_ADDR"); v != "" {
+		gateway = v
+	}
+	return
+}
+```
+Use `listen, gateway := daemonDNSAddrs()` where `runDaemonServe` currently references the consts. Keep the consts as the defaults. Commit this small enabler with Step 8.
+
+- [ ] **Step 2: Write the failing unit test** (`daemon_spawn_test.go`)
+
+```go
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNewDaemonCommandIsDetached(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd, f, err := newDaemonCommand("/usr/local/bin/cspace")
+	if err != nil {
+		t.Fatalf("newDaemonCommand: %v", err)
+	}
+	defer f.Close()
+
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
+		t.Error("daemon command must set Setsid so it survives the parent")
+	}
+	if _, ok := cmd.Stderr.(*os.File); !ok {
+		t.Errorf("stderr must be an *os.File log (not a parent-held pipe), got %T", cmd.Stderr)
+	}
+	if cmd.Stdout != cmd.Stderr {
+		t.Error("stdout and stderr should share the log file")
+	}
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.HasSuffix(joined, "daemon serve") {
+		t.Errorf("args = %v, want ... daemon serve", cmd.Args)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails** — `go test ./internal/cli/ -run TestNewDaemonCommandIsDetached -v` → FAIL `undefined: newDaemonCommand`.
+
+- [ ] **Step 4: Implement** (`daemon_spawn.go`)
+
+```go
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+func daemonLogPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".cspace")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "daemon.log"), nil
+}
+
+// newDaemonCommand builds a detached `<self> daemon serve`. Setsid detaches it
+// from the parent's session; stdout+stderr go to an append-only log FILE (not
+// a parent-held os.Pipe) so a later log write can't take EPIPE -> SIGPIPE after
+// cspace up exits. Caller closes the returned file after Start.
+func newDaemonCommand(self string) (*exec.Cmd, *os.File, error) {
+	logPath, err := daemonLogPath()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := rotateIfLarge(logPath, 1<<20); err != nil { // 1 MiB cap (spec 1a)
+		return nil, nil, err
+	}
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, nil, err
+	}
+	cmd := exec.Command(self, "daemon", "serve")
+	cmd.Stdout, cmd.Stderr = f, f
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return cmd, f, nil
+}
+
+// rotateIfLarge truncates the log by renaming to .1 once it exceeds max bytes,
+// bounding the gateway-retry chatter over long-lived hosts.
+func rotateIfLarge(path string, max int64) error {
+	if fi, err := os.Stat(path); err == nil && fi.Size() > max {
+		return os.Rename(path, path+".1")
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes** — `go test ./internal/cli/ -run TestNewDaemonCommandIsDetached -v` → PASS.
+
+- [ ] **Step 6: Rewrite `ensureRegistryDaemon`** (`cmd_up.go:1139-1198`)
+
+Reap the child with a goroutine `Wait` (prevents a zombie if the daemon fast-fails on a squatted port) and hold no pipe:
+```go
+func ensureRegistryDaemon() error {
+	if v, ok := daemonHealthVersion(time.Second); ok && v == Version {
+		return nil // healthy and current (version check added in Task 2)
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate cspace binary: %w", err)
+	}
+	cmd, logFile, err := newDaemonCommand(self)
+	if err != nil {
+		return fmt.Errorf("prepare daemon: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return fmt.Errorf("spawn cspace daemon: %w", err)
+	}
+	_ = logFile.Close() // detached daemon keeps its own handle on the log file
+	go func() { _ = cmd.Wait() }() // reap; does NOT couple lifetimes (child is Setsid-detached)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, derr := net.DialTimeout("tcp", "127.0.0.1:6280", 250*time.Millisecond); derr == nil {
+			_ = c.Close()
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if p, perr := daemonLogPath(); perr == nil {
+		if b, rerr := os.ReadFile(p); rerr == nil && len(b) > 0 {
+			tail := string(b)
+			if len(tail) > 800 {
+				tail = tail[len(tail)-800:]
+			}
+			return fmt.Errorf("daemon not accepting connections within 3s; ~/.cspace/daemon.log tail:\n%s", tail)
+		}
+	}
+	return fmt.Errorf("daemon started but not accepting connections within 3s")
+}
+```
+Then delete the now-unused `limitedBuffer` type (`cmd_up.go:1200-1229`) and drop any now-unused imports (`bytes`, `sync`) — `make vet` will flag them. (`daemonHealthVersion` is added in Task 2; if implementing Task 1 in isolation, temporarily inline a `net.DialTimeout` reuse check and replace it in Task 2.)
+
+- [ ] **Step 7: Write the survival test that drives the REAL path and can catch the regression** (`daemon_spawn_test.go`, append)
+
+```go
+import (
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// A detached daemon must keep answering after its spawner exits. We build the
+// real binary, run a throwaway "spawner" that calls the same spawn path and
+// then exits, and assert the daemon is still up. DNS/HTTP ports are overridden
+// so this never collides with a developer's live daemon.
+func TestDaemonSurvivesSpawnerExit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds + spawns real processes")
+	}
+	bin := buildCspaceForTest(t) // go build -o <tmp> ./cmd/cspace
+	home := t.TempDir()
+	env := append(os.Environ(),
+		"HOME="+home,
+		"CSPACE_REGISTRY_DAEMON_PORT=6299",
+		"CSPACE_DAEMON_DNS_ADDR=127.0.0.1:15354",
+		"CSPACE_DAEMON_GATEWAY_ADDR=127.0.0.1:15355", // loopback stand-in; gateway bind is best-effort
+		"CSPACE_REGISTRY_DAEMON_IDLE=1h",
+	)
+	// Spawner: start the daemon detached exactly like ensureRegistryDaemon, then exit.
+	spawner := exec.Command(bin, "daemon", "serve")
+	spawner.Env = env
+	logf, _ := os.Create(filepath.Join(home, "d.log"))
+	spawner.Stdout, spawner.Stderr = logf, logf
+	spawner.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := spawner.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := spawner.Process.Pid
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	waitForPort(t, "127.0.0.1:6299", 5*time.Second)
+	_ = logf.Close() // drop the only non-daemon reference to the log
+	// Force the daemon to keep logging (a real daemon logs on gateway retries);
+	// then confirm it is still alive and answering after the parent's handle is gone.
+	time.Sleep(1 * time.Second)
+	if syscall.Kill(pid, 0) != nil {
+		t.Fatal("daemon died after its spawner's log handle closed (SIGPIPE regression)")
+	}
+	if _, ok := httpGet(t, "http://127.0.0.1:6299/health"); !ok {
+		t.Fatal("daemon stopped answering /health")
+	}
+}
+```
+Add helpers `buildCspaceForTest`, `waitForPort`, `httpGet` in the test file. (This drives the real binary and overridden ports; it fails on the pre-fix code because that path wires a parent-held pipe.)
+
+- [ ] **Step 8: Full test + build + commit**
+
+```bash
+go test ./internal/cli/ -run 'TestNewDaemonCommand|TestDaemonSurvives' -v && make build && make vet
+git add internal/cli/daemon_spawn.go internal/cli/daemon_spawn_test.go internal/cli/cmd_up.go internal/cli/cmd_daemon.go
+git commit -m "fix(daemon): detach the registry daemon so it survives cspace up exiting
+
+Setsid + ~/.cspace/daemon.log (not a parent-held pipe); reap via goroutine
+Wait. Previously the daemon took SIGPIPE on its next log write after cspace up
+exited, silently killing in-container .cspace.test resolution mid-session. DNS
+listen addrs are now env-overridable so the survival test can't collide with a
+real daemon.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Version handshake + race-safe stop; re-ensure from long-running commands
+
+**Files:** Modify `internal/cli/cmd_daemon.go` (`/health`, extract `stopRegistryDaemon`), `internal/cli/cmd_up.go`, `internal/cli/cmd_send.go`, `internal/cli/cmd_attach.go`; Test `internal/cli/cmd_daemon_test.go`.
+
+**Interfaces:**
+- `/health` → `{"ok":true,"version":"<Version>"}`.
+- `daemonHealthVersion(timeout) (string, bool)`.
+- `stopRegistryDaemon() error` — `pkill -f "daemon serve"` **then blocks until `:6280` and `daemonDNSAddrs()` listen addr are free** (or a 3s timeout), so a respawn can't race the dying daemon for the fatal loopback bind.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestHealthReportsVersion(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+	Version = "v9.9.9-test"
+
+	rec := httptest.NewRecorder()
+	healthHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	var body struct {
+		OK      bool   `json:"ok"`
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if !body.OK || body.Version != "v9.9.9-test" {
+		t.Fatalf("got %+v, want ok+version v9.9.9-test", body)
+	}
+}
+```
+
+- [ ] **Step 2: Run → FAIL** `undefined: healthHandler`.
+
+- [ ] **Step 3: Named, versioned health handler** — replace the inline `GET /health` closure (`cmd_daemon.go:120-123`) with:
+```go
+func healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "version": Version})
+}
+```
+Register: `mux.HandleFunc("GET /health", healthHandler)`.
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Extract a race-safe `stopRegistryDaemon`** from the pkill body currently inline in `newDaemonStopCmd` (`cmd_daemon.go:400-421`):
+```go
+func stopRegistryDaemon() error {
+	out, err := exec.Command("pkill", "-f", "daemon serve").CombinedOutput()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 {
+			return nil // pkill exit 1 == no matches
+		}
+		return fmt.Errorf("pkill: %w (%s)", err, out)
+	}
+	// Block until the daemon's fatal-to-rebind ports are actually free, so a
+	// respawn doesn't lose the loopback DNS/HTTP bind to the dying process.
+	listen, _ := daemonDNSAddrs()
+	waitPortFree("127.0.0.1:"+daemonHTTPPort, 3*time.Second)
+	waitPortFree(listen, 3*time.Second)
+	return nil
+}
+
+func waitPortFree(addr string, d time.Duration) {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err != nil { // refused == free
+			return
+		}
+		_ = c.Close()
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+```
+Have `newDaemonStopCmd`'s RunE call `stopRegistryDaemon()` (DRY). Add `daemonHealthVersion` (GET `/health`, decode `version`). In `ensureRegistryDaemon` (Task 1), the reuse check is already `if v, ok := daemonHealthVersion(...); ok && v == Version { return nil }`; add the stale branch just after it:
+```go
+	if v, ok := daemonHealthVersion(time.Second); ok && v != Version {
+		_ = stopRegistryDaemon() // waits for ports to free, then fall through to respawn
+	}
+```
+
+- [ ] **Step 6: Test the replace-on-mismatch behavior** (spec §5)
+
+```go
+func TestStopThenEnsureReplacesStaleDaemon(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns real processes")
+	}
+	// Start a fake "old" daemon binding :6280 that reports an old version,
+	// then assert ensureRegistryDaemon stops it and a current one comes up.
+	// (Bind :6280 + a /health returning {"version":"old"} via a tiny httptest
+	// server on that port; run ensureRegistryDaemon; poll /health for Version.)
+}
+```
+Implement with an in-process `http.Server` on `127.0.0.1:6280` returning an old version, plus overridden DNS ports, then call `ensureRegistryDaemon()` and assert `/health` version becomes the test `Version`.
+
+- [ ] **Step 7: Re-ensure the daemon from long-running host commands**
+
+Agents inside containers cannot restart the daemon; host entry points must. In the RunE of **`cmd_send.go`** and **`cmd_attach.go`** (these exist; `coordinate` does **not** — do not reference it), add before the main work:
+```go
+	if err := ensureRegistryDaemon(); err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: cspace daemon not reachable: %v\n", err)
+	}
+```
+
+- [ ] **Step 8: Build + test + commit**
+
+```bash
+go test ./internal/cli/ -run 'TestHealth|TestStopThenEnsure' -v && make build && make vet
+git add internal/cli/cmd_daemon.go internal/cli/cmd_up.go internal/cli/cmd_send.go internal/cli/cmd_attach.go internal/cli/cmd_daemon_test.go
+git commit -m "fix(daemon): /health version handshake; race-safe stop; re-ensure from send/attach
+
+Replace a stale-version daemon on reuse, waiting for its loopback ports to free
+before respawning so the new daemon doesn't lose the fatal DNS bind. send/attach
+re-ensure the daemon so long sessions recover if it died.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: In-container resolution gate at boot (with retries)
+
+**Files:** Create `internal/cli/resolve_gate.go`, `internal/cli/resolve_gate_test.go`; Modify `internal/cli/cmd_up.go`.
+
+**Interfaces:** `verifyInContainerResolution(ctx, exec containerExecFn, container, host string) error`, `containerExecFn func(ctx, container string, argv ...string) ([]byte, error)`. The exec closure wraps the substrate `Adapter.Exec` already used in `cmd_up` (see `adapter.go:249`, `substrateRunner` at `cmd_up.go:1680`).
+
+- [ ] **Step 1: Write the failing test** — asserts behavior AND the argv:
+
+```go
+package cli
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestVerifyInContainerResolution(t *testing.T) {
+	host := "mercury.p.cspace.test"
+	t.Run("resolves and calls getent hosts <host>", func(t *testing.T) {
+		var gotArgv []string
+		exec := func(_ context.Context, _ string, argv ...string) ([]byte, error) {
+			gotArgv = argv
+			return []byte("192.168.64.5 " + host + "\n"), nil
+		}
+		if err := verifyInContainerResolution(context.Background(), exec, "c", host); err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+		if want := []string{"getent", "hosts", host}; !reflect.DeepEqual(gotArgv, want) {
+			t.Errorf("argv = %v, want %v", gotArgv, want)
+		}
+	})
+	t.Run("empty output fails after retries", func(t *testing.T) {
+		exec := func(_ context.Context, _ string, argv ...string) ([]byte, error) { return []byte(""), nil }
+		if err := verifyInContainerResolution(context.Background(), exec, "c", host); err == nil {
+			t.Fatal("want error on empty resolution")
+		}
+	})
+	t.Run("exec error fails", func(t *testing.T) {
+		exec := func(_ context.Context, _ string, argv ...string) ([]byte, error) { return nil, errors.New("boom") }
+		if err := verifyInContainerResolution(context.Background(), exec, "c", host); err == nil {
+			t.Fatal("want error when exec fails")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run → FAIL** `undefined: verifyInContainerResolution`.
+
+- [ ] **Step 3: Implement with retries** (cold-boot: in-container dnsmasq + the daemon's gateway bind are both racy for a few seconds):
+
+```go
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type containerExecFn func(ctx context.Context, container string, argv ...string) ([]byte, error)
+
+func verifyInContainerResolution(ctx context.Context, exec containerExecFn, container, host string) error {
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(2 * time.Second)
+		}
+		out, err := exec(ctx, container, "getent", "hosts", host)
+		if err != nil {
+			lastErr = fmt.Errorf("resolve %s in %s: %w", host, container, err)
+			continue
+		}
+		if strings.TrimSpace(string(out)) != "" {
+			return nil
+		}
+		lastErr = fmt.Errorf("%s did not resolve inside %s (cspace daemon DNS may be down)", host, container)
+	}
+	return lastErr
+}
+```
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Wire the gate into `cmd_up`** — after the sandbox is ready (and again for the browser sidecar container when `browserSidecar != nil`), warn-not-fail:
+```go
+	if wh := workspaceFriendlyHost(name, project); wh != "" {
+		if err := verifyInContainerResolution(ctx, containerExecAdapter, containerName, wh); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+				"warning: %v — sidecar browser and host will fall back to raw IPs; run `cspace doctor`\n", err)
+		}
+	}
+```
+`containerExecAdapter` is a 4-line closure over the in-scope substrate adapter: `func(ctx, name string, argv ...string) ([]byte, error) { r, err := adapter.Exec(ctx, name, strings.Join(argv, " "), ExecOpts{}); return []byte(r.Stdout), err }` (match the real `ExecOpts`/`ExecResult` fields).
+
+- [ ] **Step 6: Build + commit** — `go test ./internal/cli/ -run TestVerify -v && make build && make vet`
+```bash
+git add internal/cli/resolve_gate.go internal/cli/resolve_gate_test.go internal/cli/cmd_up.go
+git commit -m "feat(up): verify in-container .cspace.test resolution at boot (with retries); warn loudly
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Doctor probes for the container-facing path
+
+**Files:** Modify `internal/cli/probes.go` (add two `ProbeCheck`s inside `ProbeDaemon`); Test `internal/cli/probes_test.go`.
+
+**Context:** doctor is hardcoded subsystem functions returning `ProbeResult` with `[]ProbeCheck` (`cmd_doctor.go:42-49`, `probes.go:19-39`); statuses are `ProbePass`/`ProbeWarn`/`ProbeFail`. There is **no** `Probe`/`StatusFail` type. Add checks to `ProbeDaemon`, don't invent a new probe registry.
+
+**Interfaces:** `probeGatewayDNS() ProbeCheck`, `probeInContainerDNS() ProbeCheck` (fulfils the spec-1b "gateway **and** in-container" promise). Refactor the existing loopback DNS check to share `probeDnsAt(addr, label string, failIsWarn bool) ProbeCheck` (DRY with `probeDnsDaemon`, `cmd_dns.go:299`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestGatewayDNSProbeDegradesGracefully(t *testing.T) {
+	c := probeGatewayDNS()
+	if c.Title == "" {
+		t.Fatal("probe check needs a title")
+	}
+	// No vmnet bridge in CI => must warn, never hard-fail (which would fail doctor).
+	if c.Status == ProbeFail {
+		t.Errorf("gateway DNS should degrade to warn, got fail: %+v", c)
+	}
+}
+```
+
+- [ ] **Step 2: Run → FAIL** `undefined: probeGatewayDNS`.
+
+- [ ] **Step 3: Implement**
+
+```go
+func probeGatewayDNS() ProbeCheck {
+	return probeDnsAt("192.168.64.1:"+dnsLocalPort, "container-facing DNS (gateway)", true /*failIsWarn*/)
+}
+
+func probeInContainerDNS() ProbeCheck {
+	// Best-effort: pick the first alive registry entry, exec getent inside it.
+	// If no sandbox is up, return an informational skip (not fail).
+	// ... look up one alive entry via the registry, run
+	// verifyInContainerResolution against it, map err->ProbeWarn, nil->ProbePass,
+	// no-sandbox->ProbePass with "no sandbox to test".
+}
+```
+Refactor the existing loopback DNS check into `probeDnsAt(...)`, and append `probeGatewayDNS()` + `probeInContainerDNS()` to the checks `ProbeDaemon` returns.
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Manual + build** — `make build && ./bin/cspace-go doctor` (sandbox up): confirm loopback, gateway, and in-container DNS lines. `make vet`.
+
+- [ ] **Step 6: Commit**
+```bash
+git add internal/cli/probes.go internal/cli/probes_test.go
+git commit -m "feat(doctor): probe gateway (192.168.64.1:5354) and in-container .cspace.test resolution
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Refresh stale sandbox IPs on DNS lookup (bounded + memoized)
+
+**Files:** Modify `internal/cli/cmd_daemon.go` (single-match non-service branch, `:319-320`; give `lookupSidecarIP`/the inspect a timeout); Test `internal/cli/cmd_daemon_test.go`.
+
+**Interfaces:** `liveSandboxIP(project, name, registryIP string) string` — the live inspected IP, else `registryIP`. Backed by `inspectContainerIP` (package seam) with a **context timeout** and a **short single-flight memo** so it isn't an unbounded subprocess per DNS query.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestLiveSandboxIP(t *testing.T) {
+	orig := inspectContainerIP
+	t.Cleanup(func() { inspectContainerIP = orig })
+
+	inspectContainerIP = func(string) (string, error) { return "192.168.64.42", nil }
+	if got := liveSandboxIP("p", "mercury", "192.168.64.9"); got != "192.168.64.42" {
+		t.Errorf("want live 192.168.64.42, got %s", got)
+	}
+	inspectContainerIP = func(string) (string, error) { return "", errContainerGone }
+	if got := liveSandboxIP("p", "mercury", "192.168.64.9"); got != "192.168.64.9" {
+		t.Errorf("want registry fallback 192.168.64.9, got %s", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run → FAIL** `undefined: liveSandboxIP`.
+
+- [ ] **Step 3: Implement (timeout + memo)** — first give the existing inspect a deadline: change `lookupSidecarIP` (`cmd_daemon.go:428`) from `exec.Command` to `exec.CommandContext(ctx, ...)` with a 2s `context.WithTimeout`. Then:
+
+```go
+var errContainerGone = errors.New("container not found")
+
+var inspectContainerIP = func(container string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return lookupSidecarIPCtx(ctx, container) // ctx-aware variant of lookupSidecarIP
+}
+
+type ipMemo struct {
+	mu   sync.Mutex
+	ip   string
+	when time.Time
+}
+
+var sandboxIPMemo sync.Map // container -> *ipMemo
+
+// liveSandboxIP prefers the container's currently-inspected IP over the
+// registry value (which goes stale when a sandbox restarts onto a new vmnet
+// IP). Memoized for the DNS TTL so it's at most one inspect per name per 5s.
+// CAVEAT: when inspect can't answer (timeout/apiserver hung) it falls back to
+// the registry IP, which may still be stale — the reassigned-IP hazard is
+// reduced, not eliminated, in that failure window.
+func liveSandboxIP(project, name, registryIP string) string {
+	container := fmt.Sprintf("cspace-%s-%s", project, name)
+	v, _ := sandboxIPMemo.LoadOrStore(container, &ipMemo{})
+	m := v.(*ipMemo)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ip != "" && time.Since(m.when) < daemonDNSTTL*time.Second {
+		return m.ip
+	}
+	if ip, err := inspectContainerIP(container); err == nil && ip != "" {
+		m.ip, m.when = ip, time.Now()
+		return ip
+	}
+	return registryIP
+}
+```
+In the `case 1:` non-service branch (`cmd_daemon.go:319-320`) replace `ip = matches[0].IP` with `ip = liveSandboxIP(matches[0].Project, matches[0].Name, matches[0].IP)`. Leave the `service != ""` sub-branch unchanged.
+
+- [ ] **Step 4: Run → PASS.** `go test ./internal/cli/ -run TestLiveSandboxIP -v`.
+
+- [ ] **Step 5: Build + vet + commit**
+```bash
+make build && make vet
+git add internal/cli/cmd_daemon.go internal/cli/cmd_daemon_test.go
+git commit -m "fix(daemon): resolve sandbox names to the live container IP (bounded inspect + TTL memo)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Delete the dead `ServiceIPs` field (KEEP `InjectHosts`)
+
+**Files:** Modify `internal/orchestrator/types.go`, `internal/orchestrator/lifecycle.go`, `internal/cli/browser.go` (docstring only).
+
+**Reality check (do not skip):** `InjectHosts` (`browser.go:225`) is **live** — `InjectWorkspaceHost` (`browser.go:205`, called at `cmd_up.go:742`) returns `InjectHosts(...)`. **Do not delete `InjectHosts`.** What's dead is only `ServiceIPs()` (`types.go:75`) and the `serviceIPs` field it exposes, plus the field's write at `lifecycle.go:205`.
+
+- [ ] **Step 1: Confirm the exact dead set**
+
+Run: `grep -rn "ServiceIPs\|serviceIPs" internal/`
+Expected: `ServiceIPs()` method + `serviceIPs` field def + one write at `lifecycle.go:205`, and **no read** of either. (If a read exists, stop — the field isn't dead.)
+
+- [ ] **Step 2: Delete `ServiceIPs()`, the `serviceIPs` field, and its write**
+
+Remove the `ServiceIPs()` method and the `serviceIPs` struct field from `types.go`; remove the assignment at `lifecycle.go:205` (and any now-unused local it built). Leaving the field with a write and no read fails `golangci-lint`'s `unused`.
+
+- [ ] **Step 3: Fix the misleading docstring on `InjectHosts`**
+
+In `browser.go`, rewrite the `InjectHosts`/`InjectWorkspaceHost` docstrings so they describe what actually happens (inject a `workspace` alias into the sidecar) and drop the "second pass giving the browser the full sibling set" claim, which never runs.
+
+- [ ] **Step 4: Build + vet + test + commit**
+
+```bash
+make build && make vet && go test ./internal/...
+git add internal/orchestrator/types.go internal/orchestrator/lifecycle.go internal/cli/browser.go
+git commit -m "refactor(orchestrator): remove the dead ServiceIPs field; correct InjectHosts docstrings
+
+The browser sidecar relies on daemon DNS, not /etc/hosts sibling injection; the
+never-read serviceIPs field and its docstrings implied a feature that does not
+exist. InjectHosts stays (InjectWorkspaceHost calls it). Per spec, static
+/etc/hosts insurance is intentionally not adopted (stale-IP hazard, write race,
+dnsmasq no-hosts mismatch).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Set `CSPACE_WORKSPACE_HOST` unconditionally
+
+**Files:** Modify `internal/cli/cmd_up.go:636`; Test `internal/cli/cmd_up_test.go`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestWorkspaceHostSetWithoutBrowser(t *testing.T) {
+	env := map[string]string{}
+	applyWorkspaceHostEnv(env, "mercury", "resume-redux")
+	if env["CSPACE_WORKSPACE_HOST"] != "mercury.resume-redux.cspace.test" {
+		t.Fatalf("got %q", env["CSPACE_WORKSPACE_HOST"])
+	}
+}
+```
+
+- [ ] **Step 2: Run → FAIL** `undefined: applyWorkspaceHostEnv`.
+
+- [ ] **Step 3: Extract + hoist** — add `func applyWorkspaceHostEnv(env map[string]string, name, project string) { env["CSPACE_WORKSPACE_HOST"] = workspaceFriendlyHost(name, project) }`; call it **outside** the browser block; delete the assignment inside the browser block at `:636`.
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Build + commit**
+```bash
+make build && make vet
+git add internal/cli/cmd_up.go internal/cli/cmd_up_test.go
+git commit -m "feat(up): always set CSPACE_WORKSPACE_HOST, even under --no-browser
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `.env.cspace` convention + docs
+
+**Files:** Create `docs/env-cspace.md`; Modify the agent-facing guidance doc(s) that say `$(hostname)`; link from the docs index.
+
+**Test waiver:** the spec §5 "non-login shell sees the blanked var" check is **project-side compose behavior** (compose-go `env_file` ordering), not cspace Go code — explicitly waived here; verified once manually in Task-8 Step 3.
+
+- [ ] **Step 1: Write `docs/env-cspace.md`** — with the copy-pasteable compose block:
+```yaml
+env_file:
+  - path: ../.env          # required: false
+  - path: ../.env.cspace   # required: false — later file wins
+```
+Cover: `.env.cspace` is project-owned/static/committed; cspace never writes per-sandbox values into it (dynamic values ride `/sessions/extracted.env`); example `CONVEX_DEPLOYMENT=` to neutralize the cloud var; **precedence** = highest among `env_file`s only (compose `environment:`, devcontainer `containerEnv`, `.cspace/secrets.env`, `--env` all win); **naming caveat** — matches Vite/Nuxt `.env.<mode>`, so never run the app with `--mode cspace`; relationship to `.cspace/secrets.env` (secrets = cspace-delivered; `.env.cspace` = project-declared container overrides); inert on the local box.
+
+- [ ] **Step 2: Fix the `$(hostname)` guidance + add the e2e `baseURL` convention** — in the agent-facing guidance, replace `http://$(hostname):<port>` with `http://$CSPACE_WORKSPACE_HOST:<port>`, and document that a project's Playwright `baseURL` should fall back to `http://${CSPACE_WORKSPACE_HOST}:<port>` when set (the `run-server` e2e browser is remote in the sidecar). Confirm `lib/runtime/scripts/statusline.sh:241` already surfaces the FQDN; if not, add it.
+
+- [ ] **Step 3: Manual verification of the env override** — build a throwaway devcontainer with `.env` carrying `CONVEX_DEPLOYMENT=dev:x` and `.env.cspace` blanking it; `container exec … sh -c 'printenv CONVEX_DEPLOYMENT'` in a **non-login** shell shows empty. Note the result in the PR description.
+
+- [ ] **Step 4: Link + commit**
+```bash
+git add docs/env-cspace.md docs/ lib/runtime/scripts/statusline.sh
+git commit -m "docs: .env.cspace convention; point agents at CSPACE_WORKSPACE_HOST (site + e2e baseURL)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] `make sync-embedded && make build && make vet && make test` — all green.
+- [ ] `go test ./internal/cli/ -run 'Daemon|Health|Verify|LiveSandboxIP|WorkspaceHost'` (drop `-short`) — the survival + replace tests actually run.
+- [ ] Manual: `cspace up <name> --no-attach`; after it returns, `pgrep -fl "cspace daemon"` shows a live daemon and `getent hosts <name>.<project>.cspace.test` resolves **inside** both the devcontainer and the browser sidecar. Restart the sandbox and confirm the name resolves to the **new** IP (Task 5).
+- [ ] `cspace doctor` shows loopback, gateway, and in-container DNS healthy.
+- [ ] One PR with all commits on `spec/sandbox-dns-env-isolation`.

--- a/docs/superpowers/specs/2026-07-12-sandbox-name-resolution-and-env-isolation-design.md
+++ b/docs/superpowers/specs/2026-07-12-sandbox-name-resolution-and-env-isolation-design.md
@@ -1,0 +1,290 @@
+# Sandbox name resolution reliability + env isolation
+
+- **Status:** Draft (design)
+- **Date:** 2026-07-12
+- **Builds on:** `2026-06-18-shared-browser-sidecar-design.md`
+
+## 1. Motivation
+
+An agent running many tasks in cspace sandboxes for a Nuxt + self-hosted-Convex
+project hit repeated friction:
+
+1. **Stale `CONVEX_DEPLOYMENT`** (a cloud Convex var) present in the container
+   shell broke every `convex` CLI command when `CONVEX_SELF_HOSTED_URL` was also
+   set.
+2. **`convex dev` clobbered `VITE_CONVEX_URL`** in `.env.local` to
+   `http://convex-backend:3210`, which the browser sidecar can't resolve.
+3. **The browser sidecar couldn't resolve the devcontainer** (`$(hostname)` →
+   `net::ERR_NAME_NOT_RESOLVED`); the agent fell back to the raw subnet IP.
+
+Investigation surfaced a fourth, underlying problem:
+
+4. **The `*.cspace.test` DNS daemon dies mid-session**, so the friendly-name
+   path silently stops resolving — inside containers *and* on the host — while
+   the sandboxes keep running for hours.
+
+Friction #2 has been **fixed app-side** (resume-redux#942: the app ignores a
+`VITE_CONVEX_URL` that points at the backend origin and routes all readers
+through the sanitized value). That fix depends on the browser being able to
+reach the dev-server origin — which is exactly what this spec makes reliable.
+
+**This spec covers #1, #3, and #4.** It makes in-container `.cspace.test`
+resolution durable, gives the shared browser correct per-sandbox routing, and
+adds a non-invasive way to keep host/cloud env vars out of the sandbox.
+
+## 2. Verified root causes
+
+All references are to the cspace repo at time of writing.
+
+- **Daemon death is a detachment bug, not idle-exit.**
+  The idle-exit path is gated on live registry entries, so running sandboxes
+  keep the daemon alive (`internal/cli/cmd_daemon.go:163-165`,
+  `if err != nil || len(entries) > 0 { continue }`). The real cause:
+  `ensureRegistryDaemon` spawns `cspace daemon serve` with its stderr wired to a
+  **parent-held pipe** (`c.Stderr = stderrBuf`, `internal/cli/cmd_up.go:1152-1159`)
+  and **no `Setsid`/`SysProcAttr`** anywhere in `internal/`. When `cspace up`
+  exits (always, and immediately under `--no-attach`), the pipe's read end
+  closes; the daemon's next write to fd 2 (it logs on gateway-bind retries,
+  listener errors, registry errors) takes `EPIPE` → the Go runtime raises
+  `SIGPIPE` on fd 1/2 by design → the daemon dies. Empirically confirmed: after
+  `cspace up --no-attach`, no daemon process, `dig @127.0.0.1 -p5354` times out,
+  and in-container `.cspace.test` resolves nowhere.
+
+- **The browser sidecar has no static fallback for names.**
+  `orchestrator.injectAllHosts` (`internal/orchestrator/lifecycle.go`) writes
+  `/etc/hosts` entries into the devcontainer (compose service names +
+  `workspace`) but the browser sidecar gets none. `orchestrator.ServiceIPs()`
+  (`internal/orchestrator/types.go:72`) and `browser.go`'s `InjectHosts` "second
+  pass" exist for this but are **never called** — build-but-unwired plumbing.
+  So the browser depends entirely on daemon DNS; when the daemon dies (above),
+  it can resolve neither `<sandbox>.<project>.cspace.test` nor the compose
+  siblings.
+
+- **The health probes never test the failing path.**
+  `internal/cli/probes.go` only probes `127.0.0.1:6280` (HTTP) and
+  `127.0.0.1:5354` (host-loopback DNS). Nothing tests the container-facing
+  gateway listener (`192.168.64.1:5354`) or resolution *from inside* a
+  container — the exact path that fails.
+
+- **`CSPACE_WORKSPACE_HOST` is only set when the browser is enabled.**
+  `internal/cli/cmd_up.go:636` sets it inside the browser block, so under
+  `--no-browser` the one address agents are meant to use is absent.
+
+- **The cloud env var is baked in by compose, then scrubbed too late.**
+  The project's devcontainer compose uses `env_file: .env`, so compose-go folds
+  `.env` (including `CONVEX_DEPLOYMENT=dev:...`) into the container's process env
+  at create time (`internal/cli/cmd_up.go:282-288`). The project's
+  `post-create.sh` comments the var out of `.env` and writes a `/etc/profile.d`
+  unset — but that only affects **login** shells, so an agent's non-login tool
+  shell still inherits the baked-in value.
+
+## 3. Goals / non-goals
+
+**Goals**
+
+- In-container `.cspace.test` resolution stays reliable for the entire life of
+  the sandboxes, not just the minutes after `cspace up`.
+- The one shared, ref-counted browser routes each concurrent sandbox's
+  navigation to the correct dev-server origin, with real origin isolation.
+- A non-invasive, project-owned mechanism to keep conflicting host/cloud env
+  vars out of the sandbox — with zero effect on the box-native workflow.
+- Failures in the DNS chain are loud, not silent.
+
+**Non-goals**
+
+- Per-sandbox browser sidecars (explicitly rejected — sharing is kept).
+- Stopping the Convex CLI's `VITE_CONVEX_URL` clobber (fixed app-side).
+- MCP/CDP tab-level isolation between concurrent agents on the one Chromium
+  (see §7 — tracked separately, with an existing empirical finding).
+
+## 4. Design
+
+### Part 1 — Daemon survivability + reliable in-container DNS
+
+**1a. Detach the daemon (the core fix).**
+Spawn `cspace daemon serve` detached and self-sufficient:
+
+- `SysProcAttr{Setsid: true}` so it survives its spawner and terminal close.
+- Redirect its stderr/stdout to `~/.cspace/daemon.log` (append, size-capped),
+  **never** a parent-held pipe. `ensureRegistryDaemon` keeps reading only the
+  first-startup output (until the port accepts) to surface fast-fail errors,
+  then stops holding the pipe.
+- **Version-checked reuse:** the `/health` endpoint returns the daemon's cspace
+  version; `ensureRegistryDaemon` restarts the daemon when the version differs
+  from the running CLI, instead of reusing an older squatting binary.
+- **Re-ensure from long-running host commands** (`coordinate`, `send`, and the
+  host side of the supervisor loop) call the cheap `ensureRegistryDaemon` probe,
+  since agents *inside* containers cannot restart it.
+
+*Decision:* keep the self-spawned model with proper detachment (small, targeted
+diff that fixes the actual bug). A launchd `KeepAlive` LaunchAgent — which would
+also survive host reboot — is recorded as a **follow-up hardening**, not part of
+this change. (The `192.168.64.1:5354` gateway bind still needs the existing
+retry loop either way, since that address doesn't exist until the first
+container boots.)
+
+**1b. Fail loud, and probe the real path.**
+
+- **Boot-time resolution gate:** after the sandbox (and, when present, the
+  browser sidecar) is up, `cspace up` resolves `$CSPACE_WORKSPACE_HOST` *from
+  inside* each and warns loudly on failure — the DNS chain is verified end to
+  end at the moment it's provisioned.
+- Extend `probes.go` / `cspace doctor` to test the gateway listener
+  (`192.168.64.1:5354`) and an in-container resolution, not just host loopback.
+
+**1c. Qualified-name routing for the shared browser.**
+
+The shared browser resolves each sandbox's dev-server origin **per navigation**
+via its own dnsmasq → `192.168.64.1:5354` → the daemon's registry lookup, using
+the qualified `<sandbox>.<project>.cspace.test` name. No per-sandbox browser env
+or `/etc/hosts` is needed for routing: routing state lives in the URL each
+agent hands to its MCP tool, resolved live. Qualified names also give real
+**origin-storage isolation** (cookies / localStorage / service workers are
+keyed by origin, and `mercury.<p>.cspace.test` ≠ `venus.<p>.cspace.test`).
+
+Two supporting changes:
+
+- **Registry IP refresh.** The daemon answers from `Entry.IP` written at `up`.
+  A restarted sandbox gets a new vmnet IP, and vmnet reassigns freed IPs — so a
+  stale entry can resolve to a *different live container*. The daemon must
+  refresh the IP on lookup (re-inspect the container) or on container-restart
+  events, so a stale answer is never served.
+- **Drop the static `/etc/hosts` "insurance" idea, and delete the dead
+  plumbing.** Injecting names into the shared browser's `/etc/hosts` is worse
+  than relying on DNS: stale entries (after a `kill -9` / reboot / out-of-band
+  `container` use) pin a name to an IP vmnet later reassigns — silently
+  navigating to the *wrong* backend, which beats an honest `NXDOMAIN` in no way;
+  it also has a delete/rewrite race between concurrent `up`/`down`, and Chrome
+  reads `/etc/hosts` while the sidecar's dnsmasq is `no-hosts`, so curl/node and
+  Chrome would disagree on the same name. The reliability budget is spent on 1a
+  and 1b instead. Remove the unused `ServiceIPs()` / `InjectHosts` second-pass
+  code (or its misleading docstrings) so it stops implying a feature that isn't
+  there.
+
+*Scope of the isolation claim (stated honestly):* qualified names deliver
+**routing + origin-storage** isolation only. Tab/CDP-level interference between
+concurrent agents on the single Chromium is a separate concern (§7).
+
+**1d. Both browser consumers depend on this — including Playwright e2e.**
+The sidecar exposes two endpoints, and *both* browsers run inside the sidecar,
+so both need Part 1's reliable resolution of the dev-server origin:
+
+- **Shared CDP** (`CSPACE_BROWSER_CDP_URL`, `:9222`) — the one Chromium the
+  agent drives via MCP.
+- **`run-server`** (`PW_TEST_CONNECT_WS_ENDPOINT`, `:3000`) — the project's
+  `@playwright/test` e2e suite connects here (`playwright.config.ts`
+  `connectOptions.wsEndpoint`). `run-server` hands out a **fresh browser
+  instance per connection**, so e2e is already isolated and sidesteps the §7
+  CDP-tab concern.
+
+Reaching the browser works today (the devcontainer connects to the sidecar by
+subnet IP). The gap is the reverse leg: because the e2e browser is remote in
+the sidecar, the test `baseURL` must be a **sidecar-resolvable** address of the
+dev server — `http://$CSPACE_WORKSPACE_HOST:<port>` — not `localhost` (which is
+the sidecar's own loopback). Current state is broken on both counts: the config
+falls through to `http://localhost:4173`, and even the right name doesn't
+resolve once the daemon dies. Part 1a/1b fixes resolution; the `baseURL`
+convention is handled in Part 3.
+
+### Part 2 — Env isolation via `.env.cspace`
+
+A project-owned, static, committed file that the devcontainer compose loads
+after `.env`, both optional:
+
+```yaml
+# .devcontainer/docker-compose.yml (project-side)
+env_file:
+  - path: ../.env          # required: false
+  - path: ../.env.cspace   # required: false
+```
+
+- The project **declares** its cspace-mode overrides there — e.g.
+  `CONVEX_DEPLOYMENT=` (blank) to neutralize the cloud var that `env_file: .env`
+  drags in. compose-go supports `required: false`, and later env_files win, so
+  the blank value overrides `.env` in the container's process env — for **every**
+  shell, login or not. This kills friction #1 at the source and lets the
+  project's `post-create.sh` `/etc/profile.d` hack be deleted. Verified: the
+  Convex CLI coerces `CONVEX_DEPLOYMENT=""` to null and won't re-read it.
+- **cspace stays general** — it defines the file convention and (optionally)
+  scaffolds an empty one; it does not encode Convex knowledge. The project
+  author, who knows their own conflicting vars, owns the contents.
+- **cspace does NOT write per-sandbox dynamic values into this file.** It's one
+  file at the repo root shared by every concurrent sandbox; per-sandbox writes
+  would race and dirty the working tree. Dynamic values (admin keys, the
+  self-hosted URL, the workspace host) stay in the existing
+  `/sessions/extracted.env` channel.
+- **Precedence (stated honestly):** highest *among env_files only*. compose
+  `environment:`, devcontainer `containerEnv`, `.cspace/secrets.env`, and
+  `--env` all still beat it. Document this so users don't fight it.
+- **Absent locally → zero effect**, so the box-native workflow (`pnpm dev` with
+  no container) is untouched — the core "doesn't enforce its usage" requirement.
+
+**Naming caveat (accepted):** `.env.cspace` matches Vite/Nuxt's `.env.<mode>`
+pattern, so running the app with `--mode cspace` would make the *app* load it
+too. cspace projects must not use `cspace` as an app build mode. The spec
+documents this; the file is intended for compose `env_file`, not the app's own
+dotenv. (`.env.cspace` chosen over `.cspace/container.env` per maintainer
+preference.) Document its relationship to `.cspace/secrets.env`:
+`secrets.env` = cspace-delivered secrets; `.env.cspace` = project-declared
+container env overrides.
+
+### Part 3 — Discoverability / docs
+
+- Set `CSPACE_WORKSPACE_HOST` **unconditionally** (move it out of the
+  browser-only block at `cmd_up.go:636`) — the qualified name is a useful
+  address regardless of the browser, and docs will point at it.
+- Publicize `$CSPACE_WORKSPACE_HOST` (statusline, agent guidance) as *the*
+  address for reaching the site from the sidecar or host, replacing
+  `$(hostname)` (which returns the unresolvable container name). The per-project
+  CLAUDE.md guidance that currently says `$(hostname)` should reference the env
+  var instead.
+- **e2e `baseURL` convention.** Because the `run-server` e2e browser is remote
+  in the sidecar (Part 1d), document that a project's Playwright `baseURL` must
+  be `http://$CSPACE_WORKSPACE_HOST:<port>` when `CSPACE_WORKSPACE_HOST` is set,
+  not `localhost`. cspace can't inject the full `BASE_URL` — it doesn't know the
+  app's dev-server port — so this is a project-side default (the same "adapt to
+  cspace" shape as the convex fix: `baseURL` falls back to
+  `CSPACE_WORKSPACE_HOST` when present). Optionally, cspace can export the host
+  (already done via `CSPACE_WORKSPACE_HOST`) and a project convention doc shows
+  the one-line config change.
+
+## 5. Testing strategy
+
+- **Daemon survival (the crux regression test):** spawn the daemon via the
+  detached path, exit/kill the parent, then assert the daemon is still alive and
+  still answers a `.cspace.test` query. This reproduces the SIGPIPE bug and
+  guards it.
+- **Version-checked reuse:** stale-version daemon on the port → `ensureRegistryDaemon`
+  restarts it.
+- **Registry IP refresh:** a sandbox whose IP changed resolves to the new IP,
+  never the stale one.
+- **Boot-time gate:** provisioning fails loud when in-container resolution
+  doesn't work.
+- **Env isolation:** build a devcontainer with `.env` carrying `CONVEX_DEPLOYMENT`
+  and `.env.cspace` blanking it; assert a **non-login** shell sees it empty.
+- **Probes/doctor:** cover the gateway listener + an in-container resolution.
+
+## 6. Sequencing
+
+Ships as **one PR** — this is all related work making cspace's sandbox
+environment resolve and isolate reliably. Implemented in this internal order
+(commits), highest-leverage first:
+
+1. **Daemon detach + version-checked reuse + boot-time gate + probes** (Part 1a,
+   1b). Highest-leverage — fixes the mid-session daemon death that underlies #3
+   and #4.
+2. **Registry IP refresh + delete the dead hosts-injection plumbing** (Part 1c),
+   including the Part 1d clarifications (both browser consumers).
+3. **`.env.cspace` convention + docs** (Part 2, Part 3, incl. the e2e `baseURL`
+   convention).
+
+## 7. Known limitations / tracked follow-ups
+
+- **MCP/CDP tab isolation.** The shared browser is one Chromium with one CDP
+  endpoint; concurrent agents' MCP sessions can, in principle, see/close each
+  other's tabs. This is orthogonal to DNS/env and is **out of scope here.**
+  Existing empirical finding (maintainer): **Playwright MCP isolates contexts;
+  chrome-devtools-mcp did not** at last investigation. Follow-up: confirm the
+  current chrome-devtools-mcp behavior and, if still shared, give each agent its
+  own browser context (`Target.createBrowserContext` / an `--isolated` mode).
+- **launchd-managed daemon** for reboot survival (see Part 1a) — deferred.

--- a/docs/superpowers/specs/2026-07-12-sandbox-name-resolution-and-env-isolation-design.md
+++ b/docs/superpowers/specs/2026-07-12-sandbox-name-resolution-and-env-isolation-design.md
@@ -213,9 +213,14 @@ env_file:
   would race and dirty the working tree. Dynamic values (admin keys, the
   self-hosted URL, the workspace host) stay in the existing
   `/sessions/extracted.env` channel.
-- **Precedence (stated honestly):** highest *among env_files only*. compose
-  `environment:`, devcontainer `containerEnv`, `.cspace/secrets.env`, and
-  `--env` all still beat it. Document this so users don't fight it.
+- **Precedence (stated honestly):** highest *among env_files only*. Compose
+  `environment:` (which includes `env_file`-resolved content, i.e. this file),
+  devcontainer `containerEnv`, and `--env` still beat it — but
+  `.cspace/secrets.env` does **not**; it merges into the env map *before*
+  compose `environment:` is applied, so `env_file` content (`.env.cspace`)
+  actually out-ranks it. Document this so users don't fight it. (Actual
+  shipped order: `env_file` out-ranks `secrets.env`; see
+  `docs/env-cspace.md`.)
 - **Absent locally → zero effect**, so the box-native workflow (`pnpm dev` with
   no container) is untouched — the core "doesn't enforce its usage" requirement.
 

--- a/internal/cli/browser.go
+++ b/internal/cli/browser.go
@@ -61,6 +61,15 @@ func workspaceFriendlyHost(name, project string) string {
 	return strings.ToLower(name) + "." + strings.ToLower(project) + ".cspace.test"
 }
 
+// applyWorkspaceHostEnv sets CSPACE_WORKSPACE_HOST on env. Callers must
+// invoke this unconditionally (not gated behind browser-sidecar setup) —
+// agents/docs point at this var as THE address to reach the workspace from
+// outside it, so it must be present even when the browser sidecar is
+// disabled (--no-browser or devcontainer.json opt-out).
+func applyWorkspaceHostEnv(env map[string]string, name, project string) {
+	env["CSPACE_WORKSPACE_HOST"] = workspaceFriendlyHost(name, project)
+}
+
 // startBrowserSidecar runs the Playwright sidecar container, waits for its
 // IP and CDP endpoint to come up, and returns the container name and CDP
 // URL. Idempotent: if a container of the same name already exists, it is

--- a/internal/cli/browser.go
+++ b/internal/cli/browser.go
@@ -200,8 +200,9 @@ func startBrowserSidecar(ctx context.Context, project, sandbox, plVersion string
 }
 
 // InjectWorkspaceHost writes a /etc/hosts entry inside the browser sidecar
-// mapping `workspace` → workspaceIP. Convenience wrapper around InjectHosts
-// for the early-injection case where only the workspace IP is known.
+// mapping `workspace` → workspaceIP, so headless Chromium can resolve
+// http://workspace:<port> URLs back to the sandbox. Convenience wrapper
+// around InjectHosts for this single-alias case.
 func InjectWorkspaceHost(ctx context.Context, sidecarName, workspaceIP string) error {
 	if sidecarName == "" || workspaceIP == "" {
 		return nil
@@ -211,14 +212,9 @@ func InjectWorkspaceHost(ctx context.Context, sidecarName, workspaceIP string) e
 
 // InjectHosts writes a cspace-managed block to a sidecar microVM's
 // /etc/hosts mapping each hostname → IP. Replaces any prior cspace-injected
-// block (idempotent), so callers can re-issue with a wider map after more
-// IPs become known — for example, the browser sidecar gets just `workspace`
-// when the workspace boots, then the full set including convex-backend,
-// convex-dashboard, etc. once compose sidecars are up. Without this second
-// pass, headless Chromium fails fetches to direct sidecar URLs (e.g. Convex
-// storage upload's `http://convex-backend:3210/...` redirects) with
-// ERR_NAME_NOT_RESOLVED, since the sidecar's dnsmasq only forwards to public
-// resolvers and nothing knows the sandbox-internal hostnames.
+// block (idempotent). Currently used only to inject the `workspace` alias
+// (see InjectWorkspaceHost); other sandbox-internal hostnames are resolved
+// via daemon DNS rather than /etc/hosts.
 //
 // Best-effort: a single bash invocation, errors return up so callers can
 // log a warning and continue.

--- a/internal/cli/cmd_attach.go
+++ b/internal/cli/cmd_attach.go
@@ -24,6 +24,10 @@ supervisor's session non-interactively; use ` + "`cspace attach`" + ` for
 hands-on work.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := ensureRegistryDaemon(); err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: cspace daemon not reachable: %v\n", err)
+			}
+
 			name := args[0]
 			project := projectName()
 			containerName := fmt.Sprintf("cspace-%s-%s", project, name)

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -58,6 +58,40 @@ func daemonDNSAddrs() (listen, gateway string) {
 	return
 }
 
+// daemonHTTPAddr returns the loopback HTTP address the daemon binds,
+// allowing tests to override the well-known port via env (mirrors
+// daemonDNSAddrs) so they don't collide with a developer's real daemon.
+func daemonHTTPAddr() string {
+	port := daemonHTTPPort
+	if v := os.Getenv("CSPACE_REGISTRY_DAEMON_PORT"); v != "" {
+		port = v
+	}
+	return "127.0.0.1:" + port
+}
+
+// daemonHealthVersion queries the daemon's /health endpoint and returns the
+// version it reports. ok is false when the daemon isn't reachable, doesn't
+// respond 200, or the body doesn't decode — callers treat that as "no
+// version-matched daemon running" rather than an error.
+func daemonHealthVersion(timeout time.Duration) (string, bool) {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get("http://" + daemonHTTPAddr() + "/health")
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+	var body struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", false
+	}
+	return body.Version, true
+}
+
 func newDaemonCmd() *cobra.Command {
 	parent := &cobra.Command{
 		Use:   "daemon",
@@ -132,10 +166,7 @@ func runDaemonServe() error {
 		_ = json.NewEncoder(w).Encode(entries)
 	})
 
-	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{"ok":true}`)
-	})
+	mux.HandleFunc("GET /health", healthHandler)
 
 	// Idle-shutdown: track time of last HTTP request via an atomic, and
 	// have a background ticker exit the daemon once it has been idle past
@@ -260,6 +291,14 @@ func runDaemonServe() error {
 		return err
 	}
 	return nil
+}
+
+// healthHandler reports liveness plus the running binary's version, so
+// callers (ensureRegistryDaemon) can distinguish "a daemon is up" from "a
+// daemon matching this build is up" and replace a stale one on mismatch.
+func healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "version": Version})
 }
 
 // daemonDNSHandler answers A queries for <sandbox>.cspace.test from the
@@ -418,21 +457,52 @@ func newDaemonStopCmd() *cobra.Command {
 		Use:   "stop",
 		Short: "Stop the cspace daemon",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Match the embedded subcommand's process line. Anchoring on
-			// "daemon serve" is broad enough to catch both `cspace daemon
-			// serve` and `bin/cspace-go daemon serve` invocations, and
-			// narrow enough to skip `cspace daemon stop` itself (different
-			// argv tail).
-			out, err := exec.Command("pkill", "-f", "daemon serve").CombinedOutput()
-			if err != nil {
-				// pkill returns 1 when no matches; not an error for our purposes.
-				if !strings.Contains(err.Error(), "exit status 1") {
-					return fmt.Errorf("pkill: %w (%s)", err, out)
-				}
+			if err := stopRegistryDaemon(); err != nil {
+				return err
 			}
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "daemon: stopped")
 			return nil
 		},
+	}
+}
+
+// stopRegistryDaemon kills any running daemon process and blocks until its
+// fatal-to-rebind loopback ports (HTTP + DNS listen addr) are actually free,
+// or a timeout elapses. Without this wait, a caller that immediately
+// respawns a new daemon (ensureRegistryDaemon on a stale-version reuse
+// check) can race the dying process for the loopback DNS bind and lose,
+// since that bind is fatal to the new daemon.
+func stopRegistryDaemon() error {
+	// Match the embedded subcommand's process line. Anchoring on "daemon
+	// serve" is broad enough to catch both `cspace daemon serve` and
+	// `bin/cspace-go daemon serve` invocations, and narrow enough to skip
+	// `cspace daemon stop` itself (different argv tail).
+	out, err := exec.Command("pkill", "-f", "daemon serve").CombinedOutput()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 {
+			return nil // pkill exit 1 == no matches
+		}
+		return fmt.Errorf("pkill: %w (%s)", err, out)
+	}
+	listen, _ := daemonDNSAddrs()
+	waitPortFree(daemonHTTPAddr(), 3*time.Second)
+	waitPortFree(listen, 3*time.Second)
+	return nil
+}
+
+// waitPortFree polls addr until dialing it is refused (port free) or the
+// deadline elapses. It never returns an error — callers treat a still-bound
+// port past the deadline as "did our best" and fall through to the caller's
+// own respawn-retry loop.
+func waitPortFree(addr string, d time.Duration) {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err != nil { // refused == free
+			return
+		}
+		_ = c.Close()
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -43,6 +43,21 @@ const (
 	daemonIdleDefault = 30 * time.Minute
 )
 
+// daemonDNSAddrs returns the DNS listen/gateway addresses, allowing tests to
+// override the well-known defaults via env so they don't collide with a
+// developer's real daemon.
+func daemonDNSAddrs() (listen, gateway string) {
+	listen = daemonDNSListenAddr
+	if v := os.Getenv("CSPACE_DAEMON_DNS_ADDR"); v != "" {
+		listen = v
+	}
+	gateway = daemonDNSGatewayAddr
+	if v := os.Getenv("CSPACE_DAEMON_GATEWAY_ADDR"); v != "" {
+		gateway = v
+	}
+	return
+}
+
 func newDaemonCmd() *cobra.Command {
 	parent := &cobra.Command{
 		Use:   "daemon",
@@ -182,18 +197,19 @@ func runDaemonServe() error {
 	// (cspace up's ensureRegistryDaemon, which captures stderr) can surface
 	// the real error.
 	dh := daemonDNSHandler(r, &lastActivity)
-	dnsPort := daemonDNSListenAddr
-	if i := strings.LastIndex(daemonDNSListenAddr, ":"); i >= 0 {
-		dnsPort = daemonDNSListenAddr[i+1:]
+	listenAddr, gatewayAddr := daemonDNSAddrs()
+	dnsPort := listenAddr
+	if i := strings.LastIndex(listenAddr, ":"); i >= 0 {
+		dnsPort = listenAddr[i+1:]
 	}
 	// Loopback bind is fatal — it's how the host's /etc/resolver/
 	// cspace.test routes name lookups. Without it, friendly URLs
 	// don't work from the host browser at all.
 	go func() {
-		server := &dns.Server{Addr: daemonDNSListenAddr, Net: "udp", Handler: dh}
-		log.Printf("cspace daemon: DNS listening on %s/udp", daemonDNSListenAddr)
+		server := &dns.Server{Addr: listenAddr, Net: "udp", Handler: dh}
+		log.Printf("cspace daemon: DNS listening on %s/udp", listenAddr)
 		if err := server.ListenAndServe(); err != nil {
-			log.Printf("FATAL: cspace daemon DNS UDP bind on %s failed: %v", daemonDNSListenAddr, err)
+			log.Printf("FATAL: cspace daemon DNS UDP bind on %s failed: %v", listenAddr, err)
 			log.Printf("       another process may be using this port; check with `lsof -nP -iUDP:%s`", dnsPort)
 			log.Printf("       common culprits: another cspace daemon process, or mDNSResponder if 5353 was mistakenly chosen")
 			log.Printf("       cspace daemon cannot serve DNS without UDP; exiting")
@@ -201,10 +217,10 @@ func runDaemonServe() error {
 		}
 	}()
 	go func() {
-		server := &dns.Server{Addr: daemonDNSListenAddr, Net: "tcp", Handler: dh}
-		log.Printf("cspace daemon: DNS listening on %s/tcp", daemonDNSListenAddr)
+		server := &dns.Server{Addr: listenAddr, Net: "tcp", Handler: dh}
+		log.Printf("cspace daemon: DNS listening on %s/tcp", listenAddr)
 		if err := server.ListenAndServe(); err != nil {
-			log.Printf("FATAL: cspace daemon DNS TCP bind on %s failed: %v", daemonDNSListenAddr, err)
+			log.Printf("FATAL: cspace daemon DNS TCP bind on %s failed: %v", listenAddr, err)
 			log.Printf("       another process may be using this port; check with `lsof -nP -iTCP:%s`", dnsPort)
 			log.Printf("       common culprits: another cspace daemon process holding the port")
 			log.Printf("       cspace daemon cannot serve DNS without TCP; exiting")
@@ -220,19 +236,19 @@ func runDaemonServe() error {
 	// listener above is unaffected.
 	go func() {
 		for {
-			server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "udp", Handler: dh}
-			log.Printf("cspace daemon: DNS listening on %s/udp (containers)", daemonDNSGatewayAddr)
+			server := &dns.Server{Addr: gatewayAddr, Net: "udp", Handler: dh}
+			log.Printf("cspace daemon: DNS listening on %s/udp (containers)", gatewayAddr)
 			err := server.ListenAndServe()
 			log.Printf("WARN: cspace daemon DNS UDP bind on %s failed: %v; retrying in 3s "+
-				"(in-container *.cspace.test lookups NXDOMAIN until this binds)", daemonDNSGatewayAddr, err)
+				"(in-container *.cspace.test lookups NXDOMAIN until this binds)", gatewayAddr, err)
 			time.Sleep(3 * time.Second)
 		}
 	}()
 	go func() {
 		for {
-			server := &dns.Server{Addr: daemonDNSGatewayAddr, Net: "tcp", Handler: dh}
+			server := &dns.Server{Addr: gatewayAddr, Net: "tcp", Handler: dh}
 			if err := server.ListenAndServe(); err != nil {
-				log.Printf("WARN: cspace daemon DNS TCP bind on %s failed: %v; retrying in 3s", daemonDNSGatewayAddr, err)
+				log.Printf("WARN: cspace daemon DNS TCP bind on %s failed: %v; retrying in 3s", gatewayAddr, err)
 			}
 			time.Sleep(3 * time.Second)
 		}

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -585,7 +585,10 @@ var sandboxIPMemo sync.Map
 // IP — vmnet reassigns freed IPs, so a stale registry entry can point at a
 // different live container). Memoized for the DNS TTL so it's at most one
 // inspect per name per daemonDNSTTL seconds, bounding the subprocess cost
-// on the DNS hot path.
+// on the DNS hot path — this bound applies whether the inspect succeeds or
+// fails: a failing inspect is negative-cached (empty IP, fresh timestamp)
+// so a name whose container is gone doesn't pay the inspect cost on every
+// query for the rest of the TTL window.
 // CAVEAT: when inspect can't answer (timeout/apiserver hung/container
 // gone) it falls back to the registry IP, which may still be stale — the
 // reassigned-IP hazard is reduced, not eliminated, in that failure window.
@@ -595,12 +598,19 @@ func liveSandboxIP(project, name, registryIP string) string {
 	m := v.(*ipMemo)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.ip != "" && time.Since(m.when) < daemonDNSTTL*time.Second {
-		return m.ip
+	if !m.when.IsZero() && time.Since(m.when) < daemonDNSTTL*time.Second {
+		// Recently attempted, success or failure: honor the memo without
+		// re-inspecting.
+		if m.ip != "" {
+			return m.ip
+		}
+		return registryIP
 	}
+	m.when = time.Now()
 	if ip, err := inspectContainerIP(container); err == nil && ip != "" {
-		m.ip, m.when = ip, time.Now()
+		m.ip = ip
 		return ip
 	}
+	m.ip = "" // negative-cache the failure so we don't re-inspect until TTL expiry
 	return registryIP
 }

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -9,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -372,7 +375,7 @@ func daemonDNSHandler(r *registry.Registry, lastActivity *atomic.Int64) dns.Hand
 				reply.Rcode = dns.RcodeNameError
 				continue
 			case 1:
-				ip = matches[0].IP
+				ip = liveSandboxIP(matches[0].Project, matches[0].Name, matches[0].IP)
 				if service != "" {
 					// 4-label query: redirect to the sidecar container
 					// `cspace-<project>-<sandbox>-<service>` and resolve
@@ -506,12 +509,12 @@ func waitPortFree(addr string, d time.Duration) {
 	}
 }
 
-// lookupSidecarIP resolves the vmnet IP of a compose-spawned sidecar by
-// shelling out to `container inspect`. Returns ("", nil) when the
-// sidecar isn't running. The DNS handler treats both empty IP and a
+// lookupSidecarIPCtx resolves the vmnet IP of a compose-spawned sidecar by
+// shelling out to `container inspect`, bounded by ctx. Returns ("", nil)
+// when the sidecar isn't running. The DNS handler treats both empty IP and a
 // non-nil error as NXDOMAIN.
-func lookupSidecarIP(name string) (string, error) {
-	out, err := exec.Command("container", "inspect", name).Output()
+func lookupSidecarIPCtx(ctx context.Context, name string) (string, error) {
+	out, err := exec.CommandContext(ctx, "container", "inspect", name).Output()
 	if err != nil {
 		// Apple Container exits non-zero only on transport-level error;
 		// missing containers come back as exit 0 with body "[]". Treat
@@ -535,4 +538,69 @@ func lookupSidecarIP(name string) (string, error) {
 		addr = addr[:i]
 	}
 	return addr, nil
+}
+
+// lookupSidecarIP is lookupSidecarIPCtx run with an unbounded context. It
+// exists to preserve the DNS handler's one existing sidecar-resolution call
+// site (the 3-label <service>.<sandbox>.<project> branch) unchanged; that
+// branch's own registry match already bounds how often it fires, so it
+// doesn't get the 2s deadline applied to the higher-frequency
+// liveSandboxIP path below.
+func lookupSidecarIP(name string) (string, error) {
+	return lookupSidecarIPCtx(context.Background(), name)
+}
+
+// errContainerGone is returned by test stubs of inspectContainerIP to
+// simulate a container that no longer exists (or an inspect that failed for
+// any other reason); liveSandboxIP treats any non-nil error the same way,
+// by falling back to the registry IP.
+var errContainerGone = errors.New("container not found")
+
+// inspectContainerIP is the package seam liveSandboxIP calls to get a
+// container's live IP; it's a var so tests can stub it without shelling
+// out. The 2s timeout bounds a single DNS answer's worst case if the Apple
+// Container apiserver is hung, rather than blocking indefinitely.
+var inspectContainerIP = func(container string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return lookupSidecarIPCtx(ctx, container)
+}
+
+// ipMemo holds the last inspected IP for one container plus when it was
+// fetched, guarded by its own mutex so concurrent DNS handler goroutines
+// resolving the same name serialize on one inspect instead of racing.
+type ipMemo struct {
+	mu   sync.Mutex
+	ip   string
+	when time.Time
+}
+
+// sandboxIPMemo maps container name -> *ipMemo. sync.Map because the DNS
+// handler runs one goroutine per query and this is a read-mostly cache
+// across many distinct sandbox names.
+var sandboxIPMemo sync.Map
+
+// liveSandboxIP prefers the container's currently-inspected IP over the
+// registry value (which goes stale when a sandbox restarts onto a new vmnet
+// IP — vmnet reassigns freed IPs, so a stale registry entry can point at a
+// different live container). Memoized for the DNS TTL so it's at most one
+// inspect per name per daemonDNSTTL seconds, bounding the subprocess cost
+// on the DNS hot path.
+// CAVEAT: when inspect can't answer (timeout/apiserver hung/container
+// gone) it falls back to the registry IP, which may still be stale — the
+// reassigned-IP hazard is reduced, not eliminated, in that failure window.
+func liveSandboxIP(project, name, registryIP string) string {
+	container := fmt.Sprintf("cspace-%s-%s", project, name)
+	v, _ := sandboxIPMemo.LoadOrStore(container, &ipMemo{})
+	m := v.(*ipMemo)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ip != "" && time.Since(m.when) < daemonDNSTTL*time.Second {
+		return m.ip
+	}
+	if ip, err := inspectContainerIP(container); err == nil && ip != "" {
+		m.ip, m.when = ip, time.Now()
+		return ip
+	}
+	return registryIP
 }

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -194,8 +194,8 @@ func runDaemonServe() error {
 	// resolve <name>.cspace.test even though HTTP /lookup still works, and
 	// `cspace dns status` would (today) report "running" via the HTTP probe
 	// while users see broken name resolution. Exit non-zero so the parent
-	// (cspace up's ensureRegistryDaemon, which captures stderr) can surface
-	// the real error.
+	// (cspace up's ensureRegistryDaemon, which tails ~/.cspace/daemon.log on
+	// timeout) can surface the real error.
 	dh := daemonDNSHandler(r, &lastActivity)
 	listenAddr, gatewayAddr := daemonDNSAddrs()
 	dnsPort := listenAddr

--- a/internal/cli/cmd_daemon_test.go
+++ b/internal/cli/cmd_daemon_test.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestHealthReportsVersion verifies /health reports the running binary's
+// Version, which ensureRegistryDaemon uses to distinguish "a daemon is up"
+// from "a daemon matching this build is up".
+func TestHealthReportsVersion(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+	Version = "v9.9.9-test"
+
+	rec := httptest.NewRecorder()
+	healthHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	var body struct {
+		OK      bool   `json:"ok"`
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if !body.OK || body.Version != "v9.9.9-test" {
+		t.Fatalf("got %+v, want ok+version v9.9.9-test", body)
+	}
+}
+
+// TestDaemonHealthVersion covers both branches of the reuse check:
+// a reachable daemon whose /health decodes to a version, and the "nothing is
+// listening" case ensureRegistryDaemon relies on to decide to spawn.
+func TestDaemonHealthVersion(t *testing.T) {
+	t.Run("reachable daemon reports its version", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		port := ln.Addr().(*net.TCPAddr).Port
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"version":"old"}`))
+		})
+		srv := &http.Server{Handler: mux}
+		go func() { _ = srv.Serve(ln) }()
+		t.Cleanup(func() { _ = srv.Close() })
+
+		t.Setenv("CSPACE_REGISTRY_DAEMON_PORT", strconv.Itoa(port))
+
+		v, ok := daemonHealthVersion(2 * time.Second)
+		if !ok || v != "old" {
+			t.Fatalf("daemonHealthVersion() = (%q, %v), want (\"old\", true)", v, ok)
+		}
+	})
+
+	t.Run("nothing listening returns false", func(t *testing.T) {
+		// Grab a free port, then release it immediately so nothing answers.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		port := ln.Addr().(*net.TCPAddr).Port
+		if err := ln.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Setenv("CSPACE_REGISTRY_DAEMON_PORT", strconv.Itoa(port))
+
+		if v, ok := daemonHealthVersion(200 * time.Millisecond); ok {
+			t.Fatalf("daemonHealthVersion() = (%q, true), want ok=false when nothing is listening", v)
+		}
+	})
+}
+
+// TestWaitPortFree covers both branches: a port that's already free returns
+// promptly, and a port held by a real listener blocks until the deadline
+// (not indefinitely, and not before the port is actually released).
+func TestWaitPortFree(t *testing.T) {
+	t.Run("already free returns promptly", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := ln.Addr().String()
+		if err := ln.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		start := time.Now()
+		waitPortFree(addr, 2*time.Second)
+		if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+			t.Fatalf("waitPortFree on an already-free port took %s, want a prompt return", elapsed)
+		}
+	})
+
+	t.Run("held port blocks until deadline", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = ln.Close() })
+		addr := ln.Addr().String()
+
+		start := time.Now()
+		waitPortFree(addr, 300*time.Millisecond)
+		elapsed := time.Since(start)
+		if elapsed < 250*time.Millisecond {
+			t.Fatalf("waitPortFree returned after %s while the port was still held, want it to wait out its ~300ms deadline", elapsed)
+		}
+		if elapsed > 2*time.Second {
+			t.Fatalf("waitPortFree took %s, far past its 300ms deadline", elapsed)
+		}
+	})
+}
+
+// realDaemonServeRunning reports whether a process matching stopRegistryDaemon's
+// `pkill -f "daemon serve"` pattern is already running on this machine. It's
+// used to skip tests that would otherwise call the real, system-wide
+// stopRegistryDaemon and risk killing a developer's live cspace daemon as
+// collateral damage — pkill -f is not scoped to any PID a test spawns itself.
+func realDaemonServeRunning(t *testing.T) (string, bool) {
+	t.Helper()
+	out, err := exec.Command("pgrep", "-fl", "daemon serve").CombinedOutput()
+	trimmed := strings.TrimSpace(string(out))
+	if err == nil && trimmed != "" {
+		return trimmed, true
+	}
+	return "", false
+}
+
+// TestStopRegistryDaemonPkillNoMatches is the minimum required coverage from
+// the task brief: pkill exit code 1 (no matches) must be treated as success,
+// not an error.
+func TestStopRegistryDaemonPkillNoMatches(t *testing.T) {
+	if procs, running := realDaemonServeRunning(t); running {
+		t.Skipf("a real 'daemon serve' process is already running; skipping stopRegistryDaemon "+
+			"to avoid killing it (pkill -f is system-wide, not scoped to this test):\n%s", procs)
+	}
+
+	if err := stopRegistryDaemon(); err != nil {
+		t.Fatalf("stopRegistryDaemon() with no matching process = %v, want nil (pkill exit 1 == no matches == success)", err)
+	}
+}
+
+// TestStopRegistryDaemonKillsMatchingProcessAndFreesPorts spawns a real
+// `<bin> daemon serve` process on isolated ports and verifies
+// stopRegistryDaemon actually kills it AND blocks until its HTTP/DNS ports
+// are free, per the brief's race-safety requirement. Guarded like the test
+// above: pkill -f "daemon serve" is system-wide, so this only runs when no
+// other matching process already exists on the machine.
+func TestStopRegistryDaemonKillsMatchingProcessAndFreesPorts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds + spawns real processes")
+	}
+	if procs, running := realDaemonServeRunning(t); running {
+		t.Skipf("a real 'daemon serve' process is already running; skipping to avoid killing it "+
+			"as collateral damage (pkill -f is system-wide):\n%s", procs)
+	}
+
+	bin := buildCspaceForTest(t)
+	home := t.TempDir()
+
+	// Fixed, distinct-from-other-tests ports so this daemon can't collide
+	// with a developer's real one (6280/5354) or with
+	// TestDaemonSurvivesSpawnerExit's ports (6299/15354/15355).
+	const (
+		httpPort    = "6295"
+		dnsAddr     = "127.0.0.1:15364"
+		gatewayAddr = "127.0.0.1:15365"
+	)
+
+	env := append(os.Environ(),
+		"HOME="+home,
+		"CSPACE_REGISTRY_DAEMON_PORT="+httpPort,
+		"CSPACE_DAEMON_DNS_ADDR="+dnsAddr,
+		"CSPACE_DAEMON_GATEWAY_ADDR="+gatewayAddr,
+		"CSPACE_REGISTRY_DAEMON_IDLE=1h",
+	)
+	spawner := exec.Command(bin, "daemon", "serve")
+	spawner.Env = env
+	logf, err := os.Create(filepath.Join(home, "d.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spawner.Stdout, spawner.Stderr = logf, logf
+	spawner.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := spawner.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := spawner.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		_ = logf.Close()
+	})
+
+	waitForPort(t, "127.0.0.1:"+httpPort, 5*time.Second)
+
+	// Point this test process's stopRegistryDaemon (running in-process,
+	// not the spawned daemon) at the same addrs the spawned daemon bound.
+	t.Setenv("CSPACE_REGISTRY_DAEMON_PORT", httpPort)
+	t.Setenv("CSPACE_DAEMON_DNS_ADDR", dnsAddr)
+	t.Setenv("CSPACE_DAEMON_GATEWAY_ADDR", gatewayAddr)
+
+	if err := stopRegistryDaemon(); err != nil {
+		t.Fatalf("stopRegistryDaemon() = %v, want nil", err)
+	}
+
+	if syscall.Kill(pid, 0) == nil {
+		t.Error("daemon process still alive after stopRegistryDaemon returned")
+	}
+	if c, derr := net.DialTimeout("tcp", "127.0.0.1:"+httpPort, 200*time.Millisecond); derr == nil {
+		_ = c.Close()
+		t.Error("HTTP port still accepting connections after stopRegistryDaemon returned")
+	}
+	if c, derr := net.DialTimeout("tcp", dnsAddr, 200*time.Millisecond); derr == nil {
+		_ = c.Close()
+		t.Error("DNS port still accepting connections after stopRegistryDaemon returned")
+	}
+}

--- a/internal/cli/cmd_daemon_test.go
+++ b/internal/cli/cmd_daemon_test.go
@@ -204,6 +204,12 @@ func TestStopRegistryDaemonKillsMatchingProcessAndFreesPorts(t *testing.T) {
 		_ = syscall.Kill(pid, syscall.SIGKILL)
 		_ = logf.Close()
 	})
+	// Reap the spawned child asynchronously so the OS releases the pid once
+	// the daemon exits. Without this, the process lingers as a zombie after
+	// stopRegistryDaemon's pkill succeeds (ports free, but the pid is still
+	// "alive" to kill(pid, 0) until waited on) — a test-harness artifact, not
+	// a production concern, since the real daemon is reparented to init.
+	go func() { _ = spawner.Wait() }()
 
 	waitForPort(t, "127.0.0.1:"+httpPort, 5*time.Second)
 
@@ -217,7 +223,17 @@ func TestStopRegistryDaemonKillsMatchingProcessAndFreesPorts(t *testing.T) {
 		t.Fatalf("stopRegistryDaemon() = %v, want nil", err)
 	}
 
-	if syscall.Kill(pid, 0) == nil {
+	// The async Wait() above races with stopRegistryDaemon returning, so
+	// poll briefly for the pid to be reaped rather than checking once.
+	alive := true
+	for i := 0; i < 20; i++ {
+		if syscall.Kill(pid, 0) != nil {
+			alive = false
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if alive {
 		t.Error("daemon process still alive after stopRegistryDaemon returned")
 	}
 	if c, derr := net.DialTimeout("tcp", "127.0.0.1:"+httpPort, 200*time.Millisecond); derr == nil {

--- a/internal/cli/cmd_daemon_test.go
+++ b/internal/cli/cmd_daemon_test.go
@@ -229,3 +229,30 @@ func TestStopRegistryDaemonKillsMatchingProcessAndFreesPorts(t *testing.T) {
 		t.Error("DNS port still accepting connections after stopRegistryDaemon returned")
 	}
 }
+
+// TestLiveSandboxIP verifies liveSandboxIP prefers the live inspected IP
+// over the registry's (potentially stale, post-vmnet-reassignment) IP, and
+// falls back to the registry IP when the inspect fails.
+//
+// Both assertions target the same (project, name) so they share a memo
+// entry; the memo is deliberately TTL'd (see liveSandboxIP) to bound
+// inspects on the DNS hot path, so the entry is cleared between the two
+// stub swaps below to simulate TTL expiry rather than asserting a stale
+// cache hit.
+func TestLiveSandboxIP(t *testing.T) {
+	orig := inspectContainerIP
+	t.Cleanup(func() { inspectContainerIP = orig })
+	const container = "cspace-p-mercury"
+	t.Cleanup(func() { sandboxIPMemo.Delete(container) })
+
+	inspectContainerIP = func(string) (string, error) { return "192.168.64.42", nil }
+	if got := liveSandboxIP("p", "mercury", "192.168.64.9"); got != "192.168.64.42" {
+		t.Errorf("want live 192.168.64.42, got %s", got)
+	}
+
+	sandboxIPMemo.Delete(container) // simulate TTL expiry before the next inspect
+	inspectContainerIP = func(string) (string, error) { return "", errContainerGone }
+	if got := liveSandboxIP("p", "mercury", "192.168.64.9"); got != "192.168.64.9" {
+		t.Errorf("want registry fallback 192.168.64.9, got %s", got)
+	}
+}

--- a/internal/cli/cmd_daemon_test.go
+++ b/internal/cli/cmd_daemon_test.go
@@ -256,3 +256,32 @@ func TestLiveSandboxIP(t *testing.T) {
 		t.Errorf("want registry fallback 192.168.64.9, got %s", got)
 	}
 }
+
+// TestLiveSandboxIPNegativeCache verifies that a FAILING inspect is bound
+// to at most one call per name per daemonDNSTTL, same as a succeeding one.
+// Without negative-caching the failure, a name whose container is
+// permanently gone would re-invoke inspectContainerIP (and pay its full 2s
+// timeout) on every single DNS query, defeating the "at most one inspect
+// per name per TTL" bound the memo exists to provide.
+func TestLiveSandboxIPNegativeCache(t *testing.T) {
+	orig := inspectContainerIP
+	t.Cleanup(func() { inspectContainerIP = orig })
+	const container = "cspace-p-venus"
+	t.Cleanup(func() { sandboxIPMemo.Delete(container) })
+	sandboxIPMemo.Delete(container) // avoid colliding with any leftover entry
+
+	var calls int
+	inspectContainerIP = func(string) (string, error) {
+		calls++
+		return "", errContainerGone
+	}
+
+	for i := 0; i < 2; i++ {
+		if got := liveSandboxIP("p", "venus", "192.168.64.9"); got != "192.168.64.9" {
+			t.Errorf("call %d: want registry fallback 192.168.64.9, got %s", i, got)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("want inspectContainerIP invoked exactly once (second call served from negative memo), got %d calls", calls)
+	}
+}

--- a/internal/cli/cmd_dns.go
+++ b/internal/cli/cmd_dns.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/miekg/dns"
 	"github.com/spf13/cobra"
 )
 
@@ -296,10 +295,8 @@ func runDnsStatus(out io.Writer) error {
 // probeDnsDaemon issues a UDP query for a synthetic name and returns true if
 // the daemon responds at all (NXDOMAIN/NOERROR both count — we just need a
 // reply on the wire, which proves the daemon is bound and listening).
+// Delegates to probes.go's probeDnsAnswering (shared with the doctor
+// probes) with the loopback address baked in.
 func probeDnsDaemon(timeout time.Duration) bool {
-	msg := new(dns.Msg)
-	msg.SetQuestion("status-probe.cspace.test.", dns.TypeA)
-	c := &dns.Client{Net: "udp", Timeout: timeout}
-	resp, _, err := c.Exchange(msg, "127.0.0.1:"+dnsLocalPort)
-	return err == nil && resp != nil
+	return probeDnsAnswering("127.0.0.1:"+dnsLocalPort, timeout)
 }

--- a/internal/cli/cmd_send.go
+++ b/internal/cli/cmd_send.go
@@ -20,6 +20,10 @@ func newSendCmd() *cobra.Command {
 		Short: "Inject a user turn into a sandbox session",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := ensureRegistryDaemon(); err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: cspace daemon not reachable: %v\n", err)
+			}
+
 			target, text := args[0], args[1]
 
 			name, session := target, "primary"

--- a/internal/cli/cmd_up.go
+++ b/internal/cli/cmd_up.go
@@ -310,7 +310,7 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 					// "Precedence (stated honestly)" section: env_file
 					// wins by design, this only makes the footgun loud.
 					for _, key := range envFileSecretCollisions(secretValues, env, secretKeys) {
-						fmt.Fprintf(cmd.ErrOrStderr(),
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 							"warning: a project env_file (.env / .env.cspace) overrides the cspace-delivered secret %s — the sandbox will use the env_file value, not the credential cspace loaded. Remove %s from your env_file (or rename it) to use the delivered secret.\n",
 							key, key)
 					}

--- a/internal/cli/cmd_up.go
+++ b/internal/cli/cmd_up.go
@@ -15,7 +15,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/elliottregan/cspace/internal/config"
@@ -1137,6 +1136,8 @@ func randHex(n int) string {
 // one extra daemon, and only one will manage to bind the port; the others
 // exit immediately.
 func ensureRegistryDaemon() error {
+	// TODO(task 2): replace with daemonHealthVersion(time.Second) reuse check
+	// (also verifies the running daemon matches this binary's version).
 	conn, err := net.DialTimeout("tcp", "127.0.0.1:6280", time.Second)
 	if err == nil {
 		_ = conn.Close()
@@ -1149,83 +1150,35 @@ func ensureRegistryDaemon() error {
 	if err != nil {
 		return fmt.Errorf("locate cspace binary: %w", err)
 	}
-	c := exec.Command(self, "daemon", "serve")
-	// Capture daemon stderr so a fast-fail (e.g. DNS UDP bind failure on a
-	// squatted port 5354) bubbles up as a useful error instead of "not
-	// accepting connections" with no context. The buffer is bounded by
-	// limitedBuffer so a misbehaving daemon can't grow it without bound.
-	stderrBuf := &limitedBuffer{max: 8 * 1024}
-	c.Stdout = nil
-	c.Stderr = stderrBuf
-	if err := c.Start(); err != nil {
+	cmd, logFile, err := newDaemonCommand(self)
+	if err != nil {
+		return fmt.Errorf("prepare daemon: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
 		return fmt.Errorf("spawn cspace daemon: %w", err)
 	}
-	// Daemon takes ~250ms to bind in practice. Wait for the port to actually
-	// accept connections, but also short-circuit if the daemon process exits
-	// (which it does on DNS bind failure — see runDaemonServe).
-	exited := make(chan error, 1)
-	go func() { exited <- c.Wait() }()
+	_ = logFile.Close()            // detached daemon keeps its own handle on the log file
+	go func() { _ = cmd.Wait() }() // reap; does NOT couple lifetimes (child is Setsid-detached)
 
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		conn, derr := net.DialTimeout("tcp", "127.0.0.1:6280", 250*time.Millisecond)
-		if derr == nil {
-			_ = conn.Close()
+		if c, derr := net.DialTimeout("tcp", "127.0.0.1:6280", 250*time.Millisecond); derr == nil {
+			_ = c.Close()
 			return nil
 		}
-		select {
-		case waitErr := <-exited:
-			// Daemon already exited. Surface its stderr.
-			msg := strings.TrimSpace(stderrBuf.String())
-			if msg != "" {
-				return fmt.Errorf("daemon exited before accepting connections: %w\nstderr:\n%s", waitErr, msg)
+		time.Sleep(100 * time.Millisecond)
+	}
+	if p, perr := daemonLogPath(); perr == nil {
+		if b, rerr := os.ReadFile(p); rerr == nil && len(b) > 0 {
+			tail := string(b)
+			if len(tail) > 800 {
+				tail = tail[len(tail)-800:]
 			}
-			return fmt.Errorf("daemon exited before accepting connections: %w", waitErr)
-		case <-time.After(100 * time.Millisecond):
+			return fmt.Errorf("daemon not accepting connections within 3s; ~/.cspace/daemon.log tail:\n%s", tail)
 		}
 	}
-
-	// Deadline expired without HTTP coming up and without the process
-	// exiting. Kill the orphan child, drain Wait, and surface whatever
-	// stderr we collected.
-	_ = c.Process.Kill()
-	<-exited
-	msg := strings.TrimSpace(stderrBuf.String())
-	if msg != "" {
-		return fmt.Errorf("daemon failed to start within 3s; stderr:\n%s", msg)
-	}
-	return fmt.Errorf("daemon started but not accepting connections")
-}
-
-// limitedBuffer is a goroutine-safe bytes.Buffer wrapper that caps its size,
-// dropping any writes that would exceed `max`. Used to capture daemon stderr
-// without unbounded growth in pathological cases (e.g. log spam loop).
-type limitedBuffer struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
-	max int
-}
-
-func (b *limitedBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	remaining := b.max - b.buf.Len()
-	if remaining <= 0 {
-		// Pretend the write succeeded; we just drop overflow.
-		return len(p), nil
-	}
-	if len(p) > remaining {
-		b.buf.Write(p[:remaining])
-		return len(p), nil
-	}
-	b.buf.Write(p)
-	return len(p), nil
-}
-
-func (b *limitedBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.String()
+	return fmt.Errorf("daemon started but not accepting connections within 3s")
 }
 
 // nudgeSentinelName is the per-user marker file that records "the no-auth

--- a/internal/cli/cmd_up.go
+++ b/internal/cli/cmd_up.go
@@ -837,6 +837,31 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 			}
 			rep.Phase(overlay.PhaseReady)
 
+			// Gate: confirm the friendly .cspace.test hostname actually
+			// resolves from inside the sandbox (and the browser sidecar,
+			// if one is running) before we hand off to the agent. This
+			// catches a cspace daemon DNS outage or dnsmasq misconfig
+			// early — with a clear warning — instead of silently falling
+			// back to raw IPs deep into a session. Warn, don't fail: a
+			// broken friendly hostname degrades convenience, not
+			// correctness, so it must never block the boot.
+			containerExecAdapter := func(execCtx context.Context, container string, argv ...string) ([]byte, error) {
+				res, execErr := a.Exec(execCtx, container, argv, substrate.ExecOpts{})
+				return []byte(res.Stdout), execErr
+			}
+			if wh := workspaceFriendlyHost(name, project); wh != "" {
+				if rErr := verifyInContainerResolution(ctx, containerExecAdapter, containerName, wh); rErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: %v — sidecar browser and host will fall back to raw IPs; run `cspace doctor`\n", rErr)
+				}
+				if browserSidecar != nil {
+					if rErr := verifyInContainerResolution(ctx, containerExecAdapter, browserContainer, wh); rErr != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+							"warning: %v — sidecar browser and host will fall back to raw IPs; run `cspace doctor`\n", rErr)
+					}
+				}
+			}
+
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 				"%ssandbox %s up: control %s  ip %s  token %s…\n",
 				glyphPrefix(name), name, ctlURL, ip, token[:8])

--- a/internal/cli/cmd_up.go
+++ b/internal/cli/cmd_up.go
@@ -228,6 +228,10 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 				"CSPACE_REGISTRY_URL":  "http://192.168.64.1:6280",
 				"CSPACE_HOST_GATEWAY":  "192.168.64.1",
 			}
+			// Always set, independent of the browser sidecar: agents/docs
+			// point at this var as THE address to reach the workspace from
+			// outside it, and that must hold even under --no-browser.
+			applyWorkspaceHostEnv(env, name, project)
 
 			// Merged plugins config (defaults.json overlaid with project's
 			// .cspace.json) goes into the sandbox as JSON so the in-
@@ -628,11 +632,10 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 				// image doesn't need a local browser.
 				env["PLAYWRIGHT_MCP_CDP_ENDPOINT"] = bs.CDPURL
 				env["PW_TEST_CONNECT_WS_ENDPOINT"] = bs.RunServerWSURL
-				// Stable hostname agents/scripts use to reach the dev
-				// or preview server running inside the workspace from
-				// the browser sidecar. Hosts entry written below once
-				// the workspace IP is known.
-				env["CSPACE_WORKSPACE_HOST"] = workspaceFriendlyHost(name, project)
+				// CSPACE_WORKSPACE_HOST is set unconditionally above (near
+				// env's construction), not here — it must hold even under
+				// --no-browser. Hosts entry written below once the
+				// workspace IP is known.
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 					"browser sidecar: %s (cdp %s, run-server %s)\n",
 					bs.ContainerName, bs.CDPURL, bs.RunServerWSURL)

--- a/internal/cli/cmd_up.go
+++ b/internal/cli/cmd_up.go
@@ -275,6 +275,18 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 						}
 					}
 					sandboxImage = resolveSandboxImage(ctx, plan, "cspace:latest")
+					// Snapshot the cspace-delivered secret values (from
+					// `loaded`, merged into env above) BEFORE the compose
+					// env_file merge below can silently override them. Used
+					// only for the fail-loud warning after the merge — it
+					// never changes which value wins.
+					secretKeys := secrets.SecretKeys()
+					secretValues := map[string]string{}
+					for _, k := range secretKeys {
+						if v, ok := env[k]; ok {
+							secretValues[k] = v
+						}
+					}
 					// Compose service.environment (including any env_file
 					// content compose-go resolved at parse time) merges
 					// FIRST so devcontainer.json containerEnv can override.
@@ -288,6 +300,19 @@ that 8-deep convention — e.g. "issue-123" or "agent-alice".`,
 								env[k] = v
 							}
 						}
+					}
+					// Fail loud: warn (don't block) if the env_file merge
+					// just above silently overrode a cspace-delivered
+					// secret. This must run BEFORE the containerEnv merge
+					// below, so an intentional devcontainer.json
+					// containerEnv override doesn't get flagged — only
+					// env_file collisions do. See docs/env-cspace.md's
+					// "Precedence (stated honestly)" section: env_file
+					// wins by design, this only makes the footgun loud.
+					for _, key := range envFileSecretCollisions(secretValues, env, secretKeys) {
+						fmt.Fprintf(cmd.ErrOrStderr(),
+							"warning: a project env_file (.env / .env.cspace) overrides the cspace-delivered secret %s — the sandbox will use the env_file value, not the credential cspace loaded. Remove %s from your env_file (or rename it) to use the delivered secret.\n",
+							key, key)
 					}
 					// containerEnv merges into env: devcontainer values override
 					// compose env (more specific) and lose to secrets file +

--- a/internal/cli/cmd_up.go
+++ b/internal/cli/cmd_up.go
@@ -1136,12 +1136,16 @@ func randHex(n int) string {
 // one extra daemon, and only one will manage to bind the port; the others
 // exit immediately.
 func ensureRegistryDaemon() error {
-	// TODO(task 2): replace with daemonHealthVersion(time.Second) reuse check
-	// (also verifies the running daemon matches this binary's version).
-	conn, err := net.DialTimeout("tcp", "127.0.0.1:6280", time.Second)
-	if err == nil {
-		_ = conn.Close()
-		return nil
+	if v, ok := daemonHealthVersion(time.Second); ok {
+		if v == Version {
+			return nil
+		}
+		// A daemon is up but from a different cspace build/version. Stop
+		// it and fall through to respawn a version-matched one.
+		// stopRegistryDaemon blocks until the loopback ports are actually
+		// free, so the respawn below doesn't lose the fatal DNS/HTTP bind
+		// race against the dying process.
+		_ = stopRegistryDaemon()
 	}
 	// Use os.Executable() so the daemon spawns the SAME cspace binary the
 	// user just invoked, not whatever "cspace" might exist on PATH from an
@@ -1163,7 +1167,7 @@ func ensureRegistryDaemon() error {
 
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if c, derr := net.DialTimeout("tcp", "127.0.0.1:6280", 250*time.Millisecond); derr == nil {
+		if c, derr := net.DialTimeout("tcp", daemonHTTPAddr(), 250*time.Millisecond); derr == nil {
 			_ = c.Close()
 			return nil
 		}

--- a/internal/cli/cmd_up_secret_warnings.go
+++ b/internal/cli/cmd_up_secret_warnings.go
@@ -1,0 +1,31 @@
+package cli
+
+import "sort"
+
+// envFileSecretCollisions reports which of secretKeys were delivered by
+// cspace (present with a non-empty value in secretValues, a snapshot taken
+// right after secrets.Load's values were merged into the env map) but ended
+// up different in mergedEnv after a later merge layer — e.g. a project's
+// compose env_file (.env / .env.cspace) redeclaring or blanking the key.
+//
+// This is a pure, read-only check: it never mutates mergedEnv and the
+// caller must not change merge behavior based on its result. Per
+// docs/env-cspace.md's "Precedence (stated honestly)" section, the
+// env_file value is allowed to win — this only makes that footgun loud
+// instead of silent.
+//
+// The returned slice is sorted for deterministic warning output.
+func envFileSecretCollisions(secretValues, mergedEnv map[string]string, secretKeys []string) []string {
+	var collisions []string
+	for _, key := range secretKeys {
+		delivered, ok := secretValues[key]
+		if !ok || delivered == "" {
+			continue // cspace didn't deliver this secret; nothing to protect
+		}
+		if mergedEnv[key] != delivered {
+			collisions = append(collisions, key)
+		}
+	}
+	sort.Strings(collisions)
+	return collisions
+}

--- a/internal/cli/cmd_up_secret_warnings_test.go
+++ b/internal/cli/cmd_up_secret_warnings_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestEnvFileSecretCollisions covers the fail-loud warning check that fires
+// when a project's compose env_file (.env / .env.cspace) silently overrides
+// a cspace-delivered secret (ANTHROPIC_API_KEY, GH_TOKEN, ...). See
+// docs/env-cspace.md's "Precedence (stated honestly)" section: env_file
+// content wins over the delivered secret today, so this check only warns —
+// it must never change which value ends up in the merged env.
+func TestEnvFileSecretCollisions(t *testing.T) {
+	secretKeys := []string{"ANTHROPIC_API_KEY", "GH_TOKEN"}
+
+	cases := []struct {
+		name         string
+		secretValues map[string]string
+		mergedEnv    map[string]string
+		want         []string
+	}{
+		{
+			name:         "overridden with a different value is reported",
+			secretValues: map[string]string{"ANTHROPIC_API_KEY": "sk-ant-api-real"},
+			mergedEnv:    map[string]string{"ANTHROPIC_API_KEY": "sk-ant-api-fake-from-envfile"},
+			want:         []string{"ANTHROPIC_API_KEY"},
+		},
+		{
+			name:         "blanked by env_file is reported",
+			secretValues: map[string]string{"ANTHROPIC_API_KEY": "sk-ant-api-real"},
+			mergedEnv:    map[string]string{"ANTHROPIC_API_KEY": ""},
+			want:         []string{"ANTHROPIC_API_KEY"},
+		},
+		{
+			name:         "same value in env_file is not reported",
+			secretValues: map[string]string{"ANTHROPIC_API_KEY": "sk-ant-api-real"},
+			mergedEnv:    map[string]string{"ANTHROPIC_API_KEY": "sk-ant-api-real"},
+			want:         nil,
+		},
+		{
+			name:         "secret absent from secretValues is not reported",
+			secretValues: map[string]string{},
+			mergedEnv:    map[string]string{"ANTHROPIC_API_KEY": "sk-ant-api-fake-from-envfile"},
+			want:         nil,
+		},
+		{
+			name:         "non-secret key differing is not reported",
+			secretValues: map[string]string{"ANTHROPIC_API_KEY": "sk-ant-api-real"},
+			mergedEnv: map[string]string{
+				"ANTHROPIC_API_KEY": "sk-ant-api-real",
+				"SOME_OTHER_VAR":    "different-value",
+			},
+			want: nil,
+		},
+		{
+			name: "multiple collisions come back sorted",
+			secretValues: map[string]string{
+				"ANTHROPIC_API_KEY": "sk-ant-api-real",
+				"GH_TOKEN":          "gh-real",
+			},
+			mergedEnv: map[string]string{
+				"ANTHROPIC_API_KEY": "sk-ant-api-fake",
+				"GH_TOKEN":          "gh-fake",
+			},
+			want: []string{"ANTHROPIC_API_KEY", "GH_TOKEN"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := envFileSecretCollisions(tc.secretValues, tc.mergedEnv, secretKeys)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("envFileSecretCollisions() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd_up_test.go
+++ b/internal/cli/cmd_up_test.go
@@ -175,6 +175,18 @@ func TestWarnExpiredAutoDiscoveredAuth(t *testing.T) {
 
 // TestResolveBrowserEnabled covers the browser-sidecar precedence ladder:
 // project CSPACE_BROWSER_CDP_URL > --no-browser > devcontainer tristate > default ON.
+// TestWorkspaceHostSetWithoutBrowser guards against CSPACE_WORKSPACE_HOST
+// regressing into a browser-sidecar-only assignment: agents/docs point at
+// this var as THE address to reach the workspace, so it must be set even
+// under --no-browser.
+func TestWorkspaceHostSetWithoutBrowser(t *testing.T) {
+	env := map[string]string{}
+	applyWorkspaceHostEnv(env, "mercury", "resume-redux")
+	if env["CSPACE_WORKSPACE_HOST"] != "mercury.resume-redux.cspace.test" {
+		t.Fatalf("got %q", env["CSPACE_WORKSPACE_HOST"])
+	}
+}
+
 func TestResolveBrowserEnabled(t *testing.T) {
 	bptr := func(b bool) *bool { return &b }
 	cases := []struct {

--- a/internal/cli/daemon_spawn.go
+++ b/internal/cli/daemon_spawn.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+func daemonLogPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".cspace")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "daemon.log"), nil
+}
+
+// newDaemonCommand builds a detached `<self> daemon serve`. Setsid detaches it
+// from the parent's session; stdout+stderr go to an append-only log FILE (not
+// a parent-held os.Pipe) so a later log write can't take EPIPE -> SIGPIPE after
+// cspace up exits. Caller closes the returned file after Start.
+func newDaemonCommand(self string) (*exec.Cmd, *os.File, error) {
+	logPath, err := daemonLogPath()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := rotateIfLarge(logPath, 1<<20); err != nil { // 1 MiB cap (spec 1a)
+		return nil, nil, err
+	}
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, nil, err
+	}
+	cmd := exec.Command(self, "daemon", "serve")
+	cmd.Stdout, cmd.Stderr = f, f
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return cmd, f, nil
+}
+
+// rotateIfLarge truncates the log by renaming to .1 once it exceeds max bytes,
+// bounding the gateway-retry chatter over long-lived hosts.
+func rotateIfLarge(path string, max int64) error {
+	if fi, err := os.Stat(path); err == nil && fi.Size() > max {
+		return os.Rename(path, path+".1")
+	}
+	return nil
+}

--- a/internal/cli/daemon_spawn_test.go
+++ b/internal/cli/daemon_spawn_test.go
@@ -19,7 +19,7 @@ func TestNewDaemonCommandIsDetached(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newDaemonCommand: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
 		t.Error("daemon command must set Setsid so it survives the parent")

--- a/internal/cli/daemon_spawn_test.go
+++ b/internal/cli/daemon_spawn_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestNewDaemonCommandIsDetached(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd, f, err := newDaemonCommand("/usr/local/bin/cspace")
+	if err != nil {
+		t.Fatalf("newDaemonCommand: %v", err)
+	}
+	defer f.Close()
+
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
+		t.Error("daemon command must set Setsid so it survives the parent")
+	}
+	if _, ok := cmd.Stderr.(*os.File); !ok {
+		t.Errorf("stderr must be an *os.File log (not a parent-held pipe), got %T", cmd.Stderr)
+	}
+	if cmd.Stdout != cmd.Stderr {
+		t.Error("stdout and stderr should share the log file")
+	}
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.HasSuffix(joined, "daemon serve") {
+		t.Errorf("args = %v, want ... daemon serve", cmd.Args)
+	}
+}
+
+// A detached daemon must keep answering after its spawner exits. We build the
+// real binary, run a throwaway "spawner" that calls the same spawn path and
+// then exits, and assert the daemon is still up. DNS/HTTP ports are overridden
+// so this never collides with a developer's live daemon.
+func TestDaemonSurvivesSpawnerExit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds + spawns real processes")
+	}
+	bin := buildCspaceForTest(t) // go build -o <tmp> ./cmd/cspace
+	home := t.TempDir()
+	env := append(os.Environ(),
+		"HOME="+home,
+		"CSPACE_REGISTRY_DAEMON_PORT=6299",
+		"CSPACE_DAEMON_DNS_ADDR=127.0.0.1:15354",
+		"CSPACE_DAEMON_GATEWAY_ADDR=127.0.0.1:15355", // loopback stand-in; gateway bind is best-effort
+		"CSPACE_REGISTRY_DAEMON_IDLE=1h",
+	)
+	// Spawner: start the daemon detached exactly like ensureRegistryDaemon, then exit.
+	spawner := exec.Command(bin, "daemon", "serve")
+	spawner.Env = env
+	logf, _ := os.Create(filepath.Join(home, "d.log"))
+	spawner.Stdout, spawner.Stderr = logf, logf
+	spawner.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := spawner.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := spawner.Process.Pid
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	waitForPort(t, "127.0.0.1:6299", 5*time.Second)
+	_ = logf.Close() // drop the only non-daemon reference to the log
+	// Force the daemon to keep logging (a real daemon logs on gateway retries);
+	// then confirm it is still alive and answering after the parent's handle is gone.
+	time.Sleep(1 * time.Second)
+	if syscall.Kill(pid, 0) != nil {
+		t.Fatal("daemon died after its spawner's log handle closed (SIGPIPE regression)")
+	}
+	if _, ok := httpGet(t, "http://127.0.0.1:6299/health"); !ok {
+		t.Fatal("daemon stopped answering /health")
+	}
+}
+
+// buildCspaceForTest builds the real cspace binary into a temp dir so the
+// survival test can exercise the actual `daemon serve` entry point.
+func buildCspaceForTest(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "cspace-test-bin")
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/cspace")
+	cmd.Dir = repoRootForTest(t)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build ./cmd/cspace: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// repoRootForTest walks up from the package directory to find the module
+// root (where go.mod lives), since `go build ./cmd/cspace` must run there.
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root (go.mod) from " + dir)
+		}
+		dir = parent
+	}
+}
+
+// waitForPort polls until addr accepts a TCP connection or timeout elapses.
+func waitForPort(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 250*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s to accept connections", addr)
+}
+
+// httpGet performs a best-effort GET, returning (body, true) on a 200.
+func httpGet(t *testing.T, url string) (string, bool) {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		return "", false
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
+}

--- a/internal/cli/daemon_spawn_test.go
+++ b/internal/cli/daemon_spawn_test.go
@@ -36,10 +36,12 @@ func TestNewDaemonCommandIsDetached(t *testing.T) {
 	}
 }
 
-// A detached daemon must keep answering after its spawner exits. We build the
-// real binary, run a throwaway "spawner" that calls the same spawn path and
-// then exits, and assert the daemon is still up. DNS/HTTP ports are overridden
-// so this never collides with a developer's live daemon.
+// Verifies that the daemon detachment technique (Setsid + *os.File stdio) keeps
+// a "daemon serve" process alive after its spawner exits. This test hand-builds
+// the detachment wiring directly; production wiring in newDaemonCommand and
+// ensureRegistryDaemon is guarded separately by TestNewDaemonCommandIsDetached
+// plus code review. DNS/HTTP ports are overridden so the daemon never collides
+// with a developer's live instance.
 func TestDaemonSurvivesSpawnerExit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds + spawns real processes")

--- a/internal/cli/probes.go
+++ b/internal/cli/probes.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"github.com/elliottregan/cspace/internal/registry"
+	"github.com/elliottregan/cspace/internal/substrate"
 	"github.com/elliottregan/cspace/internal/substrate/applecontainer"
+	"github.com/miekg/dns"
 )
 
 // ProbeStatus is the per-check verdict.
@@ -141,29 +143,163 @@ func ProbeDaemon(ctx context.Context) ProbeResult {
 		})
 	}
 
-	// DNS UDP — share probeDnsDaemon from cmd_dns.go.
-	if probeDnsDaemon(1 * time.Second) {
-		r.Checks = append(r.Checks, ProbeCheck{
+	// DNS UDP — loopback listener, then the container-facing gateway
+	// listener and an actual in-container resolution, all via the shared
+	// probeDnsAt helper.
+	r.Checks = append(r.Checks, probeDnsAt("127.0.0.1:"+dnsLocalPort, "DNS", false /*failIsWarn*/))
+	r.Checks = append(r.Checks, probeGatewayDNS())
+	r.Checks = append(r.Checks, probeInContainerDNS())
+	return r
+}
+
+// probeDnsAnswering issues a synthetic UDP DNS query at addr and reports
+// whether anything answered. NXDOMAIN/NOERROR both count as "answering" —
+// this proves the listener is bound and alive, not that the record itself
+// resolves correctly.
+func probeDnsAnswering(addr string, timeout time.Duration) bool {
+	msg := new(dns.Msg)
+	msg.SetQuestion("status-probe.cspace.test.", dns.TypeA)
+	c := &dns.Client{Net: "udp", Timeout: timeout}
+	resp, _, err := c.Exchange(msg, addr)
+	return err == nil && resp != nil
+}
+
+// probeDnsAt checks a single UDP DNS listener and reports a ProbeCheck.
+//
+// When failIsWarn is true, any failure to get an answer degrades to
+// ProbeWarn rather than ProbeFail — used for the container-facing gateway
+// listener (192.168.64.1:5354), which simply doesn't exist until a sandbox
+// has booted and claimed a vmnet gateway IP; a hard Fail there would fail
+// `doctor` in CI where no vmnet bridge exists at all.
+//
+// When failIsWarn is false (the always-on loopback daemon), a failure is
+// further split: if the UDP port itself refuses a connection, that's a
+// Fail; if the port accepts a connection but the synthetic query goes
+// unanswered, that's a Warn (something is listening but not the cspace
+// daemon).
+func probeDnsAt(addr, label string, failIsWarn bool) ProbeCheck {
+	if probeDnsAnswering(addr, 1*time.Second) {
+		return ProbeCheck{
 			Status: ProbePass,
-			Title:  "DNS responding on 127.0.0.1:" + dnsLocalPort + "/udp",
-		})
-	} else {
-		// Differentiate "port closed" vs "port open but not answering".
-		if c, err := net.DialTimeout("udp", "127.0.0.1:"+dnsLocalPort, 500*time.Millisecond); err == nil {
-			_ = c.Close()
-			r.Checks = append(r.Checks, ProbeCheck{
-				Status:  ProbeWarn,
-				Title:   "DNS port " + dnsLocalPort + "/udp open but not answering queries",
-				Details: []string{"another process may hold UDP/" + dnsLocalPort + "; check `lsof -nP -iUDP:" + dnsLocalPort + "`"},
-			})
-		} else {
-			r.Checks = append(r.Checks, ProbeCheck{
-				Status: ProbeFail,
-				Title:  "DNS not responding on 127.0.0.1:" + dnsLocalPort + "/udp",
-			})
+			Title:  label + " responding on " + addr + "/udp",
 		}
 	}
-	return r
+	if failIsWarn {
+		return ProbeCheck{
+			Status:  ProbeWarn,
+			Title:   label + " not responding on " + addr + "/udp",
+			Details: []string{"expected until a sandbox has booted and claimed a vmnet gateway IP"},
+		}
+	}
+	// Differentiate "port closed" vs "port open but not answering".
+	if c, err := net.DialTimeout("udp", addr, 500*time.Millisecond); err == nil {
+		_ = c.Close()
+		return ProbeCheck{
+			Status:  ProbeWarn,
+			Title:   label + " port open but not answering queries at " + addr,
+			Details: []string{"another process may hold that UDP port; check `lsof -nP -iUDP:" + dnsLocalPort + "`"},
+		}
+	}
+	return ProbeCheck{
+		Status: ProbeFail,
+		Title:  label + " not responding on " + addr + "/udp",
+	}
+}
+
+// probeGatewayDNS checks the container-facing gateway DNS listener
+// (192.168.64.1:5354) that sandboxes query from inside their devcontainer.
+// Unlike the loopback listener, this address is only bound once at least
+// one sandbox has booted and claimed a vmnet gateway IP, so a failure here
+// always degrades to Warn, never Fail.
+func probeGatewayDNS() ProbeCheck {
+	return probeDnsAt("192.168.64.1:"+dnsLocalPort, "container-facing DNS (gateway)", true /*failIsWarn*/)
+}
+
+// probeInContainerDNS fulfils the "in-container resolution" half of the
+// gateway+in-container promise: it picks one alive sandbox from the
+// registry and resolves its own friendly hostname from inside its
+// devcontainer via a single `getent hosts` exec. Doctor probes must stay
+// fast, so — unlike verifyInContainerResolution's 3x2s boot-time retry loop
+// — this makes exactly one attempt.
+func probeInContainerDNS() ProbeCheck {
+	path, err := registry.DefaultPath()
+	if err != nil {
+		return ProbeCheck{
+			Status:  ProbeWarn,
+			Title:   "in-container DNS: registry path unavailable",
+			Details: []string{err.Error()},
+		}
+	}
+	reg := &registry.Registry{Path: path}
+	entries, err := reg.List()
+	if err != nil {
+		return ProbeCheck{
+			Status:  ProbeWarn,
+			Title:   "in-container DNS: registry read failed",
+			Details: []string{err.Error()},
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	entry, ok := firstAliveEntry(ctx, entries)
+	if !ok {
+		return ProbeCheck{
+			Status: ProbePass,
+			Title:  "in-container DNS (no sandbox to test)",
+		}
+	}
+
+	a := applecontainer.New()
+	exec := func(execCtx context.Context, container string, argv ...string) ([]byte, error) {
+		res, execErr := a.Exec(execCtx, container, argv, substrate.ExecOpts{})
+		return []byte(res.Stdout), execErr
+	}
+	return checkInContainerDNSOnce(ctx, exec, containerNameForEntry(entry), workspaceFriendlyHost(entry.Name, entry.Project))
+}
+
+// firstAliveEntry returns the first registry entry that has an assigned IP,
+// a live container, and isn't still mid-boot. Mirrors the aliveness check
+// ProbeSandboxes uses.
+func firstAliveEntry(ctx context.Context, entries []registry.Entry) (registry.Entry, bool) {
+	for _, e := range entries {
+		if e.IP == "" {
+			continue
+		}
+		if e.State == "starting" {
+			continue
+		}
+		if !containerExists(ctx, containerNameForEntry(e)) {
+			continue
+		}
+		return e, true
+	}
+	return registry.Entry{}, false
+}
+
+// checkInContainerDNSOnce runs a single `getent hosts` exec inside container
+// and maps the outcome to a ProbeCheck: resolves -> Pass; doesn't resolve or
+// exec error -> Warn (a dead daemon here is advisory, not a doctor failure).
+func checkInContainerDNSOnce(ctx context.Context, exec containerExecFn, container, host string) ProbeCheck {
+	out, err := exec(ctx, container, "getent", "hosts", host)
+	if err != nil {
+		return ProbeCheck{
+			Status:  ProbeWarn,
+			Title:   "in-container DNS: " + host + " did not resolve inside " + container,
+			Details: []string{err.Error()},
+		}
+	}
+	if strings.TrimSpace(string(out)) == "" {
+		return ProbeCheck{
+			Status: ProbeWarn,
+			Title:  "in-container DNS: " + host + " did not resolve inside " + container,
+		}
+	}
+	return ProbeCheck{
+		Status: ProbePass,
+		Title:  "in-container DNS: " + host + " resolves inside " + container,
+	}
 }
 
 // ProbeDns reports the macOS resolver state for *.<dnsDomain>. On non-darwin

--- a/internal/cli/probes_test.go
+++ b/internal/cli/probes_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/elliottregan/cspace/internal/registry"
+)
+
+// TestGatewayDNSProbeDegradesGracefully guards the container-facing gateway
+// DNS check (192.168.64.1:5354): the vmnet gateway address doesn't exist
+// until a container has booted, so a dial/answer failure here must degrade
+// to ProbeWarn — never ProbeFail, which would fail `doctor` in CI where no
+// vmnet bridge is up at all.
+func TestGatewayDNSProbeDegradesGracefully(t *testing.T) {
+	c := probeGatewayDNS()
+	if c.Title == "" {
+		t.Fatal("probe check needs a title")
+	}
+	// No vmnet bridge in CI => must warn, never hard-fail (which would fail doctor).
+	if c.Status == ProbeFail {
+		t.Errorf("gateway DNS should degrade to warn, got fail: %+v", c)
+	}
+}
+
+// TestFirstAliveEntryNoEntries exercises probeInContainerDNS's "nothing to
+// test" precondition in isolation from the real on-disk registry: with no
+// entries at all, there's nothing alive to pick.
+func TestFirstAliveEntryNoEntries(t *testing.T) {
+	_, ok := firstAliveEntry(context.Background(), nil)
+	if ok {
+		t.Fatal("expected no alive entry from an empty registry")
+	}
+}
+
+// TestFirstAliveEntrySkipsBootingAndIPless confirms entries still booting
+// (no IP yet, or State == "starting") are skipped rather than treated as
+// alive — a doctor probe against a half-booted sandbox would just be noise.
+func TestFirstAliveEntrySkipsBootingAndIPless(t *testing.T) {
+	entries := []registry.Entry{
+		{Name: "a", Project: "p", IP: "", State: "ready"},
+		{Name: "b", Project: "p", IP: "10.0.0.2", State: "starting"},
+	}
+	_, ok := firstAliveEntry(context.Background(), entries)
+	if ok {
+		t.Fatal("expected no alive entry: one has no IP, the other is still starting")
+	}
+}
+
+// TestCheckInContainerDNSOnceMapsOutcomes verifies the single-attempt exec
+// wrapper maps resolve/no-resolve/exec-error to Pass/Warn/Warn respectively
+// — a dead in-container resolver is advisory (Warn), never a doctor Fail.
+func TestCheckInContainerDNSOnceMapsOutcomes(t *testing.T) {
+	resolves := func(ctx context.Context, container string, argv ...string) ([]byte, error) {
+		return []byte("10.0.0.5   sandbox.project.cspace.test\n"), nil
+	}
+	c := checkInContainerDNSOnce(context.Background(), resolves, "cspace-p-a", "a.p.cspace.test")
+	if c.Status != ProbePass {
+		t.Errorf("expected Pass on successful resolution, got %+v", c)
+	}
+
+	empty := func(ctx context.Context, container string, argv ...string) ([]byte, error) {
+		return []byte(""), nil
+	}
+	c = checkInContainerDNSOnce(context.Background(), empty, "cspace-p-a", "a.p.cspace.test")
+	if c.Status != ProbeWarn {
+		t.Errorf("expected Warn on empty getent output, got %+v", c)
+	}
+
+	failing := func(ctx context.Context, container string, argv ...string) ([]byte, error) {
+		return nil, errors.New("exec: container not found")
+	}
+	c = checkInContainerDNSOnce(context.Background(), failing, "cspace-p-a", "a.p.cspace.test")
+	if c.Status != ProbeWarn {
+		t.Errorf("expected Warn on exec error (never Fail), got %+v", c)
+	}
+	if c.Status == ProbeFail {
+		t.Errorf("in-container DNS probe should never hard-fail, got: %+v", c)
+	}
+}
+
+// TestInContainerDNSProbeNeverFails is a light end-to-end smoke test against
+// probeInContainerDNS() itself. It doesn't assume anything about the host's
+// real ~/.cspace/sandbox-registry.json (which may or may not have live
+// sandboxes registered from other projects) — only that the probe never
+// reports ProbeFail, matching the "advisory, not a doctor gate" contract.
+func TestInContainerDNSProbeNeverFails(t *testing.T) {
+	c := probeInContainerDNS()
+	if c.Title == "" {
+		t.Fatal("probe check needs a title")
+	}
+	if c.Status == ProbeFail {
+		t.Errorf("in-container DNS probe should never hard-fail, got: %+v", c)
+	}
+}

--- a/internal/cli/resolve_gate.go
+++ b/internal/cli/resolve_gate.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// containerExecFn runs argv inside the named container and returns stdout.
+// Matches the shape of the substrate adapter's Exec method, adapted to a
+// variadic argv for callers that don't need the full ExecOpts surface.
+type containerExecFn func(ctx context.Context, container string, argv ...string) ([]byte, error)
+
+// verifyInContainerResolution confirms that host resolves inside container
+// via `getent hosts`. Cold boot is racy for a few seconds — the in-container
+// dnsmasq and the cspace daemon's gateway bind both need a moment to come
+// up — so this retries up to 3 times with a 2s pause between attempts
+// (~4s worst case) before giving up.
+func verifyInContainerResolution(ctx context.Context, exec containerExecFn, container, host string) error {
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(2 * time.Second)
+		}
+		out, err := exec(ctx, container, "getent", "hosts", host)
+		if err != nil {
+			lastErr = fmt.Errorf("resolve %s in %s: %w", host, container, err)
+			continue
+		}
+		if strings.TrimSpace(string(out)) != "" {
+			return nil
+		}
+		lastErr = fmt.Errorf("%s did not resolve inside %s (cspace daemon DNS may be down)", host, container)
+	}
+	return lastErr
+}

--- a/internal/cli/resolve_gate_test.go
+++ b/internal/cli/resolve_gate_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestVerifyInContainerResolution(t *testing.T) {
+	host := "mercury.p.cspace.test"
+	t.Run("resolves and calls getent hosts <host>", func(t *testing.T) {
+		var gotArgv []string
+		exec := func(_ context.Context, _ string, argv ...string) ([]byte, error) {
+			gotArgv = argv
+			return []byte("192.168.64.5 " + host + "\n"), nil
+		}
+		if err := verifyInContainerResolution(context.Background(), exec, "c", host); err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+		if want := []string{"getent", "hosts", host}; !reflect.DeepEqual(gotArgv, want) {
+			t.Errorf("argv = %v, want %v", gotArgv, want)
+		}
+	})
+	t.Run("empty output fails after retries", func(t *testing.T) {
+		exec := func(_ context.Context, _ string, argv ...string) ([]byte, error) { return []byte(""), nil }
+		if err := verifyInContainerResolution(context.Background(), exec, "c", host); err == nil {
+			t.Fatal("want error on empty resolution")
+		}
+	})
+	t.Run("exec error fails", func(t *testing.T) {
+		exec := func(_ context.Context, _ string, argv ...string) ([]byte, error) { return nil, errors.New("boom") }
+		if err := verifyInContainerResolution(context.Background(), exec, "c", host); err == nil {
+			t.Fatal("want error when exec fails")
+		}
+	})
+}

--- a/internal/orchestrator/lifecycle.go
+++ b/internal/orchestrator/lifecycle.go
@@ -199,10 +199,6 @@ func (o *Orchestration) injectAllHosts(ctx context.Context) error {
 		}
 		ips[name] = ip
 	}
-	// Cache for callers (cmd_up) that need to extend hosts injection
-	// beyond compose-managed microVMs — e.g. into the browser sidecar,
-	// which is cspace-private and not part of the compose plan.
-	o.serviceIPs = ips
 	// Per-target hosts content: every microVM gets the same compose
 	// service map, but the workspace also gets `workspace -> 127.0.0.1`
 	// so scripts inside the workspace can hit http://workspace:<port>

--- a/internal/orchestrator/types.go
+++ b/internal/orchestrator/types.go
@@ -63,22 +63,4 @@ type Orchestration struct {
 	// ExtractedEnv is populated by Up after credential extraction runs;
 	// cmd_up consumes this to inject env vars into the sandbox.
 	ExtractedEnv map[string]string
-	// serviceIPs is populated by injectAllHosts; keyed by compose service
-	// name → vmnet IP. Exposed via ServiceIPs() so cmd_up can extend hosts
-	// injection into cspace-private microVMs (e.g. the browser sidecar).
-	serviceIPs map[string]string
-}
-
-// ServiceIPs returns a copy of the service-name → IP map captured during
-// Up's hosts injection. Empty before Up has run, or when the project has
-// no compose sidecars.
-func (o *Orchestration) ServiceIPs() map[string]string {
-	if o.serviceIPs == nil {
-		return nil
-	}
-	out := make(map[string]string, len(o.serviceIPs))
-	for k, v := range o.serviceIPs {
-		out[k] = v
-	}
-	return out
 }

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -35,6 +35,16 @@ var cspaceKeys = []string{
 	"GITHUB_PERSONAL_ACCESS_TOKEN",
 }
 
+// SecretKeys returns the canonical list of cspace-owned secret env var
+// names (a copy, so callers can't mutate cspaceKeys). Used by cmd_up.go to
+// detect when a project's compose env_file silently overrides a
+// cspace-delivered secret.
+func SecretKeys() []string {
+	out := make([]string, len(cspaceKeys))
+	copy(out, cspaceKeys)
+	return out
+}
+
 // discoverClaudeOauthToken and discoverGhAuthToken are package-level function
 // variables so tests can swap them with stubs without exec'ing real binaries.
 var (


### PR DESCRIPTION
Makes cspace's `*.cspace.test` name resolution survive the life of the sandboxes, gives the shared browser correct per-sandbox routing, fails loud when the DNS chain breaks, and adds a non-invasive project env-override file. Design + plan are included (`docs/superpowers/specs/2026-07-12-…`, `docs/superpowers/plans/2026-07-13-…`).

## Why
Agents hit repeated friction: a stale cloud env var leaking into the sandbox (#1), the browser sidecar unable to resolve the devcontainer (#3), and — the root cause under both — the `.cspace.test` DNS daemon **dying mid-session**. It's spawned un-detached with stderr on a parent-held pipe, so it takes `SIGPIPE` on its next log write after `cspace up` exits; in-container resolution then silently stops while sandboxes run for hours. (Friction #2, the Convex `VITE_CONVEX_URL` clobber, was fixed app-side separately; this makes the `__SELF__` proxy path resolve reliably from the sidecar.)

## What changed
- **Daemon survivability** — detach the daemon (`Setsid` + `~/.cspace/daemon.log`, reaped via goroutine `Wait`); `/health` version handshake with a **race-safe** stop (waits for the fatal loopback ports to free before respawning); re-ensure from `send`/`attach` for long sessions.
- **Fail loud** — boot-time gate resolves `$CSPACE_WORKSPACE_HOST` from *inside* the devcontainer and browser sidecar and warns on failure; `cspace doctor` now probes the container-facing gateway listener (`192.168.64.1:5354`) and in-container resolution, not just host loopback.
- **Correct routing** — the DNS handler resolves sandbox names to the **live** container IP (bounded 2s inspect, TTL-memoized incl. negative-cache) so a restarted sandbox's reassigned vmnet IP is never served stale. Deleted the dead `ServiceIPs` field (the static `/etc/hosts` insurance was intentionally not adopted; `InjectHosts` stays).
- **`CSPACE_WORKSPACE_HOST`** is now set unconditionally (even under `--no-browser`).
- **`.env.cspace`** — a project-owned, static env-override file (via a second compose `env_file:`) to neutralize host/cloud vars like a stale `CONVEX_DEPLOYMENT`, with honest precedence docs and the `$CSPACE_WORKSPACE_HOST` / e2e `baseURL` convention. See `docs/env-cspace.md`.

## Testing / review
TDD throughout (RED→GREEN per task). Two-stage subagent review per task plus a whole-branch review caught and fixed a real Critical (unbounded DNS re-inspect on a hung apiserver → negative-cache) and an Important (env-precedence docs were reversed vs. the actual merge order). `make build`/`make vet` clean.

Known non-blocker: `TestCspaceLifecycle` fails in a dirty-worktree dev env (version-drift vs a stale prebuilt image), pre-existing and unrelated.

## Follow-ups (documented, not in this PR)
(Included in this PR: a fail-loud warning when a `.env.cspace`/`.env` key shadows a cspace-delivered secret.)
- launchd `KeepAlive` for reboot survival; browser MCP/CDP tab isolation (Playwright MCP isolates contexts; chrome-devtools-mcp did not at last check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)